### PR TITLE
Renamespace Codec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 - `Propulsion.Cosmos`: Tidied Cosmos ingester lag breakdown
 - Targeted `Jet.ConfluentKafka.FSharp` v `1.0.1` [#3](https://github.com/jet/propulsion/pull/3)
-- Moved `RenderedSpan` et al to `Propulsion.Codec.NewtonsoftJson` [#4](https://github.com/jet/propulsion/pull/4)
+- Moved `RenderedSpan` et al to `Propulsion.Codec.NewtonsoftJson` [#5](https://github.com/jet/propulsion/pull/5)
 
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 - `Propulsion.Cosmos`: Tidied Cosmos ingester lag breakdown
 - Targeted `Jet.ConfluentKafka.FSharp` v `1.0.1` [#3](https://github.com/jet/propulsion/pull/3)
+- Moved `RenderedSpan` et al to `Propulsion.Codec.NewtonsoftJson` [#4](https://github.com/jet/propulsion/pull/4)
 
 ### Removed
 ### Fixed

--- a/src/Propulsion.Kafka/Codec.fs
+++ b/src/Propulsion.Kafka/Codec.fs
@@ -1,4 +1,7 @@
-namespace Propulsion.Kafka.Codec
+// Defines a canonical format for representations of a span of events when serialized as json
+// NB logically, this could become a separated Propulsion.Codec nuget
+// (and/or series of nugets, with an implementation per concrete serialization stack)
+namespace Propulsion.Codec.NewtonsoftJson
 
 open Newtonsoft.Json
 open Newtonsoft.Json.Linq


### PR DESCRIPTION
This PR moves the `RenderedSpan` codec into a nested namespace `Propulsion.Codec.NewtonsoftJson` for the following reasons:
- While it's use is closely correlated with use of `Propulsion.Kafka`, there's nothing actually coupling
- Serializers are a Reason For Change, so being able to calve this off as a new nuget (or series thereof) without source changes is a good thing
- this same naming scheme [is used in `Equinox.Codec`](https://github.com/jet/equinox/blob/master/src/Equinox.Codec/Codec.fs) 