### PR TITLE
Add Consumer State logging

### DIFF
--- a/src/Propulsion.Kafka/ProducerSinks.fs
+++ b/src/Propulsion.Kafka/ProducerSinks.fs
@@ -1,0 +1,70 @@
+﻿namespace Propulsion.Kafka
+
+open Propulsion
+open Propulsion.Streams
+open Serilog
+open System
+open System.Collections.Generic
+
+type ParallelProducerSink =
+    static member Start(maxReadAhead, maxConcurrentStreams, render, producers : Producers, ?statsInterval)
+        : ProjectorPipeline<_> =
+        let statsInterval = defaultArg statsInterval (TimeSpan.FromMinutes 5.)
+        let handle item = async {
+            let key, value = render item
+            do! Async.Ignore <| producers.ProduceAsync(key, value) }
+        Parallel.ParallelProjector.Start(Log.Logger, maxReadAhead, maxConcurrentStreams, handle >> Async.Catch, statsInterval=statsInterval, logExternalStats = producers.DumpStats)
+
+type StreamsProducerStats(log : ILogger, statsInterval, stateInterval) =
+    inherit Streams.Scheduling.StreamSchedulerStats<OkResult<TimeSpan>,FailResult>(log, statsInterval, stateInterval)
+    let okStreams, failStreams = HashSet(), HashSet()
+    let jsonStats = Streams.Internal.LatencyStats("json")
+    let mutable okEvents, okBytes, exnEvents, exnBytes = 0, 0L, 0, 0L
+
+    override __.DumpStats() =
+        if okStreams.Count <> 0 && failStreams.Count <> 0 then
+            log.Information("Completed {okMb:n0}MB {okStreams:n0}s {okEvents:n0}e Exceptions {exnMb:n0}MB {exnStreams:n0}s {exnEvents:n0}e",
+                mb okBytes, okStreams.Count, okEvents, mb exnBytes, failStreams.Count, exnEvents)
+        okStreams.Clear(); okEvents <- 0; okBytes <- 0L
+        jsonStats.Dump log
+
+    override __.Handle message =
+        let inline adds x (set:HashSet<_>) = set.Add x |> ignore
+        base.Handle message
+        match message with
+        | Scheduling.InternalMessage.Added _ -> () // Processed by standard logging already; we have nothing to add
+        | Scheduling.InternalMessage.Result (_duration, (stream, Choice1Of2 (_,(es,bs),jsonElapsed))) ->
+            adds stream okStreams
+            okEvents <- okEvents + es
+            okBytes <- okBytes + int64 bs
+            jsonStats.Record jsonElapsed
+        | Scheduling.InternalMessage.Result (_duration, (stream, Choice2Of2 ((es,bs),_exn))) ->
+            adds stream failStreams
+            exnEvents <- exnEvents + es
+            exnBytes <- exnBytes + int64 bs
+
+type StreamsProducerSink =
+    static member Start(log : ILogger, maxReadAhead, maxConcurrentStreams, render, producers : Producers, categorize, ?statsInterval, ?stateInterval)
+        : ProjectorPipeline<_> =
+        let statsInterval, stateInterval = defaultArg statsInterval (TimeSpan.FromMinutes 5.), defaultArg stateInterval (TimeSpan.FromMinutes 5.)
+        let stats = StreamsProducerStats(log.ForContext<StreamsProducerStats>(), statsInterval, stateInterval)
+        let attemptWrite (_writePos,stream,fullBuffer : Streams.StreamSpan<_>) = async {
+            let maxEvents, maxBytes = 16384, 1_000_000 - (*fudge*)4096
+            let (eventCount,bytesCount),span = Streams.Buffering.StreamSpan.slice (maxEvents,maxBytes) fullBuffer
+            let sw = System.Diagnostics.Stopwatch.StartNew()
+            let spanJson = render (stream, span)
+            let jsonElapsed = sw.Elapsed
+            try let! _res = producers.ProduceAsync(stream,spanJson)
+                return Choice1Of2 (span.index + int64 eventCount,(eventCount,bytesCount),jsonElapsed)
+            with e -> return Choice2Of2 ((eventCount,bytesCount),e) }
+        let interpretWriteResultProgress _streams _stream = function
+            | Choice1Of2 (i',_,_) -> Some i'
+            | Choice2Of2 (_,_) -> None
+        let dispatcher = Streams.Scheduling.Dispatcher<_>(maxConcurrentStreams)
+        let streamScheduler =
+            Streams.Scheduling.StreamSchedulingEngine<OkResult<TimeSpan>,FailResult>(
+                dispatcher, stats, attemptWrite, interpretWriteResultProgress,
+                fun s l ->
+                    s.Dump(l, Streams.Buffering.StreamState.eventsSize, categorize)
+                    producers.DumpStats l)
+        Streams.Projector.StreamsProjectorPipeline.Start(log, dispatcher.Pump(), streamScheduler.Pump, maxReadAhead, streamScheduler.Submit, statsInterval)

--- a/src/Propulsion.Kafka/Producers.fs
+++ b/src/Propulsion.Kafka/Producers.fs
@@ -2,51 +2,26 @@
 
 open Confluent.Kafka
 open Jet.ConfluentKafka.FSharp
+open Propulsion
 open Serilog
 open System
 
-type ParallelProducer =
-    static member Start(log : ILogger, maxReadAhead, maxConcurrentStreams, clientId, broker, topic, render, ?statsInterval, ?customize)
-        : Propulsion.ProjectorPipeline<_> =
-        let statsInterval = defaultArg statsInterval (TimeSpan.FromMinutes 5.)
-        let cfg = KafkaProducerConfig.Create(clientId, broker, Acks.Leader, compression = CompressionType.Lz4, linger = TimeSpan.Zero, maxInFlight = 1_000_000, ?customize = customize)
-        let producer = KafkaProducer.Create(log, cfg, topic)
-        let handle item = async {
-            let key, value = render item
-            do! Async.Ignore <| producer.ProduceAsync(key, value) }
-        Propulsion.Parallel.ParallelProjector.Start(Log.Logger, maxReadAhead, maxConcurrentStreams, handle >> Async.Catch, statsInterval=statsInterval)
+/// Methods are intended to be used safely from multiple threads concurrently
+type Producers(log : ILogger, clientId, broker, topic, ?customize, ?producerParallelism) =
+    let cfg =
+        KafkaProducerConfig.Create(
+            clientId, broker, Acks.Leader,
+            compression = CompressionType.Lz4, linger = TimeSpan.Zero, maxInFlight = 1_000_000,
+            ?customize = customize)
+    let producers = Array.init (defaultArg producerParallelism 1) (fun _i -> KafkaProducer.Create(log, cfg, topic))
+    let produceStats = Streams.Internal.ConcurrentLatencyStats(sprintf "producers(%d)" producers.Length)
+    let mutable robin = 0
 
-type StreamsProducer =
-    static member Start(log : ILogger, maxReadAhead, maxConcurrentStreams, clientId, broker, topic, render, categorize, ?statsInterval, ?stateInterval, ?customize, ?producerParallelism)
-        : Propulsion.ProjectorPipeline<_> =
-        let statsInterval, stateInterval = defaultArg statsInterval (TimeSpan.FromMinutes 5.), defaultArg stateInterval (TimeSpan.FromMinutes 5.)
-        let projectionAndKafkaStats = Propulsion.Streams.Projector.Stats(log.ForContext<Propulsion.Streams.Projector.Stats>(), categorize, statsInterval, stateInterval)
-        let cfg = KafkaProducerConfig.Create(clientId, broker, Acks.Leader, compression = CompressionType.Lz4, linger = TimeSpan.FromMilliseconds 5., maxInFlight = 1_000_000, ?customize = customize)
-        let producers = Array.init (defaultArg producerParallelism 1) (fun _i -> KafkaProducer.Create(log, cfg, topic))
-        let robin = 0
-        let jsonStats = Propulsion.Streams.Internal.ConcurrentLatencyStats("json")
-        let produceStats = Propulsion.Streams.Internal.ConcurrentLatencyStats(sprintf "producers(%d)" producers.Length)
-        let attemptWrite (_writePos,stream,fullBuffer : Propulsion.Streams.StreamSpan<_>) = async {
-            let maxEvents, maxBytes = 16384, 1_000_000 - (*fudge*)4096
-            let ((eventCount,_) as stats), span = Propulsion.Streams.Buffering.StreamSpan.slice (maxEvents,maxBytes) fullBuffer
-            let sw = System.Diagnostics.Stopwatch.StartNew()
-            let spanJson = render (stream, span)
-            jsonStats.Record sw.Elapsed
-            let producer = producers.[System.Threading.Interlocked.Increment(&robin) % producers.Length]
-            try let sw = System.Diagnostics.Stopwatch.StartNew()
-                let! _res = producer.ProduceAsync(stream,spanJson)
-                produceStats.Record sw.Elapsed
-                return Choice1Of2 (span.index + int64 eventCount,stats,())
-            with e -> return Choice2Of2 (stats,e) }
-        let interpretWriteResultProgress _streams _stream = function
-            | Choice1Of2 (i',_, _) -> Some i'
-            | Choice2Of2 (_,_) -> None
-        let dispatcher = Propulsion.Streams.Scheduling.Dispatcher<_>(maxConcurrentStreams)
-        let streamScheduler =
-            Propulsion.Streams.Scheduling.StreamSchedulingEngine<_,_>(
-                dispatcher, projectionAndKafkaStats, attemptWrite, interpretWriteResultProgress,
-                fun s l ->
-                    s.Dump(l, Propulsion.Streams.Buffering.StreamState.eventsSize, categorize)
-                    produceStats.Dump l
-                    jsonStats.Dump l)
-        Propulsion.Streams.Projector.StreamsProjectorPipeline.Start(log, dispatcher.Pump(), streamScheduler.Pump, maxReadAhead, streamScheduler.Submit, statsInterval)
+    member __.DumpStats log = produceStats.Dump log
+
+    member __.ProduceAsync(key, value) = async {
+        let producer = producers.[System.Threading.Interlocked.Increment(&robin) % producers.Length]
+        let sw = System.Diagnostics.Stopwatch.StartNew()
+        let! res = producer.ProduceAsync(key, value)
+        produceStats.Record sw.Elapsed
+        return res }

--- a/src/Propulsion.Kafka/Propulsion.Kafka.fsproj
+++ b/src/Propulsion.Kafka/Propulsion.Kafka.fsproj
@@ -15,6 +15,7 @@
     <Compile Include="Bindings.fs" />
     <Compile Include="Consumers.fs" />
     <Compile Include="Producers.fs" />
+    <Compile Include="ProducerSinks.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Propulsion.Kafka0/Propulsion.Kafka0.fsproj
+++ b/src/Propulsion.Kafka0/Propulsion.Kafka0.fsproj
@@ -18,6 +18,7 @@
     <Compile Include="Bindings.fs" />
     <Compile Include="..\Propulsion.Kafka\Consumers.fs" Link="Consumers.fs" />
     <Compile Include="..\Propulsion.Kafka\Producers.fs" Link="Producers.fs" />
+    <Compile Include="..\Propulsion.Kafka\ProducerSinks.fs" Link="ProducerSinks.fs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR reorganizes the Producer and Consumer paths to use a common set of patterns wrt how one can wire in stats logging in a client app.

The utility of this will be demonstrated by updates to the examples https://github.com/jet/dotnet-templates/equinox-projector