### PR TITLE
Fix EventStore Gorge -> Tail transition #10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Removed
 ### Fixed
 
-- Gorging -> Tailing transition [#10](https://github.com/jet/propulsion/issues/10)
+- Gorging -> Tailing transition [#10](https://github.com/jet/propulsion/issues/10) [#13](https://github.com/jet/propulsion/pull/13)
 
 <a name="1.0.1-rc3"></a>
 ## [1.0.1-rc3] - 2019-06-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Removed
 ### Fixed
 
+- Idling logic bug [#13](https://github.com/jet/propulsion/pull/13)
 - Gorging -> Tailing transition [#10](https://github.com/jet/propulsion/issues/10) [#13](https://github.com/jet/propulsion/pull/13)
 
 <a name="1.0.1-rc3"></a>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Removed
 ### Fixed
 
+- Gorging -> Tailing transition [#10](https://github.com/jet/propulsion/issues/10)
+
 <a name="1.0.1-rc3"></a>
 ## [1.0.1-rc3] - 2019-06-18
 

--- a/src/Propulsion.EventStore/EventStoreSink.fs
+++ b/src/Propulsion.EventStore/EventStoreSink.fs
@@ -140,7 +140,9 @@ module Internal =
                 let _stream, ss = applyResultToStreamState res
                 Writer.logTo writerResultLog (stream,res)
                 ss.write
-            Scheduling.StreamSchedulingEngine(dispatcher, stats, attemptWrite, interpretWriteResultProgress, dumpStreams, enableSlipstreaming=true, ?maxBatches = maxBatches)
+            Scheduling.StreamSchedulingEngine
+                (   dispatcher, stats, attemptWrite, interpretWriteResultProgress, dumpStreams,
+                    enableSlipstreaming=true, ?maxBatches = maxBatches, idleDelay=TimeSpan.FromMilliseconds 2.)
 
 type EventStoreSink =
     static member Start


### PR DESCRIPTION
Fixes race conditions in how the ES ingestion logic transitions from reading in parallel to tailing, see #10
Also removes idling bug which dramatically reduces CPU consumption (and should also improve throughput)