### PR TITLE
move kafka0 shims to another namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ packages.config
 
 ## CodeRush
 .cr/
+/.ionide/

--- a/src/Propulsion.Kafka/Consumers.fs
+++ b/src/Propulsion.Kafka/Consumers.fs
@@ -3,7 +3,11 @@
 namespace Propulsion.Kafka
 
 open Confluent.Kafka
+#if CONFLUENT_KAFKA_SHIMS
+open Propulsion.Kafka0.Jet.ConfluentKafka.FSharp
+#else
 open Jet.ConfluentKafka.FSharp
+#endif
 open Propulsion
 open Propulsion.Internal // intervalCheck
 open Propulsion.Kafka.Internal // AwaitTaskCorrect
@@ -228,7 +232,7 @@ type StreamsConsumer =
     /// Starts a Kafka Consumer processing pipeline per the `config` running up to `dop` instances of `handle` concurrently to maximize global throughput across partitions.
     /// Processor pumps until `handle` yields a `Choice2Of2` or `Stop()` is requested.
     static member Start<'M,'Req,'Res>
-        (   log : ILogger, config : Jet.ConfluentKafka.FSharp.KafkaConsumerConfig, maxDop, parseStreamEvents,
+        (   log : ILogger, config : KafkaConsumerConfig, maxDop, parseStreamEvents,
             prepare, handle, stats : Streams.Scheduling.StreamSchedulerStats<OkResult<'Res>,FailResult>,
             categorize, ?pipelineStatsInterval, ?maxSubmissionsPerPartition, ?pumpInterval, ?logExternalState, ?idleDelay) =
         let pipelineStatsInterval = defaultArg pipelineStatsInterval (TimeSpan.FromMinutes 10.)
@@ -246,7 +250,7 @@ type StreamsConsumer =
     /// Starts a Kafka Consumer running spans of events per stream through the `handle` function to `maxDop` concurrently
     /// Processor statistics are accumulated serially into the supplied `stats` buffer
     static member Start<'M,'Res>
-        (   log : ILogger, config : Jet.ConfluentKafka.FSharp.KafkaConsumerConfig, maxDop,
+        (   log : ILogger, config : KafkaConsumerConfig, maxDop,
             parseStreamEvents, handle : string * Streams.StreamSpan<_> -> Async<'Res>, stats : Streams.Scheduling.StreamSchedulerStats<OkResult<'Res>,FailResult>,
             categorize, ?pipelineStatsInterval, ?maxSubmissionsPerPartition, ?pumpInterval, ?logExternalState, ?idleDelay) =
         let prepare (streamName,span) =

--- a/src/Propulsion.Kafka/Consumers.fs
+++ b/src/Propulsion.Kafka/Consumers.fs
@@ -3,7 +3,7 @@
 namespace Propulsion.Kafka
 
 open Confluent.Kafka
-#if CONFLUENT_KAFKA_SHIMS
+#if KAFKA0
 open Propulsion.Kafka0.Jet.ConfluentKafka.FSharp
 #else
 open Jet.ConfluentKafka.FSharp

--- a/src/Propulsion.Kafka/Producers.fs
+++ b/src/Propulsion.Kafka/Producers.fs
@@ -1,7 +1,12 @@
 ﻿namespace Propulsion.Kafka
 
 open Confluent.Kafka
+#if CONFLUENT_KAFKA_SHIMS
+open Propulsion.Kafka0.Confluent.Kafka
+open Propulsion.Kafka0.Jet.ConfluentKafka.FSharp
+#else
 open Jet.ConfluentKafka.FSharp
+#endif
 open Propulsion
 open Serilog
 open System

--- a/src/Propulsion.Kafka/Producers.fs
+++ b/src/Propulsion.Kafka/Producers.fs
@@ -1,7 +1,7 @@
 ﻿namespace Propulsion.Kafka
 
 open Confluent.Kafka
-#if CONFLUENT_KAFKA_SHIMS
+#if KAFKA0
 open Propulsion.Kafka0.Confluent.Kafka
 open Propulsion.Kafka0.Jet.ConfluentKafka.FSharp
 #else

--- a/src/Propulsion.Kafka0/Bindings.fs
+++ b/src/Propulsion.Kafka0/Bindings.fs
@@ -1,7 +1,8 @@
 ﻿namespace Propulsion.Kafka
 
 open Confluent.Kafka
-open Jet.ConfluentKafka.FSharp
+open Propulsion.Kafka0.Confluent.Kafka
+open Propulsion.Kafka0.Jet.ConfluentKafka.FSharp
 open Serilog
 open System
 open System.Collections.Generic

--- a/src/Propulsion.Kafka0/ConfluentKafka1Shims.fs
+++ b/src/Propulsion.Kafka0/ConfluentKafka1Shims.fs
@@ -1,5 +1,5 @@
 ﻿// Stand-ins for stuff presented in Confluent.Kafka v1
-namespace Confluent.Kafka
+namespace Propulsion.Kafka0.Confluent.Kafka
 
 open System
 open System.Collections.Generic

--- a/src/Propulsion.Kafka0/JetConfluentKafkaFSharpShims.fs
+++ b/src/Propulsion.Kafka0/JetConfluentKafkaFSharpShims.fs
@@ -1,10 +1,11 @@
 // Shims for stuff that's present in Jet.ConfluentKafka.FSharp 1.x
-namespace Jet.ConfluentKafka.FSharp
+namespace Propulsion.Kafka0.Jet.ConfluentKafka.FSharp
 
 open Confluent.Kafka
 open Newtonsoft.Json
 open Newtonsoft.Json.Linq
 open Propulsion.Kafka.Internal // Async Helpers
+open Propulsion.Kafka0.Confluent.Kafka // Confluent.Kafka shims
 open Serilog
 open System
 open System.Threading

--- a/src/Propulsion.Kafka0/Propulsion.Kafka0.fsproj
+++ b/src/Propulsion.Kafka0/Propulsion.Kafka0.fsproj
@@ -7,7 +7,8 @@
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
     <GenerateDocumentationFile Condition=" '$(Configuration)' == 'Release' ">true</GenerateDocumentationFile>
-    <DefineConstants Condition=" '$(TargetFramework)' == 'net461' ">NET461</DefineConstants>
+    <DefineConstants Condition=" '$(TargetFramework)' == 'net461' ">NET461;$(DefineConstants)</DefineConstants>
+    <DefineConstants>CONFLUENT_KAFKA_SHIMS;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Propulsion.Kafka0/Propulsion.Kafka0.fsproj
+++ b/src/Propulsion.Kafka0/Propulsion.Kafka0.fsproj
@@ -8,7 +8,7 @@
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
     <GenerateDocumentationFile Condition=" '$(Configuration)' == 'Release' ">true</GenerateDocumentationFile>
     <DefineConstants Condition=" '$(TargetFramework)' == 'net461' ">NET461;$(DefineConstants)</DefineConstants>
-    <DefineConstants>CONFLUENT_KAFKA_SHIMS;$(DefineConstants)</DefineConstants>
+    <DefineConstants>KAFKA0;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Propulsion.Kafka.Integration/ParallelIntegration.fs
+++ b/tests/Propulsion.Kafka.Integration/ParallelIntegration.fs
@@ -1,6 +1,11 @@
 ﻿namespace Propulsion.Kafka.Integration.Parallel
 
+#if KAFKA0
+open Propulsion.Kafka0.Confluent.Kafka
+open Propulsion.Kafka0.Jet.ConfluentKafka.FSharp
+#else
 open Jet.ConfluentKafka.FSharp
+#endif
 open Newtonsoft.Json
 open Propulsion.Kafka
 open Serilog

--- a/tests/Propulsion.Kafka0.Integration/Propulsion.Kafka0.Integration.fsproj
+++ b/tests/Propulsion.Kafka0.Integration/Propulsion.Kafka0.Integration.fsproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
     <WarningLevel>5</WarningLevel>
     <IsPackable>false</IsPackable>
-    <DefineConstants>KAFKA0</DefineConstants>
+    <DefineConstants>KAFKA0;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
move kafka shims under a namespace `Propulsion.Kafka0.*` so doesnt overlap with original

Some projects may want to use both Propulsion and Jet.ConfluentKafka.FSharp in the same project.
If some types have the the same fullname (namespace + name), is not possibile in F# to discriminate
the two, doesnt matter if are defined in different assemblies

It's not possibile to make all types internal, because some types like ConsumerConfig leak in public api