### PR TITLE
Make kafka0 config to another namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ packages.config
 
 ## CodeRush
 .cr/
+/.ionide/

--- a/src/Propulsion.Kafka0/ConfluentKafka1Shims.fs
+++ b/src/Propulsion.Kafka0/ConfluentKafka1Shims.fs
@@ -1,4 +1,4 @@
-﻿namespace Confluent.Kafka
+﻿namespace Jet.ConfluentKafka.FSharp
 
 open System
 open System.Collections.Generic
@@ -22,7 +22,7 @@ namespace Propulsion.Kafka0.Confluent.Kafka
 
 open System
 open System.Collections.Generic
-open Confluent.Kafka
+open Jet.ConfluentKafka.FSharp
 
 [<RequireQualifiedAccess>]
 module Config =

--- a/src/Propulsion.Kafka0/ConfluentKafka1Shims.fs
+++ b/src/Propulsion.Kafka0/ConfluentKafka1Shims.fs
@@ -1,20 +1,20 @@
 ﻿// Stand-ins for stuff presented in Confluent.Kafka v1
-namespace Confluent.Kafka
+namespace Propulsion.Kafka0.Confluent.Kafka
 
 open System
 open System.Collections.Generic
 
-[<RequireQualifiedAccess; Struct>]
-type CompressionType = None | GZip | Snappy | Lz4
+    [<RequireQualifiedAccess; Struct>]
+    type CompressionType = None | GZip | Snappy | Lz4
 
-[<RequireQualifiedAccess; Struct>]
-type Acks = Zero | Leader | All
+    [<RequireQualifiedAccess; Struct>]
+    type Acks = Zero | Leader | All
 
-[<RequireQualifiedAccess; Struct>]
-type Partitioner = Random | Consistent | ConsistentRandom
+    [<RequireQualifiedAccess; Struct>]
+    type Partitioner = Random | Consistent | ConsistentRandom
 
-[<RequireQualifiedAccess; Struct>]
-type AutoOffsetReset = Earliest | Latest | None
+    [<RequireQualifiedAccess; Struct>]
+    type AutoOffsetReset = Earliest | Latest | None
 
 [<RequireQualifiedAccess>]
 module Config =

--- a/src/Propulsion.Kafka0/ConfluentKafka1Shims.fs
+++ b/src/Propulsion.Kafka0/ConfluentKafka1Shims.fs
@@ -1,5 +1,4 @@
-﻿// Stand-ins for stuff presented in Confluent.Kafka v1
-namespace Propulsion.Kafka0.Confluent.Kafka
+﻿namespace Confluent.Kafka
 
 open System
 open System.Collections.Generic
@@ -17,6 +16,12 @@ module Types =
 
     [<RequireQualifiedAccess; Struct>]
     type AutoOffsetReset = Earliest | Latest | None
+
+// Stand-ins for stuff presented in Confluent.Kafka v1
+namespace Propulsion.Kafka0.Confluent.Kafka
+
+open System
+open System.Collections.Generic
 
 [<RequireQualifiedAccess>]
 module Config =

--- a/src/Propulsion.Kafka0/ConfluentKafka1Shims.fs
+++ b/src/Propulsion.Kafka0/ConfluentKafka1Shims.fs
@@ -4,6 +4,8 @@ namespace Propulsion.Kafka0.Confluent.Kafka
 open System
 open System.Collections.Generic
 
+[<AutoOpen>]
+module Types =
     [<RequireQualifiedAccess; Struct>]
     type CompressionType = None | GZip | Snappy | Lz4
 

--- a/src/Propulsion.Kafka0/ConfluentKafka1Shims.fs
+++ b/src/Propulsion.Kafka0/ConfluentKafka1Shims.fs
@@ -22,6 +22,7 @@ namespace Propulsion.Kafka0.Confluent.Kafka
 
 open System
 open System.Collections.Generic
+open Confluent.Kafka
 
 [<RequireQualifiedAccess>]
 module Config =

--- a/src/Propulsion.Kafka0/JetConfluentKafkaFSharpShims.fs
+++ b/src/Propulsion.Kafka0/JetConfluentKafkaFSharpShims.fs
@@ -5,6 +5,7 @@ open Confluent.Kafka
 open Newtonsoft.Json
 open Newtonsoft.Json.Linq
 open Propulsion.Kafka.Internal // Async Helpers
+open Propulsion.Kafka0.Confluent.Kafka
 open Serilog
 open System
 open System.Threading


### PR DESCRIPTION
move kafka config shims under a namespace Propulsion.Kafka0.* so doesnt overlap with original

Some projects may want to use both `Propulsion.Kafka0` and `Jet.ConfluentKafka.FSharp v0` in the same project.
If some types have the the same fullname (namespace + name), is not possibile in F# to discriminate
the two, doesnt matter if are defined in different assemblies
