### PR TITLE
Target Equinox 2.0.0-rc6, FsCodec 1.0.0-rc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 ### Changed
+
+- Targeted `Equinox`.* v `2.0.0-rc6`, `FsCodec`.* v `1.0.0-rc2` [#27](https://github.com/jet/propulsion/pull/27)
+
 ### Removed
 ### Fixed
 

--- a/src/Propulsion.Cosmos/Propulsion.Cosmos.fsproj
+++ b/src/Propulsion.Cosmos/Propulsion.Cosmos.fsproj
@@ -24,7 +24,7 @@
     <PackageReference Include="FSharp.Core" Version="3.1.2.5" Condition=" '$(TargetFramework)' == 'net461' " />
     <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' != 'net461' " />
 
-    <PackageReference Include="Equinox.Cosmos" Version="2.0.0-rc5" />
+    <PackageReference Include="Equinox.Cosmos" Version="2.0.0-rc6" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.ChangeFeedProcessor" Version="2.2.7" />
   </ItemGroup>
 

--- a/src/Propulsion.EventStore/Checkpoint.fs
+++ b/src/Propulsion.EventStore/Checkpoint.fs
@@ -21,7 +21,8 @@ module Events =
         | [<System.Runtime.Serialization.DataMember(Name="state-v1")>]
             Unfolded of Unfolded
         interface TypeShape.UnionContract.IUnionContract
-    let codec = FsCodec.NewtonsoftJson.Codec.Create<Event>()
+    // Avoid binding to a specific serializer as a) nothing else is binding to it in here b) it should serialize with any serializer so we defer
+    // let codec = FsCodec.NewtonsoftJson.Codec.Create<Event>()
 
 module Folds =
     type State = NotStarted | Running of Events.Unfolded

--- a/src/Propulsion.EventStore/Checkpoint.fs
+++ b/src/Propulsion.EventStore/Checkpoint.fs
@@ -21,6 +21,7 @@ module Events =
         | [<System.Runtime.Serialization.DataMember(Name="state-v1")>]
             Unfolded of Unfolded
         interface TypeShape.UnionContract.IUnionContract
+    let codec = FsCodec.NewtonsoftJson.Codec.Create<Event>()
 
 module Folds =
     type State = NotStarted | Running of Events.Unfolded

--- a/src/Propulsion.EventStore/EventStoreSource.fs
+++ b/src/Propulsion.EventStore/EventStoreSource.fs
@@ -34,12 +34,10 @@ module Mapping =
     type RecordedEvent with
         member __.Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(__.CreatedEpoch)
 
-    let (|PropulsionEvent|) (x : RecordedEvent) =
-        { new FsCodec.IEvent<_> with
-            member __.EventType = x.EventType
-            member __.Data = if x.Data <> null && x.Data.Length = 0 then null else x.Data
-            member __.Meta = if x.Metadata <> null && x.Metadata.Length = 0 then null else x.Metadata
-            member __.Timestamp = x.Timestamp }
+    let (|PropulsionEvent|) (x : RecordedEvent) : FsCodec.IEvent<_> =
+        let d = if x.Data <> null && x.Data.Length = 0 then null else x.Data
+        let m = if x.Metadata <> null && x.Metadata.Length = 0 then null else x.Metadata
+        FsCodec.Core.EventData.Create(x.EventType,d,m,x.Timestamp) :> _
     let (|PropulsionStreamEvent|) (x: RecordedEvent) : Propulsion.Streams.StreamEvent<_> =
         { stream = x.EventStreamId; index = x.EventNumber; event = (|PropulsionEvent|) x }
 

--- a/src/Propulsion.EventStore/Propulsion.EventStore.fsproj
+++ b/src/Propulsion.EventStore/Propulsion.EventStore.fsproj
@@ -25,7 +25,8 @@
     <PackageReference Include="FSharp.Core" Version="3.1.2.5" Condition=" '$(TargetFramework)' == 'net461' " />
     <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' != 'net461' " />
 
-    <PackageReference Include="Equinox.EventStore" Version="2.0.0-rc5" />
+    <PackageReference Include="Equinox.EventStore" Version="2.0.0-rc6" />
+    <PackageReference Include="FsCodec.NewtonsoftJson" Version="1.0.0-rc2" />
     <PackageReference Include="FSharp.UMX" Version="1.0.0" />
     <PackageReference Include="Serilog" Version="2.7.1" />
   </ItemGroup>

--- a/src/Propulsion.EventStore/Propulsion.EventStore.fsproj
+++ b/src/Propulsion.EventStore/Propulsion.EventStore.fsproj
@@ -26,9 +26,9 @@
     <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' != 'net461' " />
 
     <PackageReference Include="Equinox.EventStore" Version="2.0.0-rc6" />
-    <PackageReference Include="FsCodec.NewtonsoftJson" Version="1.0.0-rc2" />
     <PackageReference Include="FSharp.UMX" Version="1.0.0" />
     <PackageReference Include="Serilog" Version="2.7.1" />
+    <PackageReference Include="TypeShape" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Propulsion.Kafka/Propulsion.Kafka.fsproj
+++ b/src/Propulsion.Kafka/Propulsion.Kafka.fsproj
@@ -26,7 +26,7 @@
     <PackageReference Include="FSharp.Core" Version="3.1.2.5" Condition=" '$(TargetFramework)' == 'net461' " />
     <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' != 'net461' " />
 
-    <PackageReference Include="FsCodec.NewtonsoftJson" Version="1.0.0-rc1" />
+    <PackageReference Include="FsCodec.NewtonsoftJson" Version="1.0.0-rc2" />
     <PackageReference Include="Jet.ConfluentKafka.FSharp" Version="1.1.0" />
   </ItemGroup>
 

--- a/src/Propulsion.Kafka0/Propulsion.Kafka0.fsproj
+++ b/src/Propulsion.Kafka0/Propulsion.Kafka0.fsproj
@@ -30,7 +30,7 @@
     <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' != 'net461' " />
 
     <PackageReference Include="Confluent.Kafka" Version="[0.11.3]" />
-    <PackageReference Include="FsCodec.NewtonsoftJson" Version="1.0.0-rc1" />
+    <PackageReference Include="FsCodec.NewtonsoftJson" Version="1.0.0-rc2" />
     <PackageReference Include="librdkafka.redist" Version="[0.11.4]" />
   </ItemGroup>
 

--- a/src/Propulsion/Propulsion.fsproj
+++ b/src/Propulsion/Propulsion.fsproj
@@ -26,7 +26,7 @@
     <PackageReference Include="FSharp.Core" Version="3.1.2.5" Condition=" '$(TargetFramework)' == 'net461' " />
     <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' != 'net461' " />
 
-    <PackageReference Include="FsCodec" Version="1.0.0-rc1" />
+    <PackageReference Include="FsCodec" Version="1.0.0-rc2" />
     <PackageReference Include="MathNet.Numerics" Version="4.7.0" />
     <PackageReference Include="Serilog" Version="2.7.1" />
   </ItemGroup>


### PR DESCRIPTION
The above releases need to be in lockstep so pushing this release in order to simplify future updates despite there not being any significant gain or relevance for Propulsion (which can work equally with FsCodec 1.0.0-rc1 and 1.0.0-rc2)