### PR TITLE
Standardize on IIndexedevent for event representations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 ### Changed
+
+- Use `IIndexedEvent` in lieu of `IIEvent` + `index` in `StreamSpan` and `StreamEvent` [#28](https://github.com/jet/propulsion/pull/28)
+- Shorten `Rendered*.parse*` to `Rendered*.parse` [#28](https://github.com/jet/propulsion/pull/28)
+
 ### Removed
 ### Fixed
 

--- a/src/Propulsion.Cosmos/CosmosSink.fs
+++ b/src/Propulsion.Cosmos/CosmosSink.fs
@@ -41,7 +41,7 @@ module Internal =
         let write (log : ILogger) (ctx : Context) stream span = async {
             let stream = ctx.CreateStream stream
             log.Debug("Writing {s}@{i}x{n}",stream,span.index,span.events.Length)
-            let! res = ctx.Sync(stream, { index = span.index; etag = None }, span.events)
+            let! res = ctx.Sync(stream, { index = span.index; etag = None }, span.events |> Array.map (fun x -> x :> _))
             let ress =
                 match res with
                 | AppendResult.Ok pos -> Ok pos.index

--- a/src/Propulsion.Cosmos/EquinoxCosmosParser.fs
+++ b/src/Propulsion.Cosmos/EquinoxCosmosParser.fs
@@ -23,7 +23,7 @@ module EquinoxCosmosParser =
 
     /// Enumerates the events represented within a batch
     let enumEquinoxCosmosEvents (batch : Equinox.Cosmos.Store.Batch) : StreamEvent<byte[]> seq =
-        batch.e |> Seq.mapi (fun offset x -> { stream = batch.p; index = batch.i + int64 offset; event = x })
+        batch.e |> Seq.mapi (fun offset x -> { stream = batch.p; event = FsCodec.Core.IndexedEventData(batch.i+int64 offset,false,x.c,x.d,x.m,x.t) })
 
     /// Collects all events with a Document [typically obtained via the CosmosDb ChangeFeed] that potentially represents an Equinox.Cosmos event-batch
     let enumStreamEvents (d : Document) : StreamEvent<byte[]> seq =

--- a/src/Propulsion.EventStore/EventStoreSink.fs
+++ b/src/Propulsion.EventStore/EventStoreSink.fs
@@ -39,7 +39,7 @@ module Internal =
 
         let write (log : ILogger) (context : Context) stream span = async {
             log.Debug("Writing {s}@{i}x{n}",stream,span.index,span.events.Length)
-            let! res = context.Sync(log, stream, span.index - 1L, span.events)
+            let! res = context.Sync(log, stream, span.index - 1L, span.events |> Array.map (fun x -> x :> _))
             let ress =
                 match res with
                 | GatewaySyncResult.Written (Token.Unpack pos') ->

--- a/src/Propulsion.EventStore/EventStoreSource.fs
+++ b/src/Propulsion.EventStore/EventStoreSource.fs
@@ -34,12 +34,12 @@ module Mapping =
     type RecordedEvent with
         member __.Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(__.CreatedEpoch)
 
-    let (|PropulsionEvent|) (x : RecordedEvent) : FsCodec.IEvent<_> =
+    let (|PropulsionEvent|) (x : RecordedEvent) : FsCodec.IIndexedEvent<_> =
         let d = if x.Data <> null && x.Data.Length = 0 then null else x.Data
         let m = if x.Metadata <> null && x.Metadata.Length = 0 then null else x.Metadata
-        FsCodec.Core.EventData.Create(x.EventType,d,m,x.Timestamp) :> _
+        FsCodec.Core.IndexedEventData(x.EventNumber,false,x.EventType,d,m,x.Timestamp) :> _
     let (|PropulsionStreamEvent|) (x: RecordedEvent) : Propulsion.Streams.StreamEvent<_> =
-        { stream = x.EventStreamId; index = x.EventNumber; event = (|PropulsionEvent|) x }
+        { stream = x.EventStreamId; event = (|PropulsionEvent|) x }
 
 type EventStoreSource =
     static member Run

--- a/src/Propulsion.Kafka/Codec.fs
+++ b/src/Propulsion.Kafka/Codec.fs
@@ -67,11 +67,11 @@ module RenderedSpan =
             i = span.index
             e = span.events |> Array.map (fun x -> { c = x.EventType; t = x.Timestamp; d = x.Data; m = x.Meta }) }
 
-    let enumStreamEvents (span: RenderedSpan) : StreamEvent<_> seq =
+    let enum (span: RenderedSpan) : StreamEvent<_> seq =
         span.e |> Seq.mapi (fun i e -> { stream = span.s; event = FsCodec.Core.IndexedEventData(span.i+int64 i,false,e.c,e.d,e.m,e.t) })
 
-    let parseStreamEvents (spanJson: string) : StreamEvent<_> seq =
-        spanJson |> RenderedSpan.Parse |> enumStreamEvents
+    let parse (spanJson: string) : StreamEvent<_> seq =
+        spanJson |> RenderedSpan.Parse |> enum
 
 // Rendition of Summary Events representing the agregated state of a Stream at a known point / version
 type [<NoEquality; NoComparison>] RenderedSummary =
@@ -98,8 +98,8 @@ module RenderedSummary =
     let ofStreamEvent (stream : string) (index : int64) (event : FsCodec.IEvent<byte[]>) : RenderedSummary =
         ofStreamEvents stream index (Seq.singleton event)
 
-    let enumStreamSummaries (span: RenderedSummary) : StreamEvent<_> seq =
+    let enum (span: RenderedSummary) : StreamEvent<_> seq =
         seq { for e in span.u -> { stream = span.s; event = FsCodec.Core.IndexedEventData(span.i,true,e.c,e.d,e.m,e.t) } }
 
-    let parseStreamSummaries (spanJson: string) : StreamEvent<_> seq =
-        spanJson |> RenderedSummary.Parse |> enumStreamSummaries
+    let parse (spanJson: string) : StreamEvent<_> seq =
+        spanJson |> RenderedSummary.Parse |> enum

--- a/src/Propulsion.Kafka/Codec.fs
+++ b/src/Propulsion.Kafka/Codec.fs
@@ -68,7 +68,7 @@ module RenderedSpan =
             e = span.events |> Array.map (fun x -> { c = x.EventType; t = x.Timestamp; d = x.Data; m = x.Meta }) }
 
     let enumStreamEvents (span: RenderedSpan) : StreamEvent<_> seq =
-        span.e |> Seq.mapi (fun i e -> { stream = span.s; index = span.i + int64 i; event = e })
+        span.e |> Seq.mapi (fun i e -> { stream = span.s; event = FsCodec.Core.IndexedEventData(span.i+int64 i,false,e.c,e.d,e.m,e.t) })
 
     let parseStreamEvents (spanJson: string) : StreamEvent<_> seq =
         spanJson |> RenderedSpan.Parse |> enumStreamEvents
@@ -99,7 +99,7 @@ module RenderedSummary =
         ofStreamEvents stream index (Seq.singleton event)
 
     let enumStreamSummaries (span: RenderedSummary) : StreamEvent<_> seq =
-        seq { for e in span.u -> { stream = span.s; index = span.i; event = e } }
+        seq { for e in span.u -> { stream = span.s; event = FsCodec.Core.IndexedEventData(span.i,true,e.c,e.d,e.m,e.t) } }
 
     let parseStreamSummaries (spanJson: string) : StreamEvent<_> seq =
         spanJson |> RenderedSummary.Parse |> enumStreamSummaries

--- a/src/Propulsion/Streams.fs
+++ b/src/Propulsion/Streams.fs
@@ -13,7 +13,9 @@ open System.Threading
 /// A Single Event from an Ordered stream
 [<NoComparison; NoEquality>]
 type StreamEvent<'Format> = { stream: string; index: int64; event: IEvent<'Format> } with
-    interface IEvent<'Format> with
+    interface IIndexedEvent<'Format> with
+        member __.Index = __.index
+        member __.IsUnfold = false
         member __.EventType = __.event.EventType
         member __.Data = __.event.Data
         member __.Meta = __.event.Meta
@@ -21,7 +23,10 @@ type StreamEvent<'Format> = { stream: string; index: int64; event: IEvent<'Forma
 
 /// Span of events from an Ordered Stream
 [<NoComparison; NoEquality>]
-type StreamSpan<'Format> = { index: int64; events: IEvent<'Format>[] }
+type StreamSpan<'Format> = { index: int64; events: IEvent<'Format>[] } with
+    member __.Events =
+        __.events
+        |> Seq.mapi (fun i x -> FsCodec.Core.IndexedEventData(__.index+int64 i,false,x.EventType,x.Data,x.Meta,x.Timestamp))
 
 module Internal =
 

--- a/tests/Propulsion.Tests/StreamStateTests.fs
+++ b/tests/Propulsion.Tests/StreamStateTests.fs
@@ -7,7 +7,9 @@ open Xunit
 
 let canonicalTime = System.DateTimeOffset.UtcNow
 
-let mk p c : StreamSpan<string> = { index = p; events = [| for x in 0..c-1 -> FsCodec.Core.EventData.Create(p + int64 x |> string, null, timestamp=canonicalTime) |] }
+let mk p c : StreamSpan<string> =
+    {   index = p
+        events = [| for x in 0..c-1 -> FsCodec.Core.IndexedEventData(int64 x,false,p + int64 x |> string, null, null,canonicalTime) |] }
 let mergeSpans = StreamSpan.merge
 let trimSpans = StreamSpan.dropBeforeIndex
 let is (xs : StreamSpan<string>[]) (res : StreamSpan<string>[]) =

--- a/tools/Propulsion.Tool/Program.fs
+++ b/tools/Propulsion.Tool/Program.fs
@@ -200,7 +200,7 @@ let main argv =
                     | _ -> None, id
                 let projectBatch (log : ILogger) (ctx : IChangeFeedObserverContext) (docs : IReadOnlyList<Microsoft.Azure.Documents.Document>) = async {
                     sw.Stop() // Stop the clock after CFP hands off to us
-                    let render (e: StreamEvent<_>) = RenderedSpan.ofStreamSpan e.stream { StreamSpan.index = e.index; events=[| e.event |] }
+                    let render (e: StreamEvent<_>) = RenderedSpan.ofStreamSpan e.stream { StreamSpan.index = e.event.Index; events=[| e.event |] }
                     let pt, events = (fun () -> docs |> Seq.collect EquinoxCosmosParser.enumStreamEvents |> Seq.map render |> Array.ofSeq) |> Stopwatch.Time 
                     let! et = async {
                         match producer with


### PR DESCRIPTION
This cleanup, prompted by shimming otherwise required in https://github.com/jet/dotnet-templates replaces usages of `IEvent` alongside an `index` by replacing with `IIndexedEvent`. This also allows us to simplify the naming of RenderedSpan vs RenderedSummary (`IsUnfold` can be used to distinguish as necessary)