### PR TITLE
Fix transmute signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 - `.Kafka`: Targeted [`Jet.ConfluentKafka.FSharp` v `1.2.0`](https://github.com/jet/Jet.ConfluentKafka.FSharp/blob/master/CHANGELOG.md#1.2.0)
 - rename `offsetCommitInterval` to `autoCommitInterval` to match similar change in `Jet.ConfluentKafka.FSharp` v `1.2.0`
+- Generalize `Checkpoints.Folds.transmute` to be directly usable [#35](https://github.com/jet/propulsion/pull/35)
 
 ### Removed
 ### Fixed

--- a/src/Propulsion.EventStore/Checkpoint.fs
+++ b/src/Propulsion.EventStore/Checkpoint.fs
@@ -42,15 +42,15 @@ module Folds =
         | Running state -> Events.Unfolded {config = state.config; state=state.state}
 
     /// We only want to generate a first class event every N minutes, while efficiently writing contingent on the current etag value
-    let transmute events state =
+    let transmute events state : Events.Event list*Events.Event list =
         let checkpointEventIsRedundant (e: Events.Checkpointed) (s: Events.Unfolded) =
             s.state.nextCheckpointDue = e.pos.nextCheckpointDue
             && s.state.pos <> e.pos.pos
         match events, state with
         | [Events.Checkpointed e], (Running state as s) when checkpointEventIsRedundant e state ->
-            [],unfold s
+            [],[unfold s]
         | xs, state ->
-            xs,unfold state
+            xs,[unfold state]
 
 type Command =
     | Start of at: DateTimeOffset * checkpointFreq: TimeSpan * pos: int64


### PR DESCRIPTION
This cleanup removes [a shim from the templates](https://github.com/jet/dotnet-templates/blob/ead62bb379bca2a69a74613bb19b31e990f3e6b4/propulsion-sync/Program.fs#L553)