### PR TITLE
Cosmos: Change Arguments to use DocumentClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Changed
 
 - Targets `Equinox` v `2.0.0-rc8`, `FsCodec` v `1.2.1`
+- `Cosmos`: Retarget to specify stores as `DocumentClient` [#40](https://github.com/jet/propulsion/pull/40) :pray: [@Kelvin4702](https://github.com/kelvin4702)
 
 ### Removed
 ### Fixed

--- a/src/Propulsion.Cosmos/ChangeFeedProcessor.fs
+++ b/src/Propulsion.Cosmos/ChangeFeedProcessor.fs
@@ -70,15 +70,10 @@ type ChangeFeedObserverFactory =
 
 type ContainerId = { database: string; container: string }
 
-[<RequireQualifiedAccess; NoComparison; NoEquality>]
-type Discovery =
-    | UriKeyAndPolicy of databaseUri:Uri * key:string * policy: ConnectionPolicy
-    | Custom of DocumentClient * databaseUri:Uri * policy: ConnectionPolicy
-
 //// Wraps the [Azure CosmosDb ChangeFeedProcessor library](https://github.com/Azure/azure-documentdb-changefeedprocessor-dotnet)
 type ChangeFeedProcessor =
     static member Start
-        (   log : ILogger, discovery: Discovery, source: ContainerId,
+        (   log : ILogger, client: DocumentClient, source: ContainerId,
             /// The aux, non-partitioned container holding the partition leases.
             // Aux container should always read from the write region to keep the number of write conflicts to a minimum when the sdk
             // updates the leases. Since the non-write region(s) might lag behind due to us using non-strong consistency, during
@@ -86,8 +81,8 @@ type ChangeFeedProcessor =
             aux : ContainerId,
             createObserver : unit -> IChangeFeedObserver,
             ?leaseOwnerId : string,
-            /// Used to specify an endpoint/account key for the aux container, where that varies from that of the source container. Default: use `discovery`
-            ?auxDiscovery : Discovery,
+            /// Used to specify an endpoint/account key for the aux container, where that varies from that of the source container. Default: use `client`
+            ?auxClient : DocumentClient,
             /// Identifier to disambiguate multiple independent feed processor positions (akin to a 'consumer group')
             ?leasePrefix : string,
             /// (NB Only applies if this is the first time this leasePrefix is presented)
@@ -103,7 +98,7 @@ type ChangeFeedProcessor =
             /// Delay before re-polling a partitition after backlog has been drained
             ?feedPollDelay : TimeSpan,
             /// Limit on items to take in a batch when querying for changes (in addition to 4MB response size limit). Default Unlimited
-            ?maxDocuments : int, 
+            ?maxDocuments : int,
             /// Continuously fed per-partion lag information until parent Async completes
             /// callback should Async.Sleep until next update is desired
             ?reportLagAndAwaitNextEstimation) = async {
@@ -119,7 +114,7 @@ type ChangeFeedProcessor =
             s leaseAcquireInterval, s leaseTtl, s leaseRenewInterval, s feedPollDelay)
 
         let builder =
-            let feedProcessorOptions = 
+            let feedProcessorOptions =
                 ChangeFeedProcessorOptions(
                     StartFromBeginning = not (defaultArg startFromTail false),
                     LeaseAcquireInterval = leaseAcquireInterval, LeaseExpirationInterval = leaseTtl, LeaseRenewInterval = leaseRenewInterval,
@@ -133,18 +128,14 @@ type ChangeFeedProcessor =
             leasePrefix |> Option.iter (fun lp -> feedProcessorOptions.LeasePrefix <- lp + ":")
             // Max Items is not emphasized as a control mechanism as it can only be used meaningfully when events are highly regular in size
             maxDocuments |> Option.iter (fun mi -> feedProcessorOptions.MaxItemCount <- Nullable mi)
-            let mkC = function
-                | Discovery.UriKeyAndPolicy (u,k,p) -> new DocumentClient(serviceEndpoint=u, authKeyOrResourceToken=k, connectionPolicy=p,desiredConsistencyLevel=Nullable())
-                | Discovery.Custom (documentClient,_u,_p) -> documentClient
-            let mkD cid = function
-                | Discovery.UriKeyAndPolicy (u,_k,p) -> DocumentCollectionInfo(Uri=u,ConnectionPolicy=p,DatabaseName=cid.database,CollectionName=cid.container)
-                | Discovery.Custom (_,uri,p) -> DocumentCollectionInfo(Uri=uri,ConnectionPolicy=p,DatabaseName=cid.database,CollectionName=cid.container)
+            let mkD cid (dc : DocumentClient) =
+                DocumentCollectionInfo(Uri=dc.ServiceEndpoint,ConnectionPolicy=dc.ConnectionPolicy,DatabaseName=cid.database,CollectionName=cid.container)
             ChangeFeedProcessorBuilder()
                 .WithHostName(leaseOwnerId)
-                .WithFeedCollection(mkD source discovery)
-                .WithLeaseCollection(mkD aux (defaultArg auxDiscovery discovery))
-                .WithFeedDocumentClient(mkC discovery)
-                .WithLeaseDocumentClient(mkC (defaultArg auxDiscovery discovery))
+                .WithFeedCollection(mkD source client)
+                .WithLeaseCollection(mkD aux (defaultArg auxClient client))
+                .WithFeedDocumentClient(client)
+                .WithLeaseDocumentClient(defaultArg auxClient client)
                 .WithProcessorOptions(feedProcessorOptions)
         match reportLagAndAwaitNextEstimation with
         | None -> ()

--- a/src/Propulsion.Cosmos/CosmosSource.fs
+++ b/src/Propulsion.Cosmos/CosmosSource.fs
@@ -30,7 +30,7 @@ type CosmosSource =
 
     static member Run
         (   log : ILogger,
-            discovery, connectionPolicy, source,
+            discovery, source,
             aux, leaseId, startFromTail, createObserver,
             ?maxDocuments, ?lagReportFreq : TimeSpan, ?auxDiscovery) = async {
         let logLag (interval : TimeSpan) (remainingWork : (int*int64) list) = async {
@@ -45,7 +45,7 @@ type CosmosSource =
         let maybeLogLag = lagReportFreq |> Option.map logLag
         let! _feedEventHost =
             ChangeFeedProcessor.Start
-              ( log, discovery, connectionPolicy, source, aux, ?auxDiscovery = auxDiscovery, leasePrefix = leaseId, startFromTail = startFromTail,
+              ( log, discovery, source, aux, ?auxDiscovery = auxDiscovery, leasePrefix = leaseId, startFromTail = startFromTail,
                 createObserver = createObserver, ?reportLagAndAwaitNextEstimation = maybeLogLag, ?maxDocuments = maxDocuments,
                 leaseAcquireInterval = TimeSpan.FromSeconds 5., leaseRenewInterval = TimeSpan.FromSeconds 5., leaseTtl = TimeSpan.FromSeconds 10.)
         do! Async.AwaitKeyboardInterrupt() } // exiting will Cancel the child tasks, i.e. the _feedEventHost

--- a/src/Propulsion.Cosmos/CosmosSource.fs
+++ b/src/Propulsion.Cosmos/CosmosSource.fs
@@ -30,9 +30,9 @@ type CosmosSource =
 
     static member Run
         (   log : ILogger,
-            discovery, source,
+            client, source,
             aux, leaseId, startFromTail, createObserver,
-            ?maxDocuments, ?lagReportFreq : TimeSpan, ?auxDiscovery) = async {
+            ?maxDocuments, ?lagReportFreq : TimeSpan, ?auxClient) = async {
         let logLag (interval : TimeSpan) (remainingWork : (int*int64) list) = async {
             let synced, lagged, count, total = ResizeArray(), ResizeArray(), ref 0, ref 0L
             for partitionId, lag as value in remainingWork do
@@ -45,7 +45,7 @@ type CosmosSource =
         let maybeLogLag = lagReportFreq |> Option.map logLag
         let! _feedEventHost =
             ChangeFeedProcessor.Start
-              ( log, discovery, source, aux, ?auxDiscovery = auxDiscovery, leasePrefix = leaseId, startFromTail = startFromTail,
+              ( log, client, source, aux, ?auxClient = auxClient, leasePrefix = leaseId, startFromTail = startFromTail,
                 createObserver = createObserver, ?reportLagAndAwaitNextEstimation = maybeLogLag, ?maxDocuments = maxDocuments,
                 leaseAcquireInterval = TimeSpan.FromSeconds 5., leaseRenewInterval = TimeSpan.FromSeconds 5., leaseTtl = TimeSpan.FromSeconds 10.)
         do! Async.AwaitKeyboardInterrupt() } // exiting will Cancel the child tasks, i.e. the _feedEventHost

--- a/src/Propulsion.Cosmos/Infrastructure.fs
+++ b/src/Propulsion.Cosmos/Infrastructure.fs
@@ -42,3 +42,15 @@ module private AsyncHelpers =
                     elif t.IsCompleted then k ()
                     else ek(Exception "invalid Task state!"))
                 |> ignore
+
+[<AutoOpen>] // TODO remove shim after Equinox 2.0.0-rc7
+module EquinoxCosmosHelpers =
+    type Equinox.Cosmos.Connector with
+         /// Yields a DocumentClient configured per the specified strategy
+        member __.CreateClient
+            (   /// Name should be sufficient to uniquely identify this connection within a single app instance's logs
+                name, discovery : Equinox.Cosmos.Discovery,
+                /// <c>true</c> to inhibit logging of client name
+                ?skipLog) : Microsoft.Azure.Documents.Client.DocumentClient =
+            let (Equinox.Cosmos.Discovery.UriAndKey (u,k)) = discovery
+            new Microsoft.Azure.Documents.Client.DocumentClient(serviceEndpoint=u, authKeyOrResourceToken=k, connectionPolicy=__.ClientOptions)

--- a/src/Propulsion.Cosmos/Infrastructure.fs
+++ b/src/Propulsion.Cosmos/Infrastructure.fs
@@ -42,15 +42,3 @@ module private AsyncHelpers =
                     elif t.IsCompleted then k ()
                     else ek(Exception "invalid Task state!"))
                 |> ignore
-
-[<AutoOpen>] // TODO remove shim after Equinox 2.0.0-rc7
-module EquinoxCosmosHelpers =
-    type Equinox.Cosmos.Connector with
-         /// Yields a DocumentClient configured per the specified strategy
-        member __.CreateClient
-            (   /// Name should be sufficient to uniquely identify this connection within a single app instance's logs
-                name, discovery : Equinox.Cosmos.Discovery,
-                /// <c>true</c> to inhibit logging of client name
-                ?skipLog) : Microsoft.Azure.Documents.Client.DocumentClient =
-            let (Equinox.Cosmos.Discovery.UriAndKey (u,k)) = discovery
-            new Microsoft.Azure.Documents.Client.DocumentClient(serviceEndpoint=u, authKeyOrResourceToken=k, connectionPolicy=__.ClientOptions)

--- a/tools/Propulsion.Tool/Program.fs
+++ b/tools/Propulsion.Tool/Program.fs
@@ -231,9 +231,11 @@ let main argv =
                     return! Async.Sleep(int interval.TotalMilliseconds) }
                 let maybeLogLag = pargs.TryGetResult LagFreqM |> Option.map (TimeSpan.FromMinutes >> logLag)
                 let! _cfp =
-                    let discovery = let (Equinox.Cosmos.Discovery.UriAndKey (k,v)) = discovery in Discovery.UriKeyAndPolicy(k,v,connector.ClientOptions)
+                    let client =
+                        let (Equinox.Cosmos.Discovery.UriAndKey (u,k)) = discovery
+                        new Microsoft.Azure.Documents.Client.DocumentClient(serviceEndpoint=u, authKeyOrResourceToken=k, connectionPolicy=connector.ClientOptions)
                     ChangeFeedProcessor.Start
-                      ( log, discovery, source, aux, buildRangeProjector,
+                      ( log, client, source, aux, buildRangeProjector,
                         leasePrefix = leaseId,
                         startFromTail = pargs.Contains FromTail,
                         ?maxDocuments = pargs.TryGetResult MaxDocuments,

--- a/tools/Propulsion.Tool/Program.fs
+++ b/tools/Propulsion.Tool/Program.fs
@@ -231,8 +231,9 @@ let main argv =
                     return! Async.Sleep(int interval.TotalMilliseconds) }
                 let maybeLogLag = pargs.TryGetResult LagFreqM |> Option.map (TimeSpan.FromMinutes >> logLag)
                 let! _cfp =
+                    let discovery = let (Equinox.Cosmos.Discovery.UriAndKey (k,v)) = discovery in Discovery.UriKeyAndPolicy(k,v,connector.ClientOptions)
                     ChangeFeedProcessor.Start
-                      ( log, discovery, connector.ClientOptions, source, aux, buildRangeProjector,
+                      ( log, discovery, source, aux, buildRangeProjector,
                         leasePrefix = leaseId,
                         startFromTail = pargs.Contains FromTail,
                         ?maxDocuments = pargs.TryGetResult MaxDocuments,


### PR DESCRIPTION
This PR reorganizes the CFP signatures to align with the Connector changes in https://github.com/jet/equinox/pull/171

The CreateClient in this PR is a hack and doesn't log correctly, hence this probably won't mrege/release until the next Equinox release