### PR TITLE
StreamKeyEventSequencer: Handle null keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Removed
 ### Fixed
 
+- StreamKeyEventSequencer: Handle null keys [#43](https://github.com/jet/propulsion/pull/43) :pray: [@nosman](https://github.com/nosman)
+
 <a name="1.3.1"></a>
 ## [1.3.1] - 2019-11-12
 

--- a/src/Propulsion.Kafka/Consumers.fs
+++ b/src/Propulsion.Kafka/Consumers.fs
@@ -287,6 +287,7 @@ module Core =
         // we synthesize a monotonically increasing index to render the deduplication facility inert
         let indices = System.Collections.Generic.Dictionary()
         let genIndex streamName =
+            let streamName = match streamName with null -> "" | x -> x // Kafka keys can be null, Dictionary ones cannot
             match indices.TryGetValue streamName with
             | true, v -> let x = v + 1 in indices.[streamName] <- x; int64 x
             | false, _ -> let x = 0 in indices.[streamName] <- x; int64 x


### PR DESCRIPTION
Bug (and fix) identified by @nosman with regard to `null` keys not being handled