### PR TITLE
Actually write checkpoints when using Equinox.Cosmos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Removed
 ### Fixed
 
-- StreamKeyEventSequencer: Handle null keys [#43](https://github.com/jet/propulsion/pull/43) :pray: [@nosman](https://github.com/nosman)
+- `StreamKeyEventSequencer`: Handle `null` keys [#43](https://github.com/jet/propulsion/pull/43) :pray: [@nosman](https://github.com/nosman)
+- `EventStore.Checkpoint`: Fix to actually write `Checkpointed` events [#44](https://github.com/jet/propulsion/pull/44)
 
 <a name="1.3.1"></a>
 ## [1.3.1] - 2019-11-12


### PR DESCRIPTION
My [last attempt](https://github.com/jet/propulsion/pull/42) works correctly, in that it generates correct values.
However, a key oversight is that `transmute` is passed the _post_ state, so will incorporate the event we are writing.
This more directly represents the situation, by having the `decide` function emit either a `Checkpointed` or an `Updated` indicating the intent.
This simplifies the `transmute` function significantly.