### PR TITLE
update reference assemblies to 1.0.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,6 +23,6 @@
   </PropertyGroup>
 
   <ItemGroup> <!-- net461 ref assemblies https://stackoverflow.com/a/57384175/11635 -->
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
`Microsoft.NETFramework.ReferenceAssemblies` was still on `1.0.0-preview.2` while `1.0.0` has been released. Updating these.