### PR TITLE
Use FsCodec.StreamName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Added
 ### Changed
 
-- `EventStore.Checkpoint` - style sync (`Folds`->`Fold`)
+- Target `FsCodec`.* v `2.0.0`, `Equinox`.* v `2.0.0-rc9` [#47](https://github.com/jet/propulsion/pull/47)
+- Use `FsCodec.StreamName` to replace string names; remove need for `categorize` functions [#47](https://github.com/jet/propulsion/pull/47)
+- Updated `EventStore.Checkpoint` to adhere to standard naming/layout (`Folds`->`Fold`)
 
 ### Removed
 ### Fixed

--- a/src/Propulsion.Cosmos/EquinoxCosmosParser.fs
+++ b/src/Propulsion.Cosmos/EquinoxCosmosParser.fs
@@ -23,7 +23,8 @@ module EquinoxCosmosParser =
 
     /// Enumerates the events represented within a batch
     let enumEquinoxCosmosEvents (batch : Equinox.Cosmos.Store.Batch) : StreamEvent<byte[]> seq =
-        batch.e |> Seq.mapi (fun offset x -> { stream = batch.p; event = FsCodec.Core.TimelineEvent.Create(batch.i+int64 offset,x.c,x.d,x.m,timestamp=x.t) })
+        let streamName = FsCodec.StreamName.parse batch.p // we expect all Equinox data to adhere to "{category}-{aggregateId}" form (or we'll throw)
+        batch.e |> Seq.mapi (fun offset x -> { stream = streamName; event = FsCodec.Core.TimelineEvent.Create(batch.i+int64 offset, x.c, x.d, x.m, timestamp=x.t) })
 
     /// Collects all events with a Document [typically obtained via the CosmosDb ChangeFeed] that potentially represents an Equinox.Cosmos event-batch
     let enumStreamEvents (d : Document) : StreamEvent<byte[]> seq =

--- a/src/Propulsion.Cosmos/Propulsion.Cosmos.fsproj
+++ b/src/Propulsion.Cosmos/Propulsion.Cosmos.fsproj
@@ -24,7 +24,7 @@
     <PackageReference Include="FSharp.Core" Version="3.1.2.5" Condition=" '$(TargetFramework)' == 'net461' " />
     <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' != 'net461' " />
 
-    <PackageReference Include="Equinox.Cosmos" Version="2.0.0-rc8" />
+    <PackageReference Include="Equinox.Cosmos" Version="2.0.0-rc9" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.ChangeFeedProcessor" Version="2.2.8" />
   </ItemGroup>
 

--- a/src/Propulsion.EventStore/Checkpoint.fs
+++ b/src/Propulsion.EventStore/Checkpoint.fs
@@ -10,7 +10,7 @@ module CheckpointSeriesId = let ofGroupName (groupName : string) = UMX.tag group
 // NB - these schemas reflect the actual storage formats and hence need to be versioned with care
 module Events =
 
-    let (|ForSeries|) (id : CheckpointSeriesId) = Equinox.AggregateId ("Sync", % id)
+    let (|ForSeries|) (id : CheckpointSeriesId) = FsCodec.StreamName.create "Sync" %id
 
     type Checkpoint = { at: DateTimeOffset; nextCheckpointDue: DateTimeOffset; pos: int64 }
     type Config = { checkpointFreqS: int }

--- a/src/Propulsion.EventStore/Propulsion.EventStore.fsproj
+++ b/src/Propulsion.EventStore/Propulsion.EventStore.fsproj
@@ -25,7 +25,7 @@
     <PackageReference Include="FSharp.Core" Version="3.1.2.5" Condition=" '$(TargetFramework)' == 'net461' " />
     <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' != 'net461' " />
 
-    <PackageReference Include="Equinox.EventStore" Version="2.0.0-rc8" />
+    <PackageReference Include="Equinox.EventStore" Version="2.0.0-rc9" />
     <PackageReference Include="FSharp.UMX" Version="1.0.0" />
     <PackageReference Include="Serilog" Version="2.7.1" />
     <PackageReference Include="TypeShape" Version="8.0.1" />

--- a/src/Propulsion.Kafka/Propulsion.Kafka.fsproj
+++ b/src/Propulsion.Kafka/Propulsion.Kafka.fsproj
@@ -26,7 +26,7 @@
     <PackageReference Include="FSharp.Core" Version="3.1.2.5" Condition=" '$(TargetFramework)' == 'net461' " />
     <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' != 'net461' " />
 
-    <PackageReference Include="FsCodec.NewtonsoftJson" Version="1.2.1" />
+    <PackageReference Include="FsCodec.NewtonsoftJson" Version="2.0.0-rc3" />
     <PackageReference Include="FsKafka" Version="1.3.0" />
   </ItemGroup>
 

--- a/src/Propulsion.Kafka0/Propulsion.Kafka0.fsproj
+++ b/src/Propulsion.Kafka0/Propulsion.Kafka0.fsproj
@@ -30,7 +30,7 @@
     <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' != 'net461' " />
 
     <PackageReference Include="Confluent.Kafka" Version="[0.11.3]" />
-    <PackageReference Include="FsCodec.NewtonsoftJson" Version="1.2.1" />
+    <PackageReference Include="FsCodec.NewtonsoftJson" Version="2.0.0-rc3" />
     <PackageReference Include="librdkafka.redist" Version="[0.11.4]" />
   </ItemGroup>
 

--- a/src/Propulsion/Propulsion.fsproj
+++ b/src/Propulsion/Propulsion.fsproj
@@ -26,7 +26,7 @@
     <PackageReference Include="FSharp.Core" Version="3.1.2.5" Condition=" '$(TargetFramework)' == 'net461' " />
     <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' != 'net461' " />
 
-    <PackageReference Include="FsCodec" Version="1.2.1" />
+    <PackageReference Include="FsCodec" Version="2.0.0-rc3" />
     <PackageReference Include="MathNet.Numerics" Version="4.7.0" />
     <PackageReference Include="Serilog" Version="2.7.1" />
   </ItemGroup>

--- a/tests/Propulsion.Tests/ProgressTests.fs
+++ b/tests/Propulsion.Tests/ProgressTests.fs
@@ -1,11 +1,13 @@
 ﻿module ProgressTests
 
+open FsCodec
 open Propulsion.Streams
 open Swensen.Unquote
 open System.Collections.Generic
 open Xunit
 
-let mkDictionary xs = Dictionary<string,int64>(dict xs)
+let sn x = StreamName.create x x
+let mkDictionary xs = Dictionary<StreamName,int64>(dict xs)
 
 let [<Fact>] ``Empty has zero streams pending or progress to write`` () =
     let sut = Progress.ProgressState<_>()
@@ -15,16 +17,16 @@ let [<Fact>] ``Empty has zero streams pending or progress to write`` () =
 let [<Fact>] ``Can add multiple batches with overlapping streams`` () =
     let sut = Progress.ProgressState<_>()
     let noBatchesComplete () = failwith "No bathes should complete"
-    sut.AppendBatch(noBatchesComplete, mkDictionary ["a",1L; "b",2L])
-    sut.AppendBatch(noBatchesComplete, mkDictionary ["b",2L; "c",3L])
+    sut.AppendBatch(noBatchesComplete, mkDictionary [sn "a",1L; sn "b",2L])
+    sut.AppendBatch(noBatchesComplete, mkDictionary [sn "b",2L; sn "c",3L])
 
 let [<Fact>] ``Marking Progress removes batches and triggers the callbacks`` () =
     let sut = Progress.ProgressState<_>()
     let mutable callbacks = 0
     let complete () = callbacks <- callbacks + 1
-    sut.AppendBatch(complete, mkDictionary ["a",1L; "b",2L])
-    sut.MarkStreamProgress("a",1L) |> ignore
-    sut.MarkStreamProgress("b",3L) |> ignore
+    sut.AppendBatch(complete, mkDictionary [sn "a",1L; sn "b",2L])
+    sut.MarkStreamProgress(sn "a",1L) |> ignore
+    sut.MarkStreamProgress(sn "b",3L) |> ignore
     1 =! callbacks
 
 let [<Fact>] ``Empty batches get removed immediately`` () =
@@ -39,9 +41,9 @@ let [<Fact>] ``Marking progress is not persistent`` () =
     let sut = Progress.ProgressState<_>()
     let mutable callbacks = 0
     let complete () = callbacks <- callbacks + 1
-    sut.AppendBatch(complete, mkDictionary ["a",1L])
-    sut.MarkStreamProgress("a",2L) |> ignore
-    sut.AppendBatch(complete, mkDictionary ["a",1L; "b",2L])
+    sut.AppendBatch(complete, mkDictionary [sn "a",1L])
+    sut.MarkStreamProgress(sn "a",2L) |> ignore
+    sut.AppendBatch(complete, mkDictionary [sn "a",1L; sn "b",2L])
     1 =! callbacks
 
 // TODO: lots more coverage of newer functionality - the above were written very early into the exercise


### PR DESCRIPTION
This feeds through changes logically implied by Equinox adopting `FsCodec.StreamName`; all Stream Names are now managed in canonical `{category}-{aggregateId}` form

The key benefit of this for the programming model is that the `dotnet-templates` no longer need to furnish a `categorize` function, which allows [`StreamName`'s associated documentation](https://github.com/jet/FsCodec/tree/master#stream-naming-conventions) to describe then routing and matching of all streams being processed.

- Target [Equinox 2.0.0-rc9](https://github.com/jet/equinox/releases/tag/2.0.0-rc9)
- Target [FsCodec 2.0.0-rc3](https://github.com/jet/FsCodec/pull/31)