### PR TITLE
Add outcome to prepare, make producing optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,11 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 
-- `StreamsProducerSink`: Added overload to facilitate `prepare` make production of an output `option`al and admitting processing of Stats
-
+- `StreamsProducerSink`: Added overload to facilitate `prepare` make production of an output `option`al and admitting processing of Stats [#50](https://github.com/jet/propulsion/pull/50)
 
 ### Changed
 
-- `StreamsSync`: Add `* 'outcome` to `handle` function signature
+- `StreamsSync`: Add `* 'outcome` to `handle` function signature [#50](https://github.com/jet/propulsion/pull/50)
 - Update to `3.1.101` SDK
 - Retarget `netcoreapp2.1` apps to `netcoreapp3.1` (not least to make tool traverse proxies on Windows)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,13 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ## [Unreleased]
 
 ### Added
+
+- `StreamsProducerSink`: Added overload to facilitate `prepare` make production of an output `option`al and admitting processing of Stats
+
+
 ### Changed
 
+- `StreamsSync`: Add `* 'outcome` to `handle` function signature
 - Update to `3.1.101` SDK
 - Retarget `netcoreapp2.1` apps to `netcoreapp3.1` (not least to make tool traverse proxies on Windows)
 

--- a/src/Propulsion.Kafka/ProducerSinks.fs
+++ b/src/Propulsion.Kafka/ProducerSinks.fs
@@ -16,9 +16,12 @@ type ParallelProducerSink =
         Parallel.ParallelProjector.Start(Log.Logger, maxReadAhead, maxDop, handle >> Async.Catch, statsInterval=statsInterval, logExternalStats = producer.DumpStats)
 
 type StreamsProducerSink =
+
    static member Start
-        (   log : ILogger, maxReadAhead, maxConcurrentStreams, prepare, producer : Producer,
-            ?statsInterval, ?stateInterval,
+        (   log : ILogger, maxReadAhead, maxConcurrentStreams,
+            prepare : StreamName * StreamSpan<_> -> Async<(string*string) option * 'Outcome>,
+            producer : Producer,
+            stats : Streams.Sync.StreamsSyncStats<'Outcome>, projectorStatsInterval,
             /// Default .5 ms
             ?idleDelay,
             /// Default 1 MiB
@@ -32,14 +35,45 @@ type StreamsProducerSink =
         : ProjectorPipeline<_> =
             let maxBytes =  (defaultArg maxBytes (1024*1024 - (*fudge*)4096))
             let handle (stream : StreamName, span) = async {
-                let! (key : string, message : string) = prepare (stream, span)
-                match message.Length with
-                | x when x > maxBytes -> log.Warning("Message on {stream} had String.Length {length} Queue length {queueLen}", stream, x, span.events.Length)
-                | _ -> ()
-                let! _ = producer.ProduceAsync(key,message)
-                return span.index + span.events.LongLength
+                let! (maybeMsg, outcome : 'Outcome) = prepare (stream, span)
+                match maybeMsg with
+                | Some (key : string, message : string) ->
+                    match message.Length with
+                    | x when x > maxBytes -> log.Warning("Message on {stream} had String.Length {length} Queue length {queueLen}", stream, x, span.events.Length)
+                    | _ -> ()
+                    let! _ = producer.ProduceAsync(key,message) in ()
+                | None -> ()
+                return span.index + span.events.LongLength, outcome
             }
             Sync.StreamsSync.Start
-                (    log, maxReadAhead, maxConcurrentStreams, handle,
-                     maxBytes=maxBytes, ?statsInterval = statsInterval, ?stateInterval = stateInterval, ?idleDelay=idleDelay,
+                (    log, maxReadAhead, maxConcurrentStreams, handle, stats, projectorStatsInterval = projectorStatsInterval,
+                     maxBytes=maxBytes, ?idleDelay=idleDelay,
                      ?maxEvents=maxEvents, ?maxBatches=maxBatches, ?maxCycles=maxCycles, dumpExternalStats=producer.DumpStats)
+
+   static member Start
+        (   log : ILogger, maxReadAhead, maxConcurrentStreams,
+            prepare : StreamName * StreamSpan<_> -> Async<string*string>,
+            producer : Producer,
+            ?statsInterval, ?stateInterval,
+            /// Default .5 ms
+            ?idleDelay,
+            /// Default 1 MiB
+            ?maxBytes,
+            /// Default 16384
+            ?maxEvents,
+            /// Max scheduling readahead. Default 128.
+            ?maxBatches,
+            /// Max inner cycles per loop. Default 128.
+            ?maxCycles)
+        : ProjectorPipeline<_> =
+            let statsInterval, stateInterval = defaultArg statsInterval (TimeSpan.FromMinutes 5.), defaultArg stateInterval (TimeSpan.FromMinutes 5.)
+            let stats = Streams.Sync.StreamsSyncStats<unit>(log.ForContext<Sync.StreamsSyncStats<unit>>(), statsInterval, stateInterval)
+            let prepare (stream,span) = async {
+                let! k,v = prepare (stream,span)
+                return Some (k,v), ()
+            }
+            StreamsProducerSink.Start
+                (    log, maxReadAhead, maxConcurrentStreams,
+                     prepare, producer, stats, projectorStatsInterval = statsInterval,
+                     ?idleDelay=idleDelay, ?maxBytes = maxBytes,
+                     ?maxEvents=maxEvents, ?maxBatches=maxBatches, ?maxCycles=maxCycles)


### PR DESCRIPTION
- `StreamsSync`: Add `* 'outcome` to `handle` function signature
- `StreamsProducerSink`: Added overload to facilitate `prepare` make production of an output `option`al and admitting processing of Stats
@fnipo @kimserey