### PR TITLE
Clean up Stats types, add SpanResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - Revised `handle` function signatures in `Propulsion.Kafka.StreamsConsumer` and `Propulsion.Streams.StreamsProjector` to include a `Propulsion.Streams.SpanResult` representing Write Position updates [#65](https://github.com/jet/propulsion/pull/65)
 
 ### Changed
+
+- Removed egregious `int64` from stats handler signatures in `Propulsion.Streams.Scheduling.StreamSchedulerStats` and `Projector.Stats` [#65](https://github.com/jet/propulsion/pull/65)
+
 ### Removed
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Changed
 
 - Removed egregious `int64` from stats handler signatures in `Propulsion.Streams.Scheduling.StreamSchedulerStats` and `Projector.Stats` [#65](https://github.com/jet/propulsion/pull/65)
+- Renamed `Streams.Sync.StreamsSyncStats` and `Streams.Scheduling.StreamSchedulerStats` to `Stats` for consistency [#65](https://github.com/jet/propulsion/pull/65)
 
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ## [Unreleased]
 
 ### Added
+
+- Revised `handle` function signatures in `Propulsion.Kafka.StreamsConsumer` and `Propulsion.Streams.StreamsProjector` to include a `Propulsion.Streams.SpanResult` representing Write Position updates [#65](https://github.com/jet/propulsion/pull/65)
+
 ### Changed
 ### Removed
 ### Fixed

--- a/src/Propulsion.Cosmos/CosmosSink.fs
+++ b/src/Propulsion.Cosmos/CosmosSink.fs
@@ -131,7 +131,7 @@ module Internal =
     type CosmosSchedulingEngine =
 
         static member Create(log : ILogger, cosmosContexts : _ [], itemDispatcher, stats : CosmosStats, dumpStreams, ?maxBatches)
-            : Scheduling.StreamSchedulingEngine<_, _> =
+            : Scheduling.StreamSchedulingEngine<_, _, _> =
             let writerResultLog = log.ForContext<Writer.Result>()
             let mutable robin = 0
             let attemptWrite (item : Scheduling.DispatchItem<_>) = async {
@@ -153,8 +153,8 @@ module Internal =
                         streams.SetMalformed(stream,malformed)
                 let _stream, ss = applyResultToStreamState res
                 Writer.logTo writerResultLog (stream,res)
-                ss.write
-            let dispatcher = Scheduling.MultiDispatcher<_, _>(itemDispatcher, attemptWrite, interpretWriteResultProgress, stats, dumpStreams)
+                ss.write, res
+            let dispatcher = Scheduling.MultiDispatcher<_, _, _>(itemDispatcher, attemptWrite, interpretWriteResultProgress, stats, dumpStreams)
             Scheduling.StreamSchedulingEngine(dispatcher, enableSlipstreaming=true, ?maxBatches = maxBatches)
 
 type CosmosSink =

--- a/src/Propulsion.Cosmos/CosmosSink.fs
+++ b/src/Propulsion.Cosmos/CosmosSink.fs
@@ -26,7 +26,7 @@ module Internal =
             | Duplicate of updatedPos : int64
             | PartialDuplicate of overage : StreamSpan<byte[]>
             | PrefixMissing of batch : StreamSpan<byte[]> * writePos : int64
-        let logTo (log : ILogger) (res : StreamName * Choice<EventStats * Result, EventStats * exn>) =
+        let logTo (log : ILogger) (res : StreamName * Choice<EventMetrics * Result, EventMetrics * exn>) =
             match res with
             | stream, (Choice1Of2 (_, Ok pos)) ->
                 log.Information("Wrote     {stream} up to {pos}", stream, pos)
@@ -80,7 +80,7 @@ module Internal =
             | ResultKind.TooLarge | ResultKind.Malformed -> true
 
     type CosmosStats(log : ILogger, statsInterval, stateInterval) =
-        inherit Scheduling.StreamSchedulerStats<EventStats * Writer.Result, EventStats * exn>(log, statsInterval, stateInterval)
+        inherit Scheduling.Stats<EventMetrics * Writer.Result, EventMetrics * exn>(log, statsInterval, stateInterval)
         let okStreams, resultOk, resultDup, resultPartialDup, resultPrefix, resultExnOther = HashSet(), ref 0, ref 0, ref 0, ref 0, ref 0
         let badCats, failStreams, rateLimited, timedOut, tooLarge, malformed = CatStats(), HashSet(), ref 0, ref 0, ref 0, ref 0
         let rlStreams, toStreams, tlStreams, mfStreams, oStreams = HashSet(), HashSet(), HashSet(), HashSet(), HashSet()

--- a/src/Propulsion.EventStore/EventStoreSink.fs
+++ b/src/Propulsion.EventStore/EventStoreSink.fs
@@ -25,7 +25,7 @@ module Internal =
             | PartialDuplicate of overage : StreamSpan<byte[]>
             | PrefixMissing of batch : StreamSpan<byte[]> * writePos : int64
 
-        let logTo (log : ILogger) (res : FsCodec.StreamName * Choice<EventStats * Result, EventStats * exn>) =
+        let logTo (log : ILogger) (res : FsCodec.StreamName * Choice<EventMetrics * Result, EventMetrics * exn>) =
             match res with
             | stream, (Choice1Of2 (_, Ok pos)) ->
                 log.Information("Wrote     {stream} up to {pos}", stream, pos)
@@ -65,7 +65,7 @@ module Internal =
             | _ -> ResultKind.Other
 
     type EventStoreStats(log : ILogger, statsInterval, stateInterval) =
-        inherit Scheduling.StreamSchedulerStats<EventStats * Writer.Result, EventStats * exn>(log, statsInterval, stateInterval)
+        inherit Scheduling.Stats<EventMetrics * Writer.Result, EventMetrics * exn>(log, statsInterval, stateInterval)
         let okStreams, resultOk, resultDup, resultPartialDup, resultPrefix, resultExnOther = HashSet(), ref 0, ref 0, ref 0, ref 0, ref 0
         let badCats, failStreams, timedOut = CatStats(), HashSet(), ref 0
         let toStreams, oStreams = HashSet(), HashSet()

--- a/src/Propulsion.EventStore/EventStoreSink.fs
+++ b/src/Propulsion.EventStore/EventStoreSink.fs
@@ -112,7 +112,7 @@ module Internal =
 
     type EventStoreSchedulingEngine =
         static member Create(log : ILogger, storeLog, connections : _ [], itemDispatcher, stats : EventStoreStats, dumpStreams, ?maxBatches)
-            : Scheduling.StreamSchedulingEngine<_, _> =
+            : Scheduling.StreamSchedulingEngine<_, _, _> =
             let writerResultLog = log.ForContext<Writer.Result>()
             let mutable robin = 0
 
@@ -134,9 +134,9 @@ module Internal =
                     | Choice2Of2 (_stats, _exn) -> streams.SetMalformed(stream, false)
                 let _stream, ss = applyResultToStreamState res
                 Writer.logTo writerResultLog (stream, res)
-                ss.write
+                ss.write, res
 
-            let dispatcher = Scheduling.MultiDispatcher<_, _>(itemDispatcher, attemptWrite, interpretWriteResultProgress, stats, dumpStreams)
+            let dispatcher = Scheduling.MultiDispatcher<_, _, _>(itemDispatcher, attemptWrite, interpretWriteResultProgress, stats, dumpStreams)
             Scheduling.StreamSchedulingEngine(dispatcher, enableSlipstreaming = true, ?maxBatches = maxBatches, idleDelay = TimeSpan.FromMilliseconds 2.)
 
 type EventStoreSink =

--- a/src/Propulsion.Kafka/Consumers.fs
+++ b/src/Propulsion.Kafka/Consumers.fs
@@ -206,11 +206,11 @@ type ParallelConsumer private () =
         ParallelConsumer.Start<KeyValuePair<string, string>>(log, config, maxDop, Bindings.mapConsumeResult, handle >> Async.Catch,
             ?maxSubmissionsPerPartition=maxSubmissionsPerPartition, ?pumpInterval=pumpInterval, ?statsInterval=statsInterval, ?logExternalStats=logExternalStats)
 
-type EventStats = Streams.EventStats
+type EventMetrics = Streams.EventMetrics
 
 [<AbstractClass>]
 type StreamsConsumerStats<'Outcome>(log : ILogger, statsInterval, stateInterval) =
-    inherit Streams.Scheduling.StreamSchedulerStats<EventStats * 'Outcome, EventStats * exn>(log, statsInterval, stateInterval)
+    inherit Streams.Scheduling.Stats<EventMetrics * 'Outcome, EventMetrics * exn>(log, statsInterval, stateInterval)
     let okStreams, failStreams = HashSet(), HashSet()
     let mutable okEvents, okBytes, exnEvents, exnBytes = 0, 0L, 0, 0L
 
@@ -245,7 +245,7 @@ module Core =
 
         static member Start<'Info, 'Outcome>
             (   log : ILogger, config : KafkaConsumerConfig, resultToInfo, infoToStreamEvents,
-                prepare, handle, maxDop, stats : Streams.Scheduling.StreamSchedulerStats<EventStats * 'Outcome, EventStats * exn>,
+                prepare, handle, maxDop, stats : Streams.Scheduling.Stats<EventMetrics * 'Outcome, EventMetrics * exn>,
                 ?pipelineStatsInterval, ?maxSubmissionsPerPartition, ?pumpInterval, ?logExternalState, ?idleDelay, ?maxBatches, ?maximizeOffsetWriting) =
             let pipelineStatsInterval = defaultArg pipelineStatsInterval (TimeSpan.FromMinutes 10.)
             let dispatcher = Streams.Scheduling.ItemDispatcher<_> maxDop
@@ -267,7 +267,7 @@ module Core =
         static member Start<'Info, 'Outcome>
             (   log : ILogger, config : KafkaConsumerConfig, consumeResultToInfo, infoToStreamEvents,
                 handle : StreamName * Streams.StreamSpan<_> -> Async<Streams.SpanResult * 'Outcome>, maxDop,
-                stats : Streams.Scheduling.StreamSchedulerStats<EventStats * 'Outcome, EventStats * exn>,
+                stats : Streams.Scheduling.Stats<EventMetrics * 'Outcome, EventMetrics * exn>,
                 ?pipelineStatsInterval, ?maxSubmissionsPerPartition, ?pumpInterval, ?logExternalState, ?idleDelay, ?maxBatches, ?maximizeOffsetWriting) =
             let prepare (streamName, span) =
                 let stats = Streams.Buffering.StreamSpan.stats span
@@ -293,7 +293,7 @@ module Core =
                 /// often implemented via <c>StreamNameSequenceGenerator.KeyValueToStreamEvent</c>
                 keyValueToStreamEvents,
                 prepare, handle : StreamName * Streams.StreamSpan<_> -> Async<Streams.SpanResult * 'Outcome>,
-                maxDop, stats : Streams.Scheduling.StreamSchedulerStats<EventStats * 'Outcome, EventStats * exn>,
+                maxDop, stats : Streams.Scheduling.Stats<EventMetrics * 'Outcome, EventMetrics * exn>,
                 ?maximizeOffsetWriting, ?pipelineStatsInterval, ?maxSubmissionsPerPartition, ?pumpInterval, ?logExternalState, ?idleDelay)=
             StreamsConsumer.Start<KeyValuePair<string, string>, 'Outcome>(
                 log, config, Bindings.mapConsumeResult, keyValueToStreamEvents, prepare, handle, maxDop, stats,
@@ -310,7 +310,7 @@ module Core =
                 /// often implemented via <c>StreamNameSequenceGenerator.KeyValueToStreamEvent</c>
                 keyValueToStreamEvents : KeyValuePair<string, string> -> Propulsion.Streams.StreamEvent<_> seq,
                 handle : StreamName * Streams.StreamSpan<_> -> Async<Streams.SpanResult * 'Outcome>, maxDop,
-                stats : Streams.Scheduling.StreamSchedulerStats<EventStats * 'Outcome, EventStats * exn>,
+                stats : Streams.Scheduling.Stats<EventMetrics * 'Outcome, EventMetrics * exn>,
                 ?maximizeOffsetWriting, ?pipelineStatsInterval, ?maxSubmissionsPerPartition, ?pumpInterval, ?logExternalState, ?idleDelay, ?maxBatches) =
             StreamsConsumer.Start<KeyValuePair<string, string>, 'Outcome>(
                 log, config, Bindings.mapConsumeResult, keyValueToStreamEvents, handle, maxDop, stats,
@@ -416,7 +416,7 @@ type StreamsConsumer =
             /// The scheduler guarantees to never schedule two concurrent <c>handler<c> invocations for the same stream.
             maxDop,
             /// The <c>'Outcome</c> from each handler invocation is passed to the Statistics processor by the scheduler for periodic emission
-            stats : Streams.Scheduling.StreamSchedulerStats<EventStats * 'Outcome, EventStats * exn>,
+            stats : Streams.Scheduling.Stats<EventMetrics * 'Outcome, EventMetrics * exn>,
             /// Prevent batches being consolidated prior to scheduling in order to maximize granularity of consumer offset updates
             ?maximizeOffsetWriting,
             ?pipelineStatsInterval, ?maxSubmissionsPerPartition, ?pumpInterval, ?logExternalState, ?idleDelay, ?maxBatches) =
@@ -451,7 +451,7 @@ type BatchesConsumer =
             ///   new ones that arrived while the handler was processing are then eligible for retry purposes in the next dispatch cycle)
             handle : Streams.Scheduling.DispatchItem<_>[] -> Async<seq<Choice<int64, exn>>>,
             /// The responses from each <c>handle</c> invocation are passed to <c>stats</c> for periodic emission
-            stats : Streams.Scheduling.StreamSchedulerStats<EventStats * unit, EventStats * exn>,
+            stats : Streams.Scheduling.Stats<EventMetrics * unit, EventMetrics * exn>,
             /// Maximum number of batches to ingest for scheduling at any one time (Default: 24.)
             /// NOTE Stream-wise consumption defaults to taking 5 batches each time replenishment is required
             ?schedulerIngestionBatchCount, ?pipelineStatsInterval, ?maxSubmissionsPerPartition, ?pumpInterval, ?logExternalState, ?idleDelay) =
@@ -461,7 +461,7 @@ type BatchesConsumer =
             logExternalState |> Option.iter (fun f -> f log)
             streams.Dump(log, Streams.Buffering.StreamState.eventsSize)
         let handle (items : Streams.Scheduling.DispatchItem<byte[]>[])
-            : Async<(StreamName * Choice<int64 * (EventStats * unit), EventStats * exn>)[]> = async {
+            : Async<(StreamName * Choice<int64 * (EventMetrics * unit), EventMetrics * exn>)[]> = async {
             try let! results = handle items
                 return
                     [| for x in Seq.zip items results ->

--- a/src/Propulsion.Kafka/Consumers.fs
+++ b/src/Propulsion.Kafka/Consumers.fs
@@ -461,7 +461,7 @@ type BatchesConsumer =
             logExternalState |> Option.iter (fun f -> f log)
             streams.Dump(log, Streams.Buffering.StreamState.eventsSize)
         let handle (items : Streams.Scheduling.DispatchItem<byte[]>[])
-            : Async<(StreamName * Choice<int64 * EventStats * unit, EventStats * exn>)[]> = async {
+            : Async<(StreamName * Choice<int64 * (EventStats * unit), EventStats * exn>)[]> = async {
             try let! results = handle items
                 return
                     [| for x in Seq.zip items results ->
@@ -469,7 +469,7 @@ type BatchesConsumer =
                         | item, Choice1Of2 index' ->
                             let used : Streams.StreamSpan<_> = { item.span with events = item.span.events |> Seq.takeWhile (fun e -> e.Index <> index' ) |> Array.ofSeq }
                             let s = Streams.Buffering.StreamSpan.stats used
-                            item.stream, Choice1Of2 (index', s, ())
+                            item.stream, Choice1Of2 (index', (s, ()))
                         | item, Choice2Of2 exn ->
                             let s = Streams.Buffering.StreamSpan.stats item.span
                             item.stream, Choice2Of2 (s, exn) |]

--- a/src/Propulsion.Kafka/Consumers.fs
+++ b/src/Propulsion.Kafka/Consumers.fs
@@ -245,7 +245,7 @@ module Core =
 
         static member Start<'Info, 'Outcome>
             (   log : ILogger, config : KafkaConsumerConfig, resultToInfo, infoToStreamEvents,
-                prepare, handle, maxDop, stats : Streams.Scheduling.StreamSchedulerStats<int64 * EventStats * 'Outcome, EventStats * exn>,
+                prepare, handle, maxDop, stats : Streams.Scheduling.StreamSchedulerStats<EventStats * 'Outcome, EventStats * exn>,
                 ?pipelineStatsInterval, ?maxSubmissionsPerPartition, ?pumpInterval, ?logExternalState, ?idleDelay, ?maxBatches, ?maximizeOffsetWriting) =
             let pipelineStatsInterval = defaultArg pipelineStatsInterval (TimeSpan.FromMinutes 10.)
             let dispatcher = Streams.Scheduling.ItemDispatcher<_> maxDop
@@ -267,7 +267,7 @@ module Core =
         static member Start<'Info, 'Outcome>
             (   log : ILogger, config : KafkaConsumerConfig, consumeResultToInfo, infoToStreamEvents,
                 handle : StreamName * Streams.StreamSpan<_> -> Async<int64 * 'Outcome>, maxDop,
-                stats : Streams.Scheduling.StreamSchedulerStats<int64 * EventStats * 'Outcome, EventStats * exn>,
+                stats : Streams.Scheduling.StreamSchedulerStats<EventStats * 'Outcome, EventStats * exn>,
                 ?pipelineStatsInterval, ?maxSubmissionsPerPartition, ?pumpInterval, ?logExternalState, ?idleDelay, ?maxBatches, ?maximizeOffsetWriting) =
             let prepare (streamName, span) =
                 let stats = Streams.Buffering.StreamSpan.stats span
@@ -293,7 +293,7 @@ module Core =
                 /// often implemented via <c>StreamNameSequenceGenerator.KeyValueToStreamEvent</c>
                 keyValueToStreamEvents,
                 prepare, handle : StreamName * Streams.StreamSpan<_> -> Async<int64 * 'Outcome>,
-                maxDop, stats : Streams.Scheduling.StreamSchedulerStats<int64 * EventStats * 'Outcome, EventStats * exn>,
+                maxDop, stats : Streams.Scheduling.StreamSchedulerStats<EventStats * 'Outcome, EventStats * exn>,
                 ?maximizeOffsetWriting, ?pipelineStatsInterval, ?maxSubmissionsPerPartition, ?pumpInterval, ?logExternalState, ?idleDelay)=
             StreamsConsumer.Start<KeyValuePair<string, string>, 'Outcome>(
                 log, config, Bindings.mapConsumeResult, keyValueToStreamEvents, prepare, handle, maxDop, stats,
@@ -310,7 +310,7 @@ module Core =
                 /// often implemented via <c>StreamNameSequenceGenerator.KeyValueToStreamEvent</c>
                 keyValueToStreamEvents : KeyValuePair<string, string> -> Propulsion.Streams.StreamEvent<_> seq,
                 handle : StreamName * Streams.StreamSpan<_> -> Async<int64 * 'Outcome>, maxDop,
-                stats : Streams.Scheduling.StreamSchedulerStats<int64 * EventStats * 'Outcome, EventStats * exn>,
+                stats : Streams.Scheduling.StreamSchedulerStats<EventStats * 'Outcome, EventStats * exn>,
                 ?maximizeOffsetWriting, ?pipelineStatsInterval, ?maxSubmissionsPerPartition, ?pumpInterval, ?logExternalState, ?idleDelay, ?maxBatches) =
             StreamsConsumer.Start<KeyValuePair<string, string>, 'Outcome>(
                 log, config, Bindings.mapConsumeResult, keyValueToStreamEvents, handle, maxDop, stats,
@@ -416,7 +416,7 @@ type StreamsConsumer =
             /// The scheduler guarantees to never schedule two concurrent <c>handler<c> invocations for the same stream.
             maxDop,
             /// The <c>'Outcome</c> from each handler invocation is passed to the Statistics processor by the scheduler for periodic emission
-            stats : Streams.Scheduling.StreamSchedulerStats<int64 *EventStats * 'Outcome, EventStats * exn>,
+            stats : Streams.Scheduling.StreamSchedulerStats<EventStats * 'Outcome, EventStats * exn>,
             /// Prevent batches being consolidated prior to scheduling in order to maximize granularity of consumer offset updates
             ?maximizeOffsetWriting,
             ?pipelineStatsInterval, ?maxSubmissionsPerPartition, ?pumpInterval, ?logExternalState, ?idleDelay, ?maxBatches) =
@@ -451,7 +451,7 @@ type BatchesConsumer =
             ///   new ones that arrived while the handler was processing are then eligible for retry purposes in the next dispatch cycle)
             handle : Streams.Scheduling.DispatchItem<_>[] -> Async<seq<Choice<int64, exn>>>,
             /// The responses from each <c>handle</c> invocation are passed to <c>stats</c> for periodic emission
-            stats : Streams.Scheduling.StreamSchedulerStats<int64 * EventStats * unit, EventStats * exn>,
+            stats : Streams.Scheduling.StreamSchedulerStats<EventStats * unit, EventStats * exn>,
             /// Maximum number of batches to ingest for scheduling at any one time (Default: 24.)
             /// NOTE Stream-wise consumption defaults to taking 5 batches each time replenishment is required
             ?schedulerIngestionBatchCount, ?pipelineStatsInterval, ?maxSubmissionsPerPartition, ?pumpInterval, ?logExternalState, ?idleDelay) =

--- a/src/Propulsion.Kafka/Consumers.fs
+++ b/src/Propulsion.Kafka/Consumers.fs
@@ -252,7 +252,7 @@ module Core =
             let dumpStreams (streams : Streams.Scheduling.StreamStates<_>) log =
                 logExternalState |> Option.iter (fun f -> f log)
                 streams.Dump(log, Streams.Buffering.StreamState.eventsSize)
-            let streamsScheduler = Streams.Scheduling.StreamSchedulingEngine.Create<_, _, _>(dispatcher, stats, prepare, handle, dumpStreams, ?idleDelay=idleDelay, ?maxBatches=maxBatches)
+            let streamsScheduler = Streams.Scheduling.StreamSchedulingEngine.Create<_, _, _, _>(dispatcher, stats, prepare, handle, Streams.SpanResult.toIndex, dumpStreams, ?idleDelay=idleDelay, ?maxBatches=maxBatches)
             let mapConsumedMessagesToStreamsBatch onCompletion (x : Submission.SubmissionBatch<'Info>) : Streams.Scheduling.StreamsBatch<_> =
                 let onCompletion () = x.onCompletion(); onCompletion()
                 Streams.Scheduling.StreamsBatch.Create(onCompletion, Seq.collect infoToStreamEvents x.messages) |> fst
@@ -266,7 +266,7 @@ module Core =
 
         static member Start<'Info, 'Outcome>
             (   log : ILogger, config : KafkaConsumerConfig, consumeResultToInfo, infoToStreamEvents,
-                handle : StreamName * Streams.StreamSpan<_> -> Async<int64 * 'Outcome>, maxDop,
+                handle : StreamName * Streams.StreamSpan<_> -> Async<Streams.SpanResult * 'Outcome>, maxDop,
                 stats : Streams.Scheduling.StreamSchedulerStats<EventStats * 'Outcome, EventStats * exn>,
                 ?pipelineStatsInterval, ?maxSubmissionsPerPartition, ?pumpInterval, ?logExternalState, ?idleDelay, ?maxBatches, ?maximizeOffsetWriting) =
             let prepare (streamName, span) =
@@ -292,7 +292,7 @@ module Core =
             (   log : ILogger, config : KafkaConsumerConfig,
                 /// often implemented via <c>StreamNameSequenceGenerator.KeyValueToStreamEvent</c>
                 keyValueToStreamEvents,
-                prepare, handle : StreamName * Streams.StreamSpan<_> -> Async<int64 * 'Outcome>,
+                prepare, handle : StreamName * Streams.StreamSpan<_> -> Async<Streams.SpanResult * 'Outcome>,
                 maxDop, stats : Streams.Scheduling.StreamSchedulerStats<EventStats * 'Outcome, EventStats * exn>,
                 ?maximizeOffsetWriting, ?pipelineStatsInterval, ?maxSubmissionsPerPartition, ?pumpInterval, ?logExternalState, ?idleDelay)=
             StreamsConsumer.Start<KeyValuePair<string, string>, 'Outcome>(
@@ -309,7 +309,7 @@ module Core =
             (   log : ILogger, config : KafkaConsumerConfig,
                 /// often implemented via <c>StreamNameSequenceGenerator.KeyValueToStreamEvent</c>
                 keyValueToStreamEvents : KeyValuePair<string, string> -> Propulsion.Streams.StreamEvent<_> seq,
-                handle : StreamName * Streams.StreamSpan<_> -> Async<int64 * 'Outcome>, maxDop,
+                handle : StreamName * Streams.StreamSpan<_> -> Async<Streams.SpanResult * 'Outcome>, maxDop,
                 stats : Streams.Scheduling.StreamSchedulerStats<EventStats * 'Outcome, EventStats * exn>,
                 ?maximizeOffsetWriting, ?pipelineStatsInterval, ?maxSubmissionsPerPartition, ?pumpInterval, ?logExternalState, ?idleDelay, ?maxBatches) =
             StreamsConsumer.Start<KeyValuePair<string, string>, 'Outcome>(
@@ -410,7 +410,7 @@ type StreamsConsumer =
             /// - second component: Outcome (can be simply <c>unit</c>), to pass to the <c>stats</c> processor
             /// - throwing marks the processing of a stream as having faulted (the stream's pending events and/or
             ///   new ones that arrived while the handler was processing are then eligible for retry purposes in the next dispatch cycle)
-            handle : StreamName * Streams.StreamSpan<_> -> Async<int64 * 'Outcome>,
+            handle : StreamName * Streams.StreamSpan<_> -> Async<Streams.SpanResult * 'Outcome>,
             /// The maximum number of instances of <c>handle</c> that are permitted to be dispatched at any point in time.
             /// The scheduler seeks to maximise the in-flight <c>handle</c>rs at any point in time.
             /// The scheduler guarantees to never schedule two concurrent <c>handler<c> invocations for the same stream.

--- a/src/Propulsion.Kafka/ProducerSinks.fs
+++ b/src/Propulsion.Kafka/ProducerSinks.fs
@@ -21,7 +21,7 @@ type StreamsProducerSink =
         (   log : ILogger, maxReadAhead, maxConcurrentStreams,
             prepare : StreamName * StreamSpan<_> -> Async<(string*string) option * 'Outcome>,
             producer : Producer,
-            stats : Streams.Sync.StreamsSyncStats<'Outcome>, projectorStatsInterval,
+            stats : Streams.Sync.Stats<'Outcome>, projectorStatsInterval,
             /// Default .5 ms
             ?idleDelay,
             /// Default 1 MiB
@@ -67,7 +67,7 @@ type StreamsProducerSink =
             ?maxCycles)
         : ProjectorPipeline<_> =
             let statsInterval, stateInterval = defaultArg statsInterval (TimeSpan.FromMinutes 5.), defaultArg stateInterval (TimeSpan.FromMinutes 5.)
-            let stats = Streams.Sync.StreamsSyncStats<unit>(log.ForContext<Sync.StreamsSyncStats<unit>>(), statsInterval, stateInterval)
+            let stats = Streams.Sync.Stats<unit>(log.ForContext<Sync.Stats<unit>>(), statsInterval, stateInterval)
             let prepare (stream,span) = async {
                 let! k,v = prepare (stream,span)
                 return Some (k,v), ()

--- a/src/Propulsion/Streams.fs
+++ b/src/Propulsion/Streams.fs
@@ -830,14 +830,15 @@ module Projector =
             let startIngester (rangeLog, projectionId) = StreamsIngester.Start(rangeLog, projectionId, maxReadAhead, submitter.Ingest, ?statsInterval = ingesterStatsInterval)
             ProjectorPipeline.Start(log, pumpDispatcher, pumpScheduler, submitter.Pump(), startIngester)
 
-/// Represents progress handler made during the processing of the current span of events for a stream
-/// This will be reflected, where appropriate, by adjustments to the write position for the stream
+/// Represents progress attained during the processing of the supplied <c>StreamSpan</c> for a given <c>StreamName</c>.
+/// This will be reflected in adjustments to the Write Position for the stream.
+/// Incoming <c>StreamEvents</c> with <c>Index</c>es prior to the active Write Position are proactively dropped from incoming buffers.
 type SpanResult =
-   /// Signifies all events in span have been processed, and write position should move to beyond that of the last event
+   /// Indicates all events supplied in the <c>StreamSpan</c> have been processed; Write Position should move one beyond that of the last event.
    | AllProcessed
-   /// Indicates only a subset of the presented events have been processed
+   /// Indicates only a subset of the presented events have been processed; Write Position should move one beyond the <c>Index</c> of Item <c>count</c> of the <c>StreamSpan</c>.
    | PartiallyProcessed of count : int
-   /// Override the write position based on version discovered during processing (e.g., if downstream is ahead of current projection position)
+   /// Apply an externally derived Write Position determined by the handler during processing (e.g., if downstream is running ahead of current inputs)
    | OverrideWritePosition of index : int64
 
 module SpanResult =

--- a/src/Propulsion/Streams.fs
+++ b/src/Propulsion/Streams.fs
@@ -448,7 +448,7 @@ module Scheduling =
 
     /// Coordinates the dispatching of work and emission of results, subject to the maxDop concurrent processors constraint
     type private DopDispatcher<'R>(maxDop) =
-        // Using a Queue as a) the ordering is more correct, favoring more important work b) we are adding from many threads so no value in ConcurrentBag'sthread-affinity
+        // Using a Queue as a) the ordering is more correct, favoring more important work b) we are adding from many threads so no value in ConcurrentBag's thread-affinity
         let work = new BlockingCollection<_>(ConcurrentQueue<_>())
         let result = Event<TimeSpan * 'R>()
         let dop = Sem maxDop
@@ -606,7 +606,7 @@ module Scheduling =
         (   dispatcher : IDispatcher<'P, 'R, 'E>,
             /// Tune number of batches to ingest at a time. Default 5.
             ?maxBatches,
-            /// Tune the max number of check/dispatch cyles. Default 16.
+            /// Tune the max number of check/dispatch cycles. Default 16.
             ?maxCycles,
             /// Tune the sleep time when there are no items to schedule or responses to process. Default 2ms.
             ?idleDelay,
@@ -841,6 +841,7 @@ type SpanResult =
    | OverrideWritePosition of index : int64
 
 module SpanResult =
+
     let toIndex (_sn, span : StreamSpan<byte[]>) = function
         | AllProcessed -> span.index + span.events.LongLength
         | PartiallyProcessed count -> span.index + int64 count

--- a/tests/Propulsion.Kafka.Integration/ConsumersIntegration.fs
+++ b/tests/Propulsion.Kafka.Integration/ConsumersIntegration.fs
@@ -189,7 +189,7 @@ module Helpers =
             let handle (streamName : StreamName, span : Propulsion.Streams.StreamSpan<byte[]>) = async {
                 for event in span.events do
                     do! handler (getConsumer()) (deserialize consumerId event)
-                return span.index + span.events.LongLength, () }
+                return Propulsion.Streams.SpanResult.AllProcessed, () }
             let stats = Propulsion.Streams.Scheduling.StreamSchedulerStats(log, TimeSpan.FromSeconds 5.,TimeSpan.FromSeconds 5.)
             let messageIndexes = StreamNameSequenceGenerator()
             let consumer =


### PR DESCRIPTION
resolves #58:
- Simplifies many messy type signatures, particularly wrt egregious inclusion of the Write Position alongside the `'Outcome` presented to Stats handlers (this removes a lot of inconsistency in consumer code when one adjusts the overall Projector Configuration)
- replaces direct usage of an `int64` Write Position in the Handler signature with an explicit `SpanResult`:
> ```fsharp
> /// Represents progress attained during the processing of the supplied <c>StreamSpan</c> for a given <c>StreamName</c>.
> /// This will be reflected in adjustments to the Write Position for the stream.
> /// Incoming <c>StreamEvents</c> with <c>Index</c>es prior to the active Write Position are proactively dropped from incoming buffers.
> type SpanResult =
>    /// Indicates all events supplied in the <c>StreamSpan</c> have been processed; Write Position should move one beyond that of the last event.
>    | AllProcessed
>    /// Indicates only a subset of the presented events have been processed; Write Position should move one beyond the <c>Index</c> of Item <c>count</c> of the <c>StreamSpan</c>.
>    | PartiallyProcessed of count : int
>    /// Apply an externally derived Write Position determined by the handler during processing (e.g., if downstream is running ahead of current inputs)
>    | OverrideWritePosition of index : int64
> ```