### PR TITLE
Surface exceptions to incite logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 ### Changed
+
+- Added abstract `HandleExn` method to `type Stats`; removed defaulting of `stats` arguments in almost all cases [#60](https://github.com/jet/propulsion/pull/60)
+
 ### Removed
 ### Fixed
 
@@ -18,12 +21,12 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 
-- BREAKING: Revised `handle` function signatures in `Propulsion.Kafka.StreamsConsumer` and `Propulsion.Streams.StreamsProjector` to include a `Propulsion.Streams.SpanResult` representing Write Position updates [#65](https://github.com/jet/propulsion/pull/65)
+- BREAKING: Revised `handle` function signatures in `Propulsion.Kafka.StreamsConsumer` and `Propulsion.Streams.StreamsProjector` to include a `Propulsion.Streams.SpanResult` representing Write Position updates [#59](https://github.com/jet/propulsion/pull/59)
 
 ### Changed
 
-- Removed egregious `int64` from stats handler signatures in `Propulsion.Streams.Scheduling.StreamSchedulerStats` and `Projector.Stats` [#65](https://github.com/jet/propulsion/pull/65)
-- Renamed `Streams.Sync.StreamsSyncStats` and `Streams.Scheduling.StreamSchedulerStats` to `Stats` for consistency [#65](https://github.com/jet/propulsion/pull/65)
+- Removed egregious `int64` from stats handler signatures in `Propulsion.Streams.Scheduling.StreamSchedulerStats` and `Projector.Stats` [#59](https://github.com/jet/propulsion/pull/59)
+- Renamed `Streams.Sync.StreamsSyncStats` and `Streams.Scheduling.StreamSchedulerStats` to `Stats` for consistency [#59](https://github.com/jet/propulsion/pull/59)
 
 <a name="2.3.0"></a>
 ## [2.3.0] - 2019-04-22

--- a/src/Propulsion.Cosmos/CosmosSink.fs
+++ b/src/Propulsion.Cosmos/CosmosSink.fs
@@ -34,16 +34,16 @@ module Internal =
                 log.Information("Ignored   {stream} (synced up to {pos})", stream, updatedPos)
             | stream, (Choice1Of2 (_, PartialDuplicate overage)) ->
                 log.Information("Requeing  {stream} {pos} ({count} events)", stream, overage.index, overage.events.Length)
-            | stream, (Choice1Of2 (_, PrefixMissing (batch,pos))) ->
+            | stream, (Choice1Of2 (_, PrefixMissing (batch, pos))) ->
                 log.Information("Waiting   {stream} missing {gap} events ({count} events @ {pos})", stream, batch.index-pos, batch.events.Length, batch.index)
             | stream, (Choice2Of2 (_, exn)) ->
-                log.Warning(exn,"Writing   {stream} failed, retrying", stream)
+                log.Warning(exn, "Writing   {stream} failed, retrying", stream)
 
         let write (log : ILogger) (ctx : Context) stream span = async {
             let stream = ctx.CreateStream stream
-            log.Debug("Writing {s}@{i}x{n}",stream,span.index,span.events.Length)
+            log.Debug("Writing {s}@{i}x{n}", stream, span.index, span.events.Length)
             let! res = ctx.Sync(stream, { index = span.index; etag = None }, span.events |> Array.map (fun x -> x :> _))
-            let ress =
+            let res' =
                 match res with
                 | AppendResult.Ok pos -> Ok pos.index
                 | AppendResult.Conflict (pos, _) | AppendResult.ConflictUnknown pos ->
@@ -55,8 +55,8 @@ module Internal =
 #else
                     | actual -> PartialDuplicate { index = actual; events = span.events |> Array.skip (actual-span.index |> int) }
 #endif
-            log.Debug("Result: {res}",ress)
-            return ress }
+            log.Debug("Result: {res}", res')
+            return res' }
         let (|TimedOutMessage|RateLimitedMessage|TooLargeMessage|MalformedMessage|Other|) (e : exn) =
             let isMalformed () =
                 let m = string e
@@ -108,7 +108,7 @@ module Internal =
             base.Handle message
             match message with
             | Scheduling.InternalMessage.Added _ -> () // Processed by standard logging already; we have nothing to add
-            | Scheduling.InternalMessage.Result (_duration, (stream, Choice1Of2 ((es,bs),res))) ->
+            | Scheduling.InternalMessage.Result (_duration, (stream, Choice1Of2 ((es, bs), res))) ->
                 adds stream okStreams
                 okEvents <- okEvents + es
                 okBytes <- okBytes + int64 bs
@@ -118,7 +118,7 @@ module Internal =
                 | Writer.Result.PartialDuplicate _ -> incr resultPartialDup
                 | Writer.Result.PrefixMissing _ -> incr resultPrefix
                 __.HandleOk res
-            | Scheduling.InternalMessage.Result (_duration, (stream, Choice2Of2 ((es,bs),exn))) ->
+            | Scheduling.InternalMessage.Result (_duration, (stream, Choice2Of2 ((es, bs), exn))) ->
                 adds stream failStreams
                 exnEvents <- exnEvents + es
                 exnBytes <- exnBytes + int64 bs
@@ -144,24 +144,24 @@ module Internal =
                 let index = Interlocked.Increment(&robin) % cosmosContexts.Length
                 let selectedConnection = cosmosContexts.[index]
                 let maxEvents, maxBytes = 16384, 1024 * 1024 - (*fudge*)4096
-                let stats,span = Buffering.StreamSpan.slice (maxEvents,maxBytes) item.span
+                let stats, span = Buffering.StreamSpan.slice (maxEvents, maxBytes) item.span
                 try let! res = Writer.write log selectedConnection (StreamName.toString item.stream) span
-                    return Choice1Of2 (stats,res)
-                with e -> return Choice2Of2 (stats,e) }
+                    return Choice1Of2 (stats, res)
+                with e -> return Choice2Of2 (stats, e) }
             let interpretWriteResultProgress (streams: Scheduling.StreamStates<_>) stream res =
                 let applyResultToStreamState = function
                     | Choice1Of2 (_stats, Writer.Ok pos) ->                       streams.InternalUpdate stream pos null
                     | Choice1Of2 (_stats, Writer.Duplicate pos) ->                streams.InternalUpdate stream pos null
                     | Choice1Of2 (_stats, Writer.PartialDuplicate overage) ->     streams.InternalUpdate stream overage.index [|overage|]
-                    | Choice1Of2 (_stats, Writer.PrefixMissing (overage,pos)) ->  streams.InternalUpdate stream pos [|overage|]
+                    | Choice1Of2 (_stats, Writer.PrefixMissing (overage, pos)) ->  streams.InternalUpdate stream pos [|overage|]
                     | Choice2Of2 (_stats, exn) ->
                         let malformed = Writer.classify exn |> Writer.isMalformed
-                        streams.SetMalformed(stream,malformed)
+                        streams.SetMalformed(stream, malformed)
                 let _stream, ss = applyResultToStreamState res
-                Writer.logTo writerResultLog (stream,res)
+                Writer.logTo writerResultLog (stream, res)
                 ss.write, res
             let dispatcher = Scheduling.MultiDispatcher<_, _, _>(itemDispatcher, attemptWrite, interpretWriteResultProgress, stats, dumpStreams)
-            Scheduling.StreamSchedulingEngine(dispatcher, enableSlipstreaming=true, ?maxBatches = maxBatches)
+            Scheduling.StreamSchedulingEngine(dispatcher, enableSlipstreaming = true, ?maxBatches = maxBatches)
 
 type CosmosSink =
 

--- a/src/Propulsion.Kafka/Consumers.fs
+++ b/src/Propulsion.Kafka/Consumers.fs
@@ -187,7 +187,7 @@ type ParallelConsumer private () =
         let pumpInterval = defaultArg pumpInterval (TimeSpan.FromMilliseconds 5.)
 
         let dispatcher = Parallel.Scheduling.Dispatcher maxDop
-        let scheduler = Parallel.Scheduling.PartitionedSchedulingEngine<'Msg>(log, handle, dispatcher.TryAdd, statsInterval, ?logExternalStats=logExternalStats)
+        let scheduler = Parallel.Scheduling.PartitionedSchedulingEngine<'Msg>(log, handle, dispatcher.TryAdd, statsInterval, ?logExternalStats = logExternalStats)
         let maxSubmissionsPerPartition = defaultArg maxSubmissionsPerPartition 5
         let mapBatch onCompletion (x : Submission.SubmissionBatch<_>) : Parallel.Scheduling.Batch<'Msg> =
             let onCompletion' () = x.onCompletion(); onCompletion()

--- a/src/Propulsion.Kafka/Consumers.fs
+++ b/src/Propulsion.Kafka/Consumers.fs
@@ -204,7 +204,7 @@ type ParallelConsumer private () =
         (   log : ILogger, config : KafkaConsumerConfig, maxDop, handle : KeyValuePair<string, string> -> Async<unit>,
             ?maxSubmissionsPerPartition, ?pumpInterval, ?statsInterval, ?logExternalStats) =
         ParallelConsumer.Start<KeyValuePair<string, string>>(log, config, maxDop, Bindings.mapConsumeResult, handle >> Async.Catch,
-            ?maxSubmissionsPerPartition=maxSubmissionsPerPartition, ?pumpInterval=pumpInterval, ?statsInterval=statsInterval, ?logExternalStats=logExternalStats)
+            ?maxSubmissionsPerPartition=maxSubmissionsPerPartition, ?pumpInterval = pumpInterval, ?statsInterval = statsInterval, ?logExternalStats=logExternalStats)
 
 type EventMetrics = Streams.EventMetrics
 
@@ -230,12 +230,14 @@ type StreamsConsumerStats<'Outcome>(log : ILogger, statsInterval, stateInterval)
             okEvents <- okEvents + es
             okBytes <- okBytes + int64 bs
             __.HandleOk res
-        | Propulsion.Streams.Scheduling.InternalMessage.Result (_duration, (stream, Choice2Of2 ((es, bs), _exn))) ->
+        | Propulsion.Streams.Scheduling.InternalMessage.Result (_duration, (stream, Choice2Of2 ((es, bs), exn))) ->
             adds stream failStreams
             exnEvents <- exnEvents + es
             exnBytes <- exnBytes + int64 bs
+            __.HandleExn exn
 
     abstract member HandleOk : outcome : 'Outcome -> unit
+    abstract member HandleExn : exn : exn -> unit
 
 /// APIs only required for advanced scenarios (specifically the integration tests)
 /// APIs within are not part of the stable API and are subject to unlimited change

--- a/src/Propulsion.Kafka/ProducerSinks.fs
+++ b/src/Propulsion.Kafka/ProducerSinks.fs
@@ -13,7 +13,7 @@ type ParallelProducerSink =
         let handle item = async {
             let key, value = render item
             do! producer.Produce (key, value) }
-        Parallel.ParallelProjector.Start(Log.Logger, maxReadAhead, maxDop, handle >> Async.Catch, statsInterval=statsInterval, logExternalStats = producer.DumpStats)
+        Parallel.ParallelProjector.Start(Log.Logger, maxReadAhead, maxDop, handle >> Async.Catch, statsInterval = statsInterval, logExternalStats = producer.DumpStats)
 
 type StreamsProducerSink =
 
@@ -49,8 +49,8 @@ type StreamsProducerSink =
             }
             Sync.StreamsSync.Start
                 (    log, maxReadAhead, maxConcurrentStreams, handle, stats, ?statsInterval = statsInterval,
-                     maxBytes=maxBytes, ?idleDelay=idleDelay,
-                     ?maxEvents=maxEvents, ?maxBatches=maxBatches, ?maxCycles=maxCycles, dumpExternalStats=producer.DumpStats)
+                     maxBytes = maxBytes, ?idleDelay = idleDelay,
+                     ?maxEvents = maxEvents, ?maxBatches = maxBatches, ?maxCycles = maxCycles, dumpExternalStats = producer.DumpStats)
 
    static member Start
         (   log : ILogger, maxReadAhead, maxConcurrentStreams,
@@ -70,12 +70,12 @@ type StreamsProducerSink =
             /// Max inner cycles per loop. Default 128.
             ?maxCycles)
         : ProjectorPipeline<_> =
-            let prepare (stream,span) = async {
-                let! k,v = prepare (stream,span)
-                return Some (k,v), ()
+            let prepare (stream, span) = async {
+                let! k, v = prepare (stream, span)
+                return Some (k, v), ()
             }
             StreamsProducerSink.Start
                 (    log, maxReadAhead, maxConcurrentStreams,
                      prepare, producer, stats, ?statsInterval = statsInterval,
-                     ?idleDelay=idleDelay, ?maxBytes = maxBytes,
-                     ?maxEvents=maxEvents, ?maxBatches=maxBatches, ?maxCycles=maxCycles)
+                     ?idleDelay = idleDelay, ?maxBytes = maxBytes,
+                     ?maxEvents = maxEvents, ?maxBatches = maxBatches, ?maxCycles = maxCycles)

--- a/src/Propulsion.Kafka/ProducerSinks.fs
+++ b/src/Propulsion.Kafka/ProducerSinks.fs
@@ -21,7 +21,9 @@ type StreamsProducerSink =
         (   log : ILogger, maxReadAhead, maxConcurrentStreams,
             prepare : StreamName * StreamSpan<_> -> Async<(string*string) option * 'Outcome>,
             producer : Producer,
-            stats : Streams.Sync.Stats<'Outcome>, projectorStatsInterval,
+            stats : Streams.Sync.Stats<'Outcome>,
+            /// Default 5m
+            ?statsInterval,
             /// Default .5 ms
             ?idleDelay,
             /// Default 1 MiB
@@ -46,7 +48,7 @@ type StreamsProducerSink =
                 return span.index + span.events.LongLength, outcome
             }
             Sync.StreamsSync.Start
-                (    log, maxReadAhead, maxConcurrentStreams, handle, stats, projectorStatsInterval = projectorStatsInterval,
+                (    log, maxReadAhead, maxConcurrentStreams, handle, stats, ?statsInterval = statsInterval,
                      maxBytes=maxBytes, ?idleDelay=idleDelay,
                      ?maxEvents=maxEvents, ?maxBatches=maxBatches, ?maxCycles=maxCycles, dumpExternalStats=producer.DumpStats)
 
@@ -54,7 +56,9 @@ type StreamsProducerSink =
         (   log : ILogger, maxReadAhead, maxConcurrentStreams,
             prepare : StreamName * StreamSpan<_> -> Async<string*string>,
             producer : Producer,
-            ?statsInterval, ?stateInterval,
+            stats : Streams.Sync.Stats<unit>,
+            /// Default 5m
+            ?statsInterval,
             /// Default .5 ms
             ?idleDelay,
             /// Default 1 MiB
@@ -66,14 +70,12 @@ type StreamsProducerSink =
             /// Max inner cycles per loop. Default 128.
             ?maxCycles)
         : ProjectorPipeline<_> =
-            let statsInterval, stateInterval = defaultArg statsInterval (TimeSpan.FromMinutes 5.), defaultArg stateInterval (TimeSpan.FromMinutes 5.)
-            let stats = Streams.Sync.Stats<unit>(log.ForContext<Sync.Stats<unit>>(), statsInterval, stateInterval)
             let prepare (stream,span) = async {
                 let! k,v = prepare (stream,span)
                 return Some (k,v), ()
             }
             StreamsProducerSink.Start
                 (    log, maxReadAhead, maxConcurrentStreams,
-                     prepare, producer, stats, projectorStatsInterval = statsInterval,
+                     prepare, producer, stats, ?statsInterval = statsInterval,
                      ?idleDelay=idleDelay, ?maxBytes = maxBytes,
                      ?maxEvents=maxEvents, ?maxBatches=maxBatches, ?maxCycles=maxCycles)

--- a/src/Propulsion/Streams.fs
+++ b/src/Propulsion/Streams.fs
@@ -23,7 +23,7 @@ module Internal =
     type CatStats() =
         let cats = Dictionary<string, int64>()
 
-        member __.Ingest(cat,?weight) =
+        member __.Ingest(cat, ?weight) =
             let weight = defaultArg weight 1L
             match cats.TryGetValue cat with
             | true, catCount -> cats.[cat] <- catCount + weight
@@ -87,7 +87,7 @@ open Internal
 [<AutoOpen>]
 module private Impl =
 
-    let (|NNA|) xs = if obj.ReferenceEquals(null,xs) then Array.empty else xs
+    let (|NNA|) xs = if obj.ReferenceEquals(null, xs) then Array.empty else xs
     let inline arrayBytes (x : _ []) = if obj.ReferenceEquals(null, x) then 0 else x.Length
     let inline stringBytes (x : string) = match x with null -> 0 | x -> x.Length * sizeof<char>
     let inline eventSize (x : FsCodec.IEventData<byte[]>) = arrayBytes x.Data + arrayBytes x.Meta + stringBytes x.EventType + 16
@@ -130,7 +130,7 @@ module Progress =
                 let batch = pending.Dequeue()
                 batch.markCompleted()
 
-        member __.AppendBatch(markCompleted, reqs : Dictionary<StreamName,int64>) =
+        member __.AppendBatch(markCompleted, reqs : Dictionary<StreamName, int64>) =
             pending.Enqueue { markCompleted = markCompleted; streamToRequiredIndex = reqs }
             trim ()
 
@@ -804,8 +804,8 @@ module Projector =
                 let items = Array.ofSeq items
                 let streams = HashSet(seq { for x in items -> x.stream })
                 let batch : Submission.SubmissionBatch<_> = { partitionId = partitionId; onCompletion = onCompletion; messages = items }
-                batch,(streams.Count,items.Length)
-            Ingestion.Ingester<StreamEvent<_> seq,Submission.SubmissionBatch<StreamEvent<_>>>.Start(log, maxRead, makeBatch, submit, ?statsInterval = statsInterval, ?sleepInterval = sleepInterval)
+                batch, (streams.Count, items.Length)
+            Ingestion.Ingester<StreamEvent<_> seq, Submission.SubmissionBatch<StreamEvent<_>>>.Start(log, maxRead, makeBatch, submit, ?statsInterval = statsInterval, ?sleepInterval = sleepInterval)
 
     type StreamsSubmitter =
         static member Create(log : Serilog.ILogger, mapBatch, submitStreamsBatch, statsInterval, ?maxSubmissionsPerPartition, ?pumpInterval, ?disableCompaction) =
@@ -958,8 +958,8 @@ module Sync =
                 with e -> return Choice2Of2 ((eventCount, bytesCount), e) }
 
             let interpretWriteResultProgress _streams (stream : StreamName) = function
-                | Choice1Of2 (i', stats, r) ->
-                    Some i', Choice1Of2 (stats, r)
+                | Choice1Of2 (i', stats, outcome) ->
+                    Some i', Choice1Of2 (stats, outcome)
                 | Choice2Of2 (((eventCount, bytesCount) as stats), exn : exn) ->
                     log.Warning(exn, "Handling {events:n0}e {bytes:n0}b for {stream} failed, retrying", eventCount, bytesCount, stream)
                     None, Choice2Of2 (stats, exn)

--- a/tests/Propulsion.Tests/StreamStateTests.fs
+++ b/tests/Propulsion.Tests/StreamStateTests.fs
@@ -9,19 +9,19 @@ let canonicalTime = System.DateTimeOffset.UtcNow
 
 let mk p c : StreamSpan<string> =
     {   index = p
-        events = [| for x in 0..c-1 -> FsCodec.Core.TimelineEvent.Create(int64 x,p + int64 x |> string, null, timestamp=canonicalTime) |] }
+        events = [| for x in 0..c-1 -> FsCodec.Core.TimelineEvent.Create(int64 x, p + int64 x |> string, null, timestamp = canonicalTime) |] }
 let mergeSpans = StreamSpan.merge
 let trimSpans = StreamSpan.dropBeforeIndex
 let is (xs : StreamSpan<string>[]) (res : StreamSpan<string>[]) =
-    (xs,res) ||> Seq.forall2 (fun x y -> x.index = y.index && (x.events,y.events) ||> Seq.forall2 (fun x y -> x.EventType = y.EventType))
+    (xs, res) ||> Seq.forall2 (fun x y -> x.index = y.index && (x.events, y.events) ||> Seq.forall2 (fun x y -> x.EventType = y.EventType))
 
 let [<Fact>] ``nothing`` () =
     let r = mergeSpans 0L [ mk 0L 0; mk 0L 0 ]
-    test <@ obj.ReferenceEquals(null,r) @>
+    test <@ obj.ReferenceEquals(null, r) @>
 
 let [<Fact>] ``synced`` () =
     let r = mergeSpans 1L [ mk 0L 1; mk 0L 0 ]
-    test <@ obj.ReferenceEquals(null,r) @>
+    test <@ obj.ReferenceEquals(null, r) @>
 
 let [<Fact>] ``no overlap`` () =
     let r = mergeSpans 0L [ mk 0L 1; mk 2L 2 ]


### PR DESCRIPTION
In lieu of doing lots of logging in https://github.com/jet/dotnet-templates/pull/65, this adds an `abstract HandleExn` method to the `Stats` type, and removes defaulting in order to force the consideration of how to manifest contextual information about error rates out to the caller/host