### PR TITLE
Make Scheduling.Stats abstract; stats consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 ### Changed
+
+- Mark `Scheduler.Stats` abstract, reorder/name `statsInterval` arguments [#61](https://github.com/jet/propulsion/pull/61)
+
 ### Removed
 ### Fixed
 

--- a/src/Propulsion.EventStore/EventStoreReader.fs
+++ b/src/Propulsion.EventStore/EventStoreReader.fs
@@ -203,7 +203,7 @@ type Res =
 type EventStoreReader(conns : _ [], defaultBatchSize, minBatchSize, tryMapEvent, post : Res -> Async<int * int>, tailInterval, dop, ?statsInterval) =
     let work = System.Collections.Concurrent.ConcurrentQueue()
     let sleepIntervalMs = 100
-    let overallStats = OverallStats(?statsInterval = statsInterval)
+    let overallStats = OverallStats(?statsInterval=statsInterval)
     let slicesStats = SliceStatsBuffer()
 
     /// Invoked by pump to process a tranche of work; can have parallel invocations

--- a/src/Propulsion.Kafka/Consumers.fs
+++ b/src/Propulsion.Kafka/Consumers.fs
@@ -278,11 +278,11 @@ module Core =
                 log, config, consumeResultToInfo, infoToStreamEvents, prepare, handle, maxDop,
                 stats, statsInterval,
                 ?maxSubmissionsPerPartition = maxSubmissionsPerPartition,
-                ?pumpInterval = pumpInterval,
-                ?logExternalState = logExternalState,
-                ?idleDelay = idleDelay,
-                ?maxBatches = maxBatches,
-                ?maximizeOffsetWriting = maximizeOffsetWriting)
+                ?pumpInterval=pumpInterval,
+                ?logExternalState=logExternalState,
+                ?idleDelay=idleDelay,
+                ?maxBatches=maxBatches,
+                ?maximizeOffsetWriting=maximizeOffsetWriting)
 
         (* KeyValuePair optimized mappings (these were the original implementation); retained as:
             - the default mapping overloads in Propulsion.Kafka.StreamsConsumer pass the ConsumeResult to parser functions,
@@ -426,12 +426,12 @@ type StreamsConsumer =
         Core.StreamsConsumer.Start<ConsumeResult<_, _>, 'Outcome>(
             log, config, id, consumeResultToStreamEvents, handle, maxDop,
             stats, statsInterval,
-            ?maxSubmissionsPerPartition = maxSubmissionsPerPartition,
-            ?pumpInterval = pumpInterval,
-            ?logExternalState = logExternalState,
-            ?idleDelay = idleDelay,
-            ?maxBatches = maxBatches,
-            ?maximizeOffsetWriting = maximizeOffsetWriting)
+            ?maxSubmissionsPerPartition=maxSubmissionsPerPartition,
+            ?pumpInterval=pumpInterval,
+            ?logExternalState=logExternalState,
+            ?idleDelay=idleDelay,
+            ?maxBatches=maxBatches,
+            ?maximizeOffsetWriting=maximizeOffsetWriting)
 
 type BatchesConsumer =
 

--- a/src/Propulsion.Kafka/Consumers.fs
+++ b/src/Propulsion.Kafka/Consumers.fs
@@ -277,7 +277,7 @@ module Core =
             StreamsConsumer.Start<'Info, 'Outcome>(
                 log, config, consumeResultToInfo, infoToStreamEvents, prepare, handle, maxDop,
                 stats, statsInterval,
-                ?maxSubmissionsPerPartition = maxSubmissionsPerPartition,
+                ?maxSubmissionsPerPartition=maxSubmissionsPerPartition,
                 ?pumpInterval=pumpInterval,
                 ?logExternalState=logExternalState,
                 ?idleDelay=idleDelay,

--- a/src/Propulsion.Kafka/ProducerSinks.fs
+++ b/src/Propulsion.Kafka/ProducerSinks.fs
@@ -21,9 +21,7 @@ type StreamsProducerSink =
         (   log : ILogger, maxReadAhead, maxConcurrentStreams,
             prepare : StreamName * StreamSpan<_> -> Async<(string*string) option * 'Outcome>,
             producer : Producer,
-            stats : Streams.Sync.Stats<'Outcome>,
-            /// Default 5m
-            ?statsInterval,
+            stats : Streams.Sync.Stats<'Outcome>, statsInterval,
             /// Default .5 ms
             ?idleDelay,
             /// Default 1 MiB
@@ -48,7 +46,8 @@ type StreamsProducerSink =
                 return span.index + span.events.LongLength, outcome
             }
             Sync.StreamsSync.Start
-                (    log, maxReadAhead, maxConcurrentStreams, handle, stats, ?statsInterval=statsInterval,
+                (    log, maxReadAhead, maxConcurrentStreams, handle,
+                     stats, statsInterval=statsInterval,
                      maxBytes=maxBytes, ?idleDelay=idleDelay,
                      ?maxEvents=maxEvents, ?maxBatches=maxBatches, ?maxCycles=maxCycles, dumpExternalStats=producer.DumpStats)
 
@@ -56,9 +55,7 @@ type StreamsProducerSink =
         (   log : ILogger, maxReadAhead, maxConcurrentStreams,
             prepare : StreamName * StreamSpan<_> -> Async<string*string>,
             producer : Producer,
-            stats : Streams.Sync.Stats<unit>,
-            /// Default 5m
-            ?statsInterval,
+            stats : Streams.Sync.Stats<unit>, statsInterval,
             /// Default .5 ms
             ?idleDelay,
             /// Default 1 MiB
@@ -75,7 +72,7 @@ type StreamsProducerSink =
                 return Some (k, v), ()
             }
             StreamsProducerSink.Start
-                (    log, maxReadAhead, maxConcurrentStreams,
-                     prepare, producer, stats, ?statsInterval=statsInterval,
+                (    log, maxReadAhead, maxConcurrentStreams, prepare, producer,
+                     stats, statsInterval,
                      ?idleDelay=idleDelay, ?maxBytes=maxBytes,
                      ?maxEvents=maxEvents, ?maxBatches=maxBatches, ?maxCycles=maxCycles)

--- a/src/Propulsion/Streams.fs
+++ b/src/Propulsion/Streams.fs
@@ -806,7 +806,7 @@ module Projector =
                 let streams = HashSet(seq { for x in items -> x.stream })
                 let batch : Submission.SubmissionBatch<_> = { partitionId = partitionId; onCompletion = onCompletion; messages = items }
                 batch, (streams.Count, items.Length)
-            Ingestion.Ingester<StreamEvent<_> seq, Submission.SubmissionBatch<StreamEvent<_>>>.Start(log, maxRead, makeBatch, submit, ?statsInterval = statsInterval, ?sleepInterval = sleepInterval)
+            Ingestion.Ingester<StreamEvent<_> seq, Submission.SubmissionBatch<StreamEvent<_>>>.Start(log, maxRead, makeBatch, submit, ?statsInterval=statsInterval, ?sleepInterval=sleepInterval)
 
     type StreamsSubmitter =
         static member Create
@@ -834,7 +834,7 @@ module Projector =
                 let onCompletion () = x.onCompletion(); onCompletion()
                 Scheduling.StreamsBatch.Create(onCompletion, x.messages) |> fst
             let submitter = StreamsSubmitter.Create(log, mapBatch, submitStreamsBatch, statsInterval, ?maxSubmissionsPerPartition=maxSubmissionsPerPartition)
-            let startIngester (rangeLog, projectionId) = StreamsIngester.Start(rangeLog, projectionId, maxReadAhead, submitter.Ingest, ?statsInterval = ingesterStatsInterval)
+            let startIngester (rangeLog, projectionId) = StreamsIngester.Start(rangeLog, projectionId, maxReadAhead, submitter.Ingest, ?statsInterval=ingesterStatsInterval)
             ProjectorPipeline.Start(log, pumpDispatcher, pumpScheduler, submitter.Pump(), startIngester)
 
 /// Represents progress attained during the processing of the supplied <c>StreamSpan</c> for a given <c>StreamName</c>.

--- a/src/Propulsion/Streams.fs
+++ b/src/Propulsion/Streams.fs
@@ -752,11 +752,11 @@ module Scheduling =
                 | Choice2Of2 (stats, exn) -> None, Choice2Of2 (stats, exn)
 
             let dispatcher = MultiDispatcher<int64 * 'Metrics * 'Outcome, 'Metrics * 'Outcome, 'Metrics * exn>(itemDispatcher, project, interpretProgress, stats, dumpStreams)
-            StreamSchedulingEngine<_, _, _>(dispatcher, ?maxBatches = maxBatches, ?idleDelay = idleDelay, ?enableSlipstreaming = enableSlipstreaming)
+            StreamSchedulingEngine<_, _, _>(dispatcher, ?maxBatches=maxBatches, ?idleDelay=idleDelay, ?enableSlipstreaming=enableSlipstreaming)
 
         static member Create(dispatcher, ?maxBatches, ?idleDelay, ?enableSlipstreaming)
             : StreamSchedulingEngine<int64 * ('Metrics * unit), 'Stats * unit, 'Stats * exn> =
-            StreamSchedulingEngine<_, _, _>(dispatcher, ?maxBatches = maxBatches, ?idleDelay = idleDelay, ?enableSlipstreaming = enableSlipstreaming)
+            StreamSchedulingEngine<_, _, _>(dispatcher, ?maxBatches=maxBatches, ?idleDelay=idleDelay, ?enableSlipstreaming=enableSlipstreaming)
 
 module Projector =
 

--- a/src/Propulsion/Streams.fs
+++ b/src/Propulsion/Streams.fs
@@ -392,6 +392,7 @@ module Scheduling =
     type BufferState = Idle | Busy | Full | Slipstreaming
 
     /// Gathers stats pertaining to the core projection/ingestion activity
+    [<AbstractClass>]
     type Stats<'R, 'E>(log : ILogger, statsInterval : TimeSpan, stateInterval : TimeSpan) =
         let cycles, fullCycles, states, oks, exns = ref 0, ref 0, CatStats(), LatencyStats("ok"), LatencyStats("exceptions")
         let batchesPended, streamsPended, eventsSkipped, eventsPended = ref 0, ref 0, ref 0, ref 0
@@ -933,9 +934,7 @@ module Sync =
         static member Start
             (   log : ILogger, maxReadAhead, maxConcurrentStreams,
                 handle : StreamName * StreamSpan<_> -> Async<int64 * 'Outcome>,
-                stats : Stats<'Outcome>,
-                /// Default 5m
-                ?statsInterval,
+                stats : Stats<'Outcome>, statsInterval,
                 /// Default .5 ms
                 ?idleDelay,
                 /// Default 1 MiB
@@ -949,7 +948,6 @@ module Sync =
                 /// Hook to wire in external stats
                 ?dumpExternalStats)
             : ProjectorPipeline<_> =
-            let statsInterval = defaultArg statsInterval (TimeSpan.FromMinutes 5.)
 
             let maxBatches, maxEvents, maxBytes = defaultArg maxBatches 128, defaultArg maxEvents 16384, (defaultArg maxBytes (1024 * 1024 - (*fudge*)4096))
 

--- a/tests/Propulsion.Kafka.Integration/ConsumersIntegration.fs
+++ b/tests/Propulsion.Kafka.Integration/ConsumersIntegration.fs
@@ -202,7 +202,7 @@ module Helpers =
                  StreamsConsumer.Start<unit>
                     (   log, config, messageIndexes.ConsumeResultToStreamEvent(mapStreamConsumeResultToDataAndContext),
                         handle, 256, stats, TimeSpan.FromSeconds 10.,
-                        maxBatches = 50)
+                        maxBatches=50)
 
             consumerCell := Some consumer
 

--- a/tools/Propulsion.Tool/Program.fs
+++ b/tools/Propulsion.Tool/Program.fs
@@ -237,9 +237,9 @@ let main argv =
                     ChangeFeedProcessor.Start
                       ( log, connector.CreateClient(appName,discovery), source, aux, buildRangeProjector,
                         leasePrefix = leaseId,
-                        startFromTail = pargs.Contains FromTail,
-                        ?maxDocuments = pargs.TryGetResult MaxDocuments,
-                        ?reportLagAndAwaitNextEstimation = maybeLogLag)
+                        startFromTail=pargs.Contains FromTail,
+                        ?maxDocuments=pargs.TryGetResult MaxDocuments,
+                        ?reportLagAndAwaitNextEstimation=maybeLogLag)
                 return! Async.AwaitKeyboardInterrupt() }
             Async.RunSynchronously run
         | _ -> failwith "Please specify a valid subcommand :- init or project"


### PR DESCRIPTION
`Scheduling.Stats` needs to be `abstract` in order to trigger usage of an alternative that provides an `abstract HandleExn`