### PR TITLE
Upgrade StreamsResult to SpanResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 ### Changed
+
+- Revised `handle` function signatures in `Propulsion.Sync.StreamsSync` and `Propulsion.Streams.StreamsProjector` to use `Propulsion.Streams.SpanResult` representing Write Position updates [#62](https://github.com/jet/propulsion/pull/62)
+
 ### Removed
 ### Fixed
 

--- a/src/Propulsion.Kafka/ProducerSinks.fs
+++ b/src/Propulsion.Kafka/ProducerSinks.fs
@@ -43,7 +43,7 @@ type StreamsProducerSink =
                     | _ -> ()
                     do! producer.Produce(key, message)
                 | None -> ()
-                return span.index + span.events.LongLength, outcome
+                return SpanResult.AllProcessed, outcome
             }
             Sync.StreamsSync.Start
                 (    log, maxReadAhead, maxConcurrentStreams, handle,


### PR DESCRIPTION
`StreamsSync` was still reliant on a raw `int64` post-position result; for consistency (highlighted by dotnet-templates), this converges it on the same signature