### PR TITLE
Kafka0: Add BatchedConsumer

### DIFF
--- a/src/Propulsion.Kafka0/Bindings.fs
+++ b/src/Propulsion.Kafka0/Bindings.fs
@@ -27,4 +27,4 @@ module Bindings =
             if consumer.Consume(&message, intervalRemainder) then
                 if message.Error.HasError then log.Warning("Consuming... error {e}", message.Error)
                 else ingest message
-        with| :? System.OperationCanceledException -> log.Warning("Consuming... cancelled")
+        with| :? System.OperationCanceledException -> log.Warning("Consuming... cancelled {name}", consumer.Name)

--- a/src/Propulsion.Kafka0/ConfluentKafka1Shims.fs
+++ b/src/Propulsion.Kafka0/ConfluentKafka1Shims.fs
@@ -1,8 +1,5 @@
 ﻿namespace FsKafka
 
-open System
-open System.Collections.Generic
-
 [<AutoOpen>]
 module Types =
     [<RequireQualifiedAccess; Struct>]

--- a/src/Propulsion.Kafka0/FsKafkaShims.fs
+++ b/src/Propulsion.Kafka0/FsKafkaShims.fs
@@ -11,6 +11,7 @@ open System
 open System.Threading
 open System.Threading.Tasks
 open System.Collections.Generic
+open System.Collections.Concurrent
 
 // Cloned from FsKafka master branch
 module Core =
@@ -38,17 +39,7 @@ module Core =
                     busyWork ()
                 log.Verbose "Consumer resuming polling"
 
-module Config =
-    let validateBrokerUri (u : Uri) =
-        if not u.IsAbsoluteUri then invalidArg "broker" "should be of 'host:port' format"
-        if String.IsNullOrEmpty u.Authority then
-            // handle a corner case in which Uri instances are erroneously putting the hostname in the `scheme` field.
-            if System.Text.RegularExpressions.Regex.IsMatch(string u, "^\S+:[0-9]+$") then string u
-            else invalidArg "broker" "should be of 'host:port' format"
-
-        else u.Authority
-
-/// See https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md for documentation on the implications of specfic settings
+/// See https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md for documentation on the implications of specific settings
 [<NoComparison>]
 type KafkaProducerConfig private (inner, bootstrapServers) =
     member __.Inner : ProducerConfig = inner
@@ -105,8 +96,8 @@ type KafkaProducerConfig private (inner, bootstrapServers) =
 [<AutoOpen>]
 module Impl =
     let encoding = System.Text.Encoding.UTF8
-    let mkSerializer() = new Confluent.Kafka.Serialization.StringSerializer(encoding)
-    let mkDeserializer() = new Confluent.Kafka.Serialization.StringDeserializer(encoding)
+    let mkSerializer() = Confluent.Kafka.Serialization.StringSerializer(encoding)
+    let mkDeserializer() = Confluent.Kafka.Serialization.StringDeserializer(encoding)
 
 /// Creates and wraps a Confluent.Kafka Producer with the supplied configuration
 type KafkaProducer private (inner : Producer<string, string>, topic : string, unsub) =
@@ -155,8 +146,7 @@ type BatchedProducer private (log: ILogger, inner : IProducer<string, string>, t
 
         let! ct = Async.CancellationToken
 
-        let tcs = new TaskCompletionSource<DeliveryReport<_,_>[]>()
-        let numMessages = keyValueBatch.Length
+        let tcs = TaskCompletionSource<DeliveryReport<_,_>[]>()
         let numMessages = keyValueBatch.Length
         let results = Array.zeroCreate<DeliveryReport<_,_>> numMessages
         let numCompleted = ref 0
@@ -334,3 +324,179 @@ type ConsumerBuilder =
         let consumer = new Consumer<_,_>(config.Render(), mkDeserializer(), mkDeserializer())
         let unsubLog = ConsumerBuilder.WithLogging(log, consumer, ?onRevoke = onRevoke)
         consumer, unsubLog
+
+module Bindings =
+
+    let inline storeOffset (log : ILogger) (consumer : Consumer<_,_>) (highWaterMark : Confluent.Kafka.Message<string,string>) =
+        try let e = consumer.StoreOffset(highWaterMark)
+            if e.Error.HasError then log.Error("Consuming... storing offsets failed {@e}", e.Error)
+        with e -> log.Error(e, "Consuming... storing offsets failed")
+
+module private ConsumerImpl =
+    /// guesstimate approximate message size in bytes
+    let approximateMessageBytes (result : Message<string, string>) =
+        let inline len (x:string) = match x with null -> 0 | x -> sizeof<char> * x.Length
+        16 + len result.Key + len result.Value |> int64
+
+    type BlockingCollection<'T> with
+        member bc.FillBuffer(buffer : 'T[], maxDelay : TimeSpan) : int =
+            let cts = new CancellationTokenSource()
+            do cts.CancelAfter maxDelay
+
+            let n = buffer.Length
+            let mutable i = 0
+            let mutable t = Unchecked.defaultof<'T>
+
+            while i < n && not cts.IsCancellationRequested do
+                if bc.TryTake(&t, 5 (* ms *)) then
+                    buffer.[i] <- t ; i <- i + 1
+                    while i < n && not cts.IsCancellationRequested && bc.TryTake(&t) do
+                        buffer.[i] <- t ; i <- i + 1
+            i
+
+    type PartitionedBlockingCollection<'Key, 'Message when 'Key : equality>(?perPartitionCapacity : int) =
+        let collections = new ConcurrentDictionary<'Key, Lazy<BlockingCollection<'Message>>>()
+        let onPartitionAdded = new Event<'Key * BlockingCollection<'Message>>()
+
+        let createCollection() =
+            match perPartitionCapacity with
+            | None -> new BlockingCollection<'Message>()
+            | Some c -> new BlockingCollection<'Message>(boundedCapacity = c)
+
+        [<CLIEvent>]
+        member __.OnPartitionAdded = onPartitionAdded.Publish
+
+        member __.Add (key : 'Key, message : 'Message) =
+            let factory key = lazy(
+                let coll = createCollection()
+                onPartitionAdded.Trigger(key, coll)
+                coll)
+
+            let buffer = collections.GetOrAdd(key, factory)
+            buffer.Value.Add message
+
+        member __.Revoke(key : 'Key) =
+            match collections.TryRemove key with
+            | true, coll -> Task.Delay(10000).ContinueWith(fun _ -> coll.Value.CompleteAdding()) |> ignore
+            | _ -> ()
+
+    let mkBatchedMessageConsumer (log: ILogger) (buf : Core.ConsumerBufferingConfig) (ct : CancellationToken) (consumer : Consumer<string, string>)
+            (partitionedCollection : PartitionedBlockingCollection<TopicPartition, Confluent.Kafka.Message<string, string>>)
+            (handler : Confluent.Kafka.Message<string,string>[] -> Async<unit>) = async {
+        let tcs = TaskCompletionSource<unit>()
+        use cts = CancellationTokenSource.CreateLinkedTokenSource(ct)
+        use _ = ct.Register(fun _ -> tcs.TrySetResult () |> ignore)
+
+        use _ = consumer
+
+        let mcLog = log.ForContext(Serilog.Core.Constants.SourceContextPropertyName, Core.Constants.messageCounterSourceContext)
+        let counter = Core.InFlightMessageCounter(mcLog, buf.minInFlightBytes, buf.maxInFlightBytes)
+
+        // starts a tail recursive loop that dequeues batches for a given partition buffer and schedules the user callback
+        let consumePartition (collection : BlockingCollection<Confluent.Kafka.Message<string, string>>) =
+            let buffer = Array.zeroCreate buf.maxBatchSize
+            let nextBatch () =
+                let count = collection.FillBuffer(buffer, buf.maxBatchDelay)
+                if count <> 0 then log.Debug("Consuming {count}", count)
+                let batch = Array.init count (fun i -> buffer.[i])
+                Array.Clear(buffer, 0, count)
+                batch
+
+            let rec loop () = async {
+                if not collection.IsCompleted then
+                    try match nextBatch() with
+                        | [||] -> ()
+                        | batch ->
+                            // run the handler function
+                            do! handler batch
+
+                            // store completed offsets
+                            let lastItem = batch |> Array.maxBy (fun m -> let o = m.Offset in o.Value)
+                            Bindings.storeOffset log consumer lastItem
+
+                            // decrement in-flight message counter
+                            let batchSize = batch |> Array.sumBy approximateMessageBytes
+                            counter.Delta(-batchSize)
+                    with e ->
+                        tcs.TrySetException e |> ignore
+                        cts.Cancel()
+                    return! loop() }
+
+            Async.Start(loop(), cts.Token)
+
+        use _ = partitionedCollection.OnPartitionAdded.Subscribe (fun (_key,buffer) -> consumePartition buffer)
+
+        // run the consumer
+        let ct = cts.Token
+        try while not ct.IsCancellationRequested do
+                counter.AwaitThreshold(fun () -> Thread.Sleep 1)
+                try let mutable message = null
+                    if consumer.Consume(&message, 5) then
+                        if message.Error.HasError then log.Warning("Consuming... error {e}", message.Error)
+                        else
+                            counter.Delta(+approximateMessageBytes message)
+                            partitionedCollection.Add(message.TopicPartition, message)
+                with| :? System.OperationCanceledException -> log.Warning("Consuming... cancelled {name}", consumer.Name)
+        finally
+            consumer.Dispose()
+
+        // await for handler faults or external cancellation
+        return! Async.AwaitTaskCorrect tcs.Task
+    }
+
+/// Creates and wraps a Confluent.Kafka IConsumer, wrapping it to afford a batched consumption mode with implicit offset progression at the end of each
+/// (parallel across partitions, sequenced/monotonic within) batch of processing carried out by the `partitionHandler`
+/// Conclusion of the processing (when a `partitionHandler` throws and/or `Stop()` is called) can be awaited via `AwaitCompletion()`
+type BatchedConsumer private (inner : Consumer<string, string>, task : Task<unit>, triggerStop) =
+
+    member __.Inner = inner
+
+    interface IDisposable with member __.Dispose() = __.Stop()
+    /// Request cancellation of processing
+    member __.Stop() =  triggerStop ()
+    /// Inspects current status of processing task
+    member __.Status = task.Status
+    member __.RanToCompletion = task.Status = System.Threading.Tasks.TaskStatus.RanToCompletion
+    /// Asynchronously awaits until consumer stops or is faulted
+    member __.AwaitCompletion() = Async.AwaitTaskCorrect task
+
+    /// Starts a Kafka consumer with the provided configuration. Batches are grouped by topic partition.
+    /// Batches belonging to the same topic partition will be scheduled sequentially and monotonically; however batches from different partitions can run concurrently.
+    /// Completion of the `partitionHandler` saves the attained offsets so the auto-commit can mark progress; yielding an exception terminates the processing
+    static member Start(log : ILogger, config : KafkaConsumerConfig, partitionHandler : Message<string,string>[] -> Async<unit>) =
+        if List.isEmpty config.topics then invalidArg "config" "must specify at least one topic"
+        log.Information("Consuming... {bootstrapServers} {topics} {groupId} autoOffsetReset={autoOffsetReset} fetchMaxBytes={fetchMaxB} maxInFlight={maxInFlightGB:n1}GB maxBatchDelay={maxBatchDelay}s maxBatchSize={maxBatchSize}",
+            config.inner.BootstrapServers, config.topics, config.inner.GroupId, (let x = config.inner.AutoOffsetReset in x.Value), config.inner.FetchMaxBytes,
+            float config.buffering.maxInFlightBytes / 1024. / 1024. / 1024., (let t = config.buffering.maxBatchDelay in t.TotalSeconds), config.buffering.maxBatchSize)
+        let partitionedCollection = ConsumerImpl.PartitionedBlockingCollection<TopicPartition, Message<string, string>>()
+        let onRevoke (xs : seq<TopicPartition>) =
+            for x in xs do
+                partitionedCollection.Revoke(x)
+        let consumer, unsubLog = ConsumerBuilder.WithLogging(log, config.inner, onRevoke = onRevoke)
+        let cts = new CancellationTokenSource()
+        let triggerStop () =
+            log.Information("Consuming... Stopping {name}", consumer.Name)
+            cts.Cancel()
+        let task = ConsumerImpl.mkBatchedMessageConsumer log config.buffering cts.Token consumer partitionedCollection partitionHandler |> Async.StartAsTask
+        let c = new BatchedConsumer(consumer, task, triggerStop)
+        consumer.Subscribe config.topics
+        c
+
+    /// Starts a Kafka consumer instance that schedules handlers grouped by message key. Additionally accepts a global degreeOfParallelism parameter
+    /// that controls the number of handlers running concurrently across partitions for the given consumer instance.
+    static member StartByKey(log: ILogger, config : KafkaConsumerConfig, degreeOfParallelism : int, keyHandler : Message<_,_> [] -> Async<unit>) =
+        let semaphore = new SemaphoreSlim(degreeOfParallelism)
+        let partitionHandler (results : Message<_,_>[]) = async {
+            return!
+                results
+                |> Seq.groupBy (fun r -> r.Key)
+                |> Seq.map (fun (_,gp) -> async {
+                    let! ct = Async.CancellationToken
+                    let! _ = semaphore.WaitAsync ct |> Async.AwaitTaskCorrect
+                    try do! keyHandler (Seq.toArray gp)
+                    finally semaphore.Release() |> ignore })
+                |> Async.Parallel
+                |> Async.Ignore
+        }
+
+        BatchedConsumer.Start(log, config, partitionHandler)


### PR DESCRIPTION
Propulsion.Kafka0 provides a shim layer allowing one to use FsKafka's API over Confluent.kafka 0.11.3 - to date, the config and producer APIs are covered.

This adds the key missing component: BatchedConsumer.