### PR TITLE
Fix StreamsProjector hang when >1 instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Removed
 ### Fixed
 
+- Fix Projector hang when using >1 Streams Scheduler [#74](https://github.com/jet/propulsion/pull/74) :pray: [@fnipo](https://github.com/fnipo)
+
 <a name="2.7.0"></a>
 ## [2.7.0] - 2020-06-09
 

--- a/src/Propulsion/Streams.fs
+++ b/src/Propulsion/Streams.fs
@@ -629,7 +629,7 @@ module Scheduling =
             int64 acc
 
         // ingest information to be gleaned from processing the results into `streams`
-        static let workLocalBuffer = Array.zeroCreate 1024
+        let workLocalBuffer = Array.zeroCreate 1024
         let tryDrainResults feedStats =
             let mutable worked, more = false, true
             while more do


### PR DESCRIPTION
Fixes an issue reported and repro'd internally by @fnipo where test scenarios hang when run repeatedly.

This had gone unnoticed (despite automated tests and more than a year of heavy production usage) as typically one only runs (and from a performance perspective, should only run) a single StreamsProjector per Process.