### PR TITLE
Correct Kafka Polling pause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Removed
 ### Fixed
 
+- Apply [Corrected FsKafka Poll loop](https://github.com/jet/FsKafka/pull/70) when over `maxInFlightBytes` threshold as per `FsKafka` v `1.5.0` [#77](https://github.com/jet/propulsion/pull/77)
+
 <a name="2.8.0"></a>
 ## [2.8.0] - 2020-07-27
 

--- a/src/Propulsion.Kafka/Propulsion.Kafka.fsproj
+++ b/src/Propulsion.Kafka/Propulsion.Kafka.fsproj
@@ -26,7 +26,7 @@
     <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' != 'net461' " />
 
     <PackageReference Include="FsCodec.NewtonsoftJson" Version="2.0.0" />
-    <PackageReference Include="FsKafka" Version="1.5.0" />
+    <PackageReference Include="FsKafka" Version="[1.5.0,1.6.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Propulsion.Kafka0/Propulsion.Kafka0.fsproj
+++ b/src/Propulsion.Kafka0/Propulsion.Kafka0.fsproj
@@ -28,7 +28,7 @@
     <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' != 'net461' " />
 
     <PackageReference Include="FsCodec.NewtonsoftJson" Version="2.0.0" />
-    <PackageReference Include="FsKafka0" Version="1.5.0" />
+    <PackageReference Include="FsKafka0" Version="[1.5.0,1.6.0)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Applies technique used in FsKafka 1.5.1 (can work against `FsKafka >= 1.5`, but pinning to `< 1.6` so we can remove obsolete overloads in timely fashion)