### PR TITLE
Kafka: Make default Producer linger 5ms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 ### Changed
+
+- `Kafka`: Adjust default linger to 5ms [#78](https://github.com/jet/propulsion/pull/78)
+
 ### Removed
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ## [Unreleased]
 
 ### Added
+
+- `Kafka.Producer`: Expose `acks`, `linger`, `compression` options [#78](https://github.com/jet/propulsion/pull/78)
+
 ### Changed
 
 - `Kafka`: Adjust default linger to 5ms [#78](https://github.com/jet/propulsion/pull/78)


### PR DESCRIPTION
To align with Confluent.Kafka 1.5.0 and typical usage patterns, this applies a default producer timeout of 5ms (it previously was 0ms, so this is do a degree a breaking change)