### PR TITLE
Logging consistency tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Removed
 ### Fixed
 
+- Corrected Cosmos + Stream Sink error logging [#79](https://github.com/jet/propulsion/pull/79)
+
 <a name="2.8.1"></a>
 ## [2.8.1] - 2020-08-04
 

--- a/src/Propulsion.Cosmos/ChangeFeedProcessor.fs
+++ b/src/Propulsion.Cosmos/ChangeFeedProcessor.fs
@@ -95,11 +95,11 @@ type ChangeFeedProcessor =
             ?leaseRenewInterval : TimeSpan,
             /// Duration to take lease when acquired/renewed. Default 10s
             ?leaseTtl : TimeSpan,
-            /// Delay before re-polling a partitition after backlog has been drained
+            /// Delay before re-polling a partition after backlog has been drained
             ?feedPollDelay : TimeSpan,
             /// Limit on items to take in a batch when querying for changes (in addition to 4MB response size limit). Default Unlimited
             ?maxDocuments : int,
-            /// Continuously fed per-partion lag information until parent Async completes
+            /// Continuously fed per-partition lag information until parent Async completes
             /// callback should Async.Sleep until next update is desired
             ?reportLagAndAwaitNextEstimation) = async {
 
@@ -110,7 +110,7 @@ type ChangeFeedProcessor =
         let leaseTtl = defaultArg leaseTtl (TimeSpan.FromSeconds 10.)
 
         let inline s (x : TimeSpan) = x.TotalSeconds
-        log.Information("Processing Lease acquire {leaseAcquireIntervalS:n0}s ttl {ttlS:n0}s renew {renewS:n0}s feedPollDelay {feedPollDelayS:n0}s",
+        log.Information("Changefeed Lease acquire {leaseAcquireIntervalS:n0}s ttl {ttlS:n0}s renew {renewS:n0}s feedPollDelay {feedPollDelayS:n0}s",
             s leaseAcquireInterval, s leaseTtl, s leaseRenewInterval, s feedPollDelay)
 
         let builder =
@@ -153,7 +153,7 @@ type ChangeFeedProcessor =
         // If k>1 processes share an owner id, then they will compete for same partitions.
         // In that scenario, redundant processing happen on assigned partitions, but checkpoint will process on only 1 consumer.
         // Including the processId should eliminate the possibility that a broken process manager causes k>1 scenario to happen.
-        // The only downside is that upon redeploy, lease experation / TTL would have to be observed before a consumer can pick it up.
+        // The only downside is that upon redeploy, lease expiration / TTL would have to be observed before a consumer can pick it up.
         let processName = System.Reflection.Assembly.GetEntryAssembly().GetName().Name
         let processId = System.Diagnostics.Process.GetCurrentProcess().Id
         let hostName = System.Environment.MachineName

--- a/src/Propulsion.Cosmos/CosmosSource.fs
+++ b/src/Propulsion.Cosmos/CosmosSource.fs
@@ -39,7 +39,7 @@ type CosmosSource =
                 total := !total + lag
                 incr count
                 if lag = 0L then synced.Add partitionId else lagged.Add value
-            log.Information("Backlog {backlog:n0} / {count} Lagging {lagging} Synced {in-sync}",
+            log.Information("Changefeed Backlog {backlog:n0} / {count} Lagging {@lagging} Synced {@inSync}",
                 !total, !count, lagged, synced)
             return! Async.Sleep interval }
         let maybeLogLag = lagReportFreq |> Option.map logLag

--- a/src/Propulsion.EventStore/EventStoreSink.fs
+++ b/src/Propulsion.EventStore/EventStoreSink.fs
@@ -82,7 +82,7 @@ module Internal =
                     mb exnBytes, fails, failStreams.Count, exnEvents, !timedOut, toStreams.Count)
                 timedOut := 0; resultExnOther := 0; failStreams.Clear(); toStreams.Clear(); exnBytes <- 0L; exnEvents <- 0
             if badCats.Any then
-                log.Warning("Malformed cats {@badCats} Other {other:n0}r {@oStreams}",
+                log.Warning("Affected cats {@badCats} Other {other:n0}r {@oStreams}",
                     badCats.StatsDescending |> Seq.truncate 50, !resultExnOther, oStreams |> Seq.truncate 100)
                 badCats.Clear(); resultExnOther := 0; oStreams.Clear()
             Equinox.EventStore.Log.InternalMetrics.dump log


### PR DESCRIPTION
Adjustments to logging for consistency purposes (made in the course of implementing pruning)

Includes `HandleExn` signature change (it was originally incorrect)