### PR TITLE
Fix StreamsProducerSink idle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Removed
 ### Fixed
 
+- `Kafka.StreamsProducerSink`: Changed bad default `idleDelay` from 0ms to 2ms [#82](https://github.com/jet/propulsion/pull/82)
+
 <a name="2.9.0-rc1"></a>
 ## [2.9.0-rc1] - 2020-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Removed
 ### Fixed
 
-- `Kafka.StreamsProducerSink`: Changed bad default `idleDelay` from 0ms to 2ms [#82](https://github.com/jet/propulsion/pull/82)
+- `Kafka.StreamsProducerSink`: Changed bad default `idleDelay` from 0ms to 1ms [#82](https://github.com/jet/propulsion/pull/82)
 
 <a name="2.9.0-rc1"></a>
 ## [2.9.0-rc1] - 2020-08-31

--- a/src/Propulsion.Kafka/ProducerSinks.fs
+++ b/src/Propulsion.Kafka/ProducerSinks.fs
@@ -22,7 +22,7 @@ type StreamsProducerSink =
             prepare : StreamName * StreamSpan<_> -> Async<(string*string) option * 'Outcome>,
             producer : Producer,
             stats : Streams.Sync.Stats<'Outcome>, statsInterval,
-            /// Default 2 ms
+            /// Default 1 ms
             ?idleDelay,
             /// Default 1 MiB
             ?maxBytes,
@@ -56,7 +56,7 @@ type StreamsProducerSink =
             prepare : StreamName * StreamSpan<_> -> Async<string*string>,
             producer : Producer,
             stats : Streams.Sync.Stats<unit>, statsInterval,
-            /// Default 2 ms
+            /// Default 1 ms
             ?idleDelay,
             /// Default 1 MiB
             ?maxBytes,

--- a/src/Propulsion.Kafka/ProducerSinks.fs
+++ b/src/Propulsion.Kafka/ProducerSinks.fs
@@ -22,7 +22,7 @@ type StreamsProducerSink =
             prepare : StreamName * StreamSpan<_> -> Async<(string*string) option * 'Outcome>,
             producer : Producer,
             stats : Streams.Sync.Stats<'Outcome>, statsInterval,
-            /// Default .5 ms
+            /// Default 2 ms
             ?idleDelay,
             /// Default 1 MiB
             ?maxBytes,
@@ -56,7 +56,7 @@ type StreamsProducerSink =
             prepare : StreamName * StreamSpan<_> -> Async<string*string>,
             producer : Producer,
             stats : Streams.Sync.Stats<unit>, statsInterval,
-            /// Default .5 ms
+            /// Default 2 ms
             ?idleDelay,
             /// Default 1 MiB
             ?maxBytes,

--- a/src/Propulsion/Streams.fs
+++ b/src/Propulsion/Streams.fs
@@ -941,7 +941,7 @@ module Sync =
             (   log : ILogger, maxReadAhead, maxConcurrentStreams,
                 handle : StreamName * StreamSpan<_> -> Async<SpanResult * 'Outcome>,
                 stats : Stats<'Outcome>, statsInterval,
-                /// Default .5 ms
+                /// Default 2 ms
                 ?idleDelay,
                 /// Default 1 MiB
                 ?maxBytes,
@@ -981,7 +981,7 @@ module Sync =
             let dispatcher = Scheduling.MultiDispatcher<_, _, _>(itemDispatcher, attemptWrite, interpretWriteResultProgress, stats, dumpStreams)
             let streamScheduler =
                 Scheduling.StreamSchedulingEngine<int64 * (EventMetrics * TimeSpan) * 'Outcome, (EventMetrics * TimeSpan) * 'Outcome, EventMetrics * exn>
-                    (   dispatcher, maxBatches=maxBatches, maxCycles=defaultArg maxCycles 128, idleDelay=defaultArg idleDelay (TimeSpan.FromMilliseconds 0.5))
+                    (   dispatcher, maxBatches=maxBatches, maxCycles=defaultArg maxCycles 128, ?idleDelay=idleDelay)
 
             Projector.StreamsProjectorPipeline.Start(
                 log, itemDispatcher.Pump(), streamScheduler.Pump, maxReadAhead, streamScheduler.Submit, statsInterval, maxSubmissionsPerPartition=maxBatches, ?pumpInterval=pumpInterval)

--- a/src/Propulsion/Streams.fs
+++ b/src/Propulsion/Streams.fs
@@ -609,11 +609,11 @@ module Scheduling =
             ?maxBatches,
             /// Tune the max number of check/dispatch cycles. Default 16.
             ?maxCycles,
-            /// Tune the sleep time when there are no items to schedule or responses to process. Default 2ms.
+            /// Tune the sleep time when there are no items to schedule or responses to process. Default 1ms.
             ?idleDelay,
             /// Opt-in to allowing items to be processed independent of batch sequencing - requires upstream/projection function to be able to identify gaps. Default false.
             ?enableSlipstreaming) =
-        let idleDelay = defaultArg idleDelay (TimeSpan.FromMilliseconds 2.)
+        let idleDelay = defaultArg idleDelay (TimeSpan.FromMilliseconds 1.)
         let sleepIntervalMs = int idleDelay.TotalMilliseconds
         let maxCycles, maxBatches, slipstreamingEnabled = defaultArg maxCycles 16, defaultArg maxBatches 5, defaultArg enableSlipstreaming false
         let work = ConcurrentStack<InternalMessage<Choice<'P, 'E>>>() // dont need them ordered so Queue is unwarranted; usage is cross-thread so Bag is not better
@@ -862,7 +862,7 @@ type StreamsProjector =
         (   log : ILogger, maxReadAhead, maxConcurrentStreams,
             prepare, handle, toIndex,
             stats, statsInterval, ?pumpInterval,
-            /// Tune the sleep time when there are no items to schedule or responses to process. Default 2ms.
+            /// Tune the sleep time when there are no items to schedule or responses to process. Default 1ms.
             ?idleDelay)
         : ProjectorPipeline<_> =
         let dispatcher = Scheduling.ItemDispatcher<_>(maxConcurrentStreams)
@@ -879,7 +879,7 @@ type StreamsProjector =
         (   log : ILogger, maxReadAhead, maxConcurrentStreams,
             handle : StreamName * StreamSpan<_> -> Async<SpanResult * 'Outcome>,
             stats, statsInterval,
-            /// Tune the sleep time when there are no items to schedule or responses to process. Default 2ms.
+            /// Tune the sleep time when there are no items to schedule or responses to process. Default 1ms.
             ?idleDelay, ?pumpInterval)
         : ProjectorPipeline<_> =
         let prepare (streamName, span) =
@@ -892,7 +892,7 @@ type StreamsProjector =
         (   log : ILogger, maxReadAhead, maxConcurrentStreams,
             handle : StreamName * StreamSpan<_> -> Async<'Outcome>,
             stats, statsInterval, ?pumpInterval,
-            /// Tune the sleep time when there are no items to schedule or responses to process. Default 2ms.
+            /// Tune the sleep time when there are no items to schedule or responses to process. Default 1ms.
             ?idleDelay)
         : ProjectorPipeline<_> =
         let handle (streamName, span : StreamSpan<_>) = async {
@@ -941,7 +941,7 @@ module Sync =
             (   log : ILogger, maxReadAhead, maxConcurrentStreams,
                 handle : StreamName * StreamSpan<_> -> Async<SpanResult * 'Outcome>,
                 stats : Stats<'Outcome>, statsInterval,
-                /// Default 2 ms
+                /// Default 1 ms
                 ?idleDelay,
                 /// Default 1 MiB
                 ?maxBytes,


### PR DESCRIPTION
Via @gardito, removes a custom `idleDelay` used for `StreamsProducerSink` as this leads to excessive CPU consumption

- [x] Main bug is that the 0.5ms gets rounded down to 0ms, which effectively neuters all sleeps
- [x] validate reducing it to 1ms (it was 2ms) as is default for all projectors works appropriately in production cluster configuration