### PR TITLE
Cosmos: Expose maxBytes, maxEvents params on CosmosSink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 
-- Exposed optional `maxEvents` and `maxBytes` arguments for `CosmosSink` [#83](https://github.com/jet/propulsion/pull/83)
+- Exposed optional `maxEvents` and `maxBytes` arguments for `CosmosSink` [#84](https://github.com/jet/propulsion/pull/84)
 
 ### Changed
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ## [Unreleased]
 
 ### Added
+
+- Exposed optional `maxEvents` and `maxBytes` arguments for `CosmosSink` [#83](https://github.com/jet/propulsion/pull/83)
+
 ### Changed
 ### Removed
 ### Fixed

--- a/src/Propulsion/Streams.fs
+++ b/src/Propulsion/Streams.fs
@@ -205,7 +205,7 @@ module Buffering =
                 let eventBytes = estimateBytesAsJsonUtf8 y
                 bytesBudget <- bytesBudget - eventBytes
                 // always send at least one event in order to surface the problem and have the stream marked malformed
-                let res = count = 0 || (countBudget > 0 && bytesBudget > 0)
+                let res = count = 0 || (countBudget >= 0 && bytesBudget >= 0)
                 if res then count <- count + 1; bytes <- bytes + eventBytes
                 res
             let trimmed = { streamSpan with events = streamSpan.events |> Array.takeWhile withinLimits }


### PR DESCRIPTION
While the CosmosDB document size limit is ~2MB, the limit `CosmosSink` imposes is 1MB/16384 events based on that being the limit of the size of arguments that may be submitted on a stored procedure invocation.

Performance tuning on the archiver template has made it clear that:
- self-limiting to 80KB yields a predictable RU cost of < 100
- self-limiting to 1MB can cause continual rejection of requests when 400RU is allocated (charges run up to ~1600RU can be sustained)
- self-limiting to 512K has not caused such a hang (charges stay < 500RU)
- self-limiting to 128K seems to trigger significant jitter in the charges

As a result, this PR exposes the `maxEvents` and `maxBytes` parameters in order that the default in the templates can be shifted downward into the 512K (or lower) thresholds in order to work most effectively within environments with limited RU allocations