### PR TITLE
Add RollForward Major for tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 ### Changed
+
+- Add `<RollForward>Major</RollForward>` for `Propulsion.Tool` [#92](https://github.com/jet/propulsion/pull/92)
+
 ### Removed
 ### Fixed
 

--- a/tools/Propulsion.Tool/Propulsion.Tool.fsproj
+++ b/tools/Propulsion.Tool/Propulsion.Tool.fsproj
@@ -11,6 +11,9 @@
 
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>propulsion</ToolCommandName>
+    <!-- Allow to run on SDK >= 5-->
+    <RollForward>Major</RollForward>
+
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Allow Tool to be used for e.g. environments with only net5.0 runtimes present