### PR TITLE
Add Streams scheduler metrics + Prometheus integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,14 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ## [Unreleased]
 
 ### Added
+
+- `Propulsion.Prometheus`: Add Buffer, Cpu and Handler metrics to `Propulsion.Streams` Scheduler 
+
 ### Changed
 ### Removed
 ### Fixed
+
+- Replaced numeric field names with strings in latency percentiles message
 
 <a name="2.10.0-rc1"></a>
 ## [2.10.0-rc1] - 2020-12-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,13 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 
-- `Propulsion.Prometheus`: Add Buffer, Cpu and Handler metrics to `Propulsion.Streams` Scheduler 
+- `Propulsion.Prometheus`: Add Buffer, Cpu and Handler latency metrics to `Propulsion.Streams` Scheduler [#93](https://github.com/jet/propulsion/pull/93) 
 
 ### Changed
 ### Removed
 ### Fixed
 
-- Replaced numeric field names with strings in latency percentiles message
+- Replaced numeric field names with strings in latency percentiles message [#93](https://github.com/jet/propulsion/pull/93)
 
 <a name="2.10.0-rc1"></a>
 ## [2.10.0-rc1] - 2020-12-03

--- a/src/Propulsion.Cosmos/Propulsion.Cosmos.fsproj
+++ b/src/Propulsion.Cosmos/Propulsion.Cosmos.fsproj
@@ -28,9 +28,6 @@
 
     <PackageReference Include="Equinox.Cosmos" Version="2.3.0" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.ChangeFeedProcessor" Version="2.2.8" />
-    
-<!--    NB TEMP; needs to be shipped out-->
-    <PackageReference Include="prometheus-net.AspNetCore" Version="3.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Propulsion/Propulsion.fsproj
+++ b/src/Propulsion/Propulsion.fsproj
@@ -17,6 +17,7 @@
     <Compile Include="Projector.fs" />
     <Compile Include="Parallel.fs" />
     <Compile Include="Streams.fs" />
+    <Compile Include="PropulsionPrometheus.fs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -28,6 +29,8 @@
 
     <PackageReference Include="FsCodec" Version="2.0.0" />
     <PackageReference Include="MathNet.Numerics" Version="4.7.0" />
+    <!--    NB TEMP; needs to be shipped out-->
+    <PackageReference Include="prometheus-net" Version="3.6.0" />
     <PackageReference Include="Serilog" Version="2.7.1" />
   </ItemGroup>
 

--- a/src/Propulsion/PropulsionPrometheus.fs
+++ b/src/Propulsion/PropulsionPrometheus.fs
@@ -1,0 +1,98 @@
+namespace Propulsion.Prometheus
+
+module private Impl =
+
+    let baseName stat = "propulsion_scheduler_" + stat
+    let baseDesc desc = "Propulsion Scheduler " + desc
+    let groupLabels = [| "app"; "group"; "state" |]
+    let activityLabels = [| "app"; "group"; "activity" |]
+    let latencyLabels = [| "app"; "group"; "kind" |]
+
+module private Gauge =
+
+    let private mk (cfg : Prometheus.GaugeConfiguration) name help =
+        let g = Prometheus.Metrics.CreateGauge(name, help, cfg)
+        fun app group state v -> g.WithLabels(app, group, state).Set(v)
+    let private config = Prometheus.GaugeConfiguration(LabelNames = Impl.groupLabels)
+    let create stat desc = mk config (Impl.baseName stat) (Impl.baseDesc desc)
+
+module private Counter =
+
+    let private mk (cfg : Prometheus.CounterConfiguration) name desc =
+        let c = Prometheus.Metrics.CreateCounter(name, desc, cfg)
+        fun app group activity v -> c.WithLabels(app, group, activity).Inc(v)
+    let private config = Prometheus.CounterConfiguration(LabelNames = Impl.activityLabels)
+    let create stat desc =
+        mk config (Impl.baseName stat) (Impl.baseDesc desc)
+
+module private Summary =
+
+    let private create (cfg : Prometheus.SummaryConfiguration) name desc  =
+        let s = Prometheus.Metrics.CreateSummary(name, desc, cfg)
+        fun app (group, kind) v -> s.WithLabels(app, group, kind).Observe(v)
+    let config =
+        let inline qep q e = Prometheus.QuantileEpsilonPair(q, e)
+        let objectives = [| qep 0.50 0.05; qep 0.95 0.01; qep 0.99 0.01 |]
+        Prometheus.SummaryConfiguration(Objectives = objectives, LabelNames = Impl.latencyLabels, MaxAge = System.TimeSpan.FromMinutes 1.)
+    let latency stat desc = create config (Impl.baseName stat + "_seconds") (Impl.baseDesc desc + " latency")
+
+module private Histogram =
+
+    let private create (cfg : Prometheus.HistogramConfiguration) name desc =
+        let h = Prometheus.Metrics.CreateHistogram(name, desc, cfg)
+        fun app (group, kind) v -> h.WithLabels(app, group, kind).Observe(v)
+    let private sHistogram =
+        let sBuckets = Prometheus.Histogram.ExponentialBuckets(0.001, 2., 16) // 1ms .. 64s
+        let sCfg = Prometheus.HistogramConfiguration(Buckets = sBuckets, LabelNames = Impl.latencyLabels)
+        create sCfg
+    let latency stat desc = sHistogram (Impl.baseName stat + "_seconds") (Impl.baseDesc desc + " latency")
+
+open Propulsion.Streams.Log
+
+module private Stats =
+
+    let observeCats =    Gauge.create      "cats"            "Current categories"
+    let observeStreams = Gauge.create      "streams"         "Current streams"
+    let observeEvents =  Gauge.create      "events"          "Current events"
+    let observeBytes =   Gauge.create      "bytes"           "Current bytes"
+
+    let observeCpu =     Counter.create    "cpu"             "Processing Time Breakdown"
+
+    let observeLatSum =  Summary.latency   "handler_summary" "Handler action"
+    let observeLatHis =  Histogram.latency "handler"         "Handler action"
+
+    let observeState app ctx state (m : BufferMetric) =
+        observeCats app ctx state (float m.cats)
+        observeStreams app ctx state (float m.streams)
+        observeEvents app ctx state (float m.events)
+        observeBytes app ctx state (float m.bytes)
+
+type LogSink(app, group) =
+
+    let observeState = Stats.observeState app group
+    let observeCpu = Stats.observeCpu app group
+    let observeLatency kind latenciesS =
+        for v in latenciesS do
+            Stats.observeLatSum app (group, kind) v
+            Stats.observeLatHis app (group, kind) v
+
+    interface Serilog.Core.ILogEventSink with
+        member __.Emit logEvent = logEvent |> function
+            | MetricEvent cm -> cm |> function
+                | Metric.BufferReport m ->
+                    observeState "ingesting" m
+                | Metric.SchedulerStateReport (synced, busyStats, readyStats, bufferingStats, malformedStats) ->
+                    Stats.observeStreams app group "synced" (float synced)
+                    observeState "active" busyStats
+                    observeState "ready" readyStats
+                    observeState "buffering" bufferingStats
+                    observeState "malformed" malformedStats
+                | Metric.SchedulerCpu (merge, ingest, dispatch, results, stats) ->
+                    observeCpu "merge" merge.TotalSeconds
+                    observeCpu "ingest" ingest.TotalSeconds
+                    observeCpu "dispatch" dispatch.TotalSeconds
+                    observeCpu "results" results.TotalSeconds
+                    observeCpu "stats" stats.TotalSeconds
+                | Metric.AttemptLatencies (kind, latenciesS) ->
+                    observeLatency kind latenciesS
+            | _ -> ()


### PR DESCRIPTION
Applies the same high level approach used to emit metrics from `Propulsion.Cosmos` to `Propulsion.Streams`

Initial impl hosts `Propulsion.Prometheus` within the `Propulsion` package; this will likely be separated out at a future juncture before a full release