### PR TITLE
Streams: Reduce memory usage for streams with only write positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ## [Unreleased]
 
 ### Added
+
+- Streams Scheduler: Tune memory consumption [#93](https://github.com/jet/propulsion/pull/93) 
+
 ### Changed
 ### Removed
 ### Fixed

--- a/src/Propulsion.Cosmos/CosmosSink.fs
+++ b/src/Propulsion.Cosmos/CosmosSink.fs
@@ -160,7 +160,7 @@ module Internal =
                         streams.SetMalformed(stream, malformed), malformed
                 let (_stream, ss), malformed = applyResultToStreamState res
                 Writer.logTo writerResultLog malformed (stream, res)
-                ss.write, res
+                ss.Write, res
             let dispatcher = Scheduling.MultiDispatcher<_, _, _>(itemDispatcher, attemptWrite, interpretWriteResultProgress, stats, dumpStreams)
             Scheduling.StreamSchedulingEngine(dispatcher, enableSlipstreaming=true, ?maxBatches=maxBatches, ?idleDelay=idleDelay)
 

--- a/src/Propulsion.EventStore/EventStoreSink.fs
+++ b/src/Propulsion.EventStore/EventStoreSink.fs
@@ -140,7 +140,7 @@ module Internal =
                     | Choice2Of2 (_stats, _exn) -> streams.SetMalformed(stream, false)
                 let _stream, ss = applyResultToStreamState res
                 Writer.logTo writerResultLog (stream, res)
-                ss.write, res
+                ss.Write, res
 
             let dispatcher = Scheduling.MultiDispatcher<_, _, _>(itemDispatcher, attemptWrite, interpretWriteResultProgress, stats, dumpStreams)
             Scheduling.StreamSchedulingEngine(dispatcher, enableSlipstreaming=true, ?maxBatches=maxBatches, ?idleDelay=idleDelay)

--- a/tests/Propulsion.Tests/Propulsion.Tests.fsproj
+++ b/tests/Propulsion.Tests/Propulsion.Tests.fsproj
@@ -18,8 +18,12 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="ObjectLayoutInspector" Version="0.1.2" />
     <PackageReference Include="unquote" Version="4.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="ObjectLayoutInspector" Version="0.1.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/tests/Propulsion.Tests/Propulsion.Tests.fsproj
+++ b/tests/Propulsion.Tests/Propulsion.Tests.fsproj
@@ -18,12 +18,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
-    <PackageReference Include="ObjectLayoutInspector" Version="0.1.2" />
     <PackageReference Include="unquote" Version="4.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
-    <PackageReference Include="ObjectLayoutInspector" Version="0.1.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/tests/Propulsion.Tests/StreamStateTests.fs
+++ b/tests/Propulsion.Tests/StreamStateTests.fs
@@ -82,3 +82,10 @@ let [<Fact>] ``fail`` () =
 let [<Fact>] ``fail 2`` () =
     let r = mergeSpans 11613L [ mk 11614L 1; {index=11614L; events=null} ]
     test <@ r |> is [| mk 11614L 1 |] @>
+
+type Perf(out : Xunit.Abstractions.ITestOutputHelper) =
+
+    let [<Fact>] layout () =
+        ObjectLayoutInspector.TypeLayout.GetLayout<StreamState<byte[]>>()
+        |> fun s -> s.ToString(true)
+        |> out.WriteLine

--- a/tests/Propulsion.Tests/StreamStateTests.fs
+++ b/tests/Propulsion.Tests/StreamStateTests.fs
@@ -83,9 +83,14 @@ let [<Fact>] ``fail 2`` () =
     let r = mergeSpans 11613L [ mk 11614L 1; {index=11614L; events=null} ]
     test <@ r |> is [| mk 11614L 1 |] @>
 
+#if MEMORY_USAGE_ANALYSIS
+// https://bartoszsypytkowski.com/writing-high-performance-f-code
+// https://github.com/SergeyTeplyakov/ObjectLayoutInspector
+//<PackageReference Include="ObjectLayoutInspector" Version="0.1.2" />
 type Perf(out : Xunit.Abstractions.ITestOutputHelper) =
 
     let [<Fact>] layout () =
         ObjectLayoutInspector.TypeLayout.GetLayout<StreamState<byte[]>>()
         |> fun s -> s.ToString(true)
         |> out.WriteLine
+#endif


### PR DESCRIPTION
There's an unbounded Dictionary that maintains, for each stream that's ever been processed:
a) the backlog of events that have yet to be processed. Definitely necessary state.
b) the write position. Provides performance benefits as it enables:
    i) deduplication of repeated events coming from the input source (the Ingester can throw away the events before they even get to the scheduler)
    ii) proactive discarding because a projection has an awareness of the index of the first event in the stream that's going to be useful. For example, for replication to a warm standby that's already got data, but also when catching up or replaying events for arbitrary projection scenarios. (The underlying mechanism is the same as used for the previous scenario - the handler can yield a response that indicates the lowest position for which we are interested in processing events)
 
However, being unbounded and ever growing, that obviously risks running out of memory.

This PR optimizes the in-memory representation to delay (*not prevent*) this consequence.

The existing memory layout was:

```
Type layout for 'StreamState`1'
Size: 24 bytes. Paddings: 7 bytes (%29 of empty space)
|========================================|
| Object Header (8 bytes)                |
|----------------------------------------|
| Method Table Ptr (8 bytes)             |
|========================================|
|   0-7: FSharpOption`1 write@ (8 bytes) |
|----------------------------------------|
|  8-15: StreamSpan`1[] queue@ (8 bytes) |
|----------------------------------------|
|    16: Boolean isMalformed@ (1 byte)   |
|----------------------------------------|
| 17-23: padding (7 bytes)               |
|========================================|
```

This PR changes from an Object / `type` to a `struct`/`Struct` with the following layout:

```
Type layout for 'StreamState`1'
Size: 16 bytes. Paddings: 0 bytes (%0 of empty space)
|========================================|
|   0-7: StreamSpan`1[] queue@ (8 bytes) |
|----------------------------------------|
|  8-15: Int64 write@ (8 bytes)          |
|========================================|
```