### PR TITLE
Streams: Add Purge interval for Write Positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 
-- Streams Scheduler: Tune memory consumption [#93](https://github.com/jet/propulsion/pull/93) 
-- Streams Scheduler: Add `purgeInterval` to reclaim memory used by write positions of inactive streams [#94](https://github.com/jet/propulsion/pull/94) 
+- Streams Scheduler: Tune memory consumption re write positions of inactive streams [#94](https://github.com/jet/propulsion/pull/94) 
+- Streams Scheduler: Add `purgeInterval` to reclaim memory used by write positions of inactive streams [#95](https://github.com/jet/propulsion/pull/95) 
 
 ### Changed
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Added
 
 - Streams Scheduler: Tune memory consumption [#93](https://github.com/jet/propulsion/pull/93) 
-- Streams Scheduler: Add `purgeInterval` [#94](https://github.com/jet/propulsion/pull/94) 
+- Streams Scheduler: Add `purgeInterval` to reclaim memory used by write positions of inactive streams [#94](https://github.com/jet/propulsion/pull/94) 
 
 ### Changed
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Added
 
 - Streams Scheduler: Tune memory consumption [#93](https://github.com/jet/propulsion/pull/93) 
+- Streams Scheduler: Add `purgeInterval` [#94](https://github.com/jet/propulsion/pull/94) 
 
 ### Changed
 ### Removed

--- a/src/Propulsion.Cosmos/CosmosSink.fs
+++ b/src/Propulsion.Cosmos/CosmosSink.fs
@@ -137,7 +137,7 @@ module Internal =
 
     type StreamSchedulingEngine =
 
-        static member Create(log : ILogger, cosmosContexts : _ [], itemDispatcher, stats : Stats, dumpStreams, ?maxBatches, ?idleDelay, ?maxEvents, ?maxBytes)
+        static member Create(log : ILogger, cosmosContexts : _ [], itemDispatcher, stats : Stats, dumpStreams, ?maxBatches, ?idleDelay, ?purgeInterval, ?maxEvents, ?maxBytes)
             : Scheduling.StreamSchedulingEngine<_, _, _> =
             let maxEvents, maxBytes = defaultArg maxEvents 16384, defaultArg maxBytes (1024 * 1024 - (*fudge*)4096)
             let writerResultLog = log.ForContext<Writer.Result>()
@@ -162,7 +162,7 @@ module Internal =
                 Writer.logTo writerResultLog malformed (stream, res)
                 ss.Write, res
             let dispatcher = Scheduling.MultiDispatcher<_, _, _>(itemDispatcher, attemptWrite, interpretWriteResultProgress, stats, dumpStreams)
-            Scheduling.StreamSchedulingEngine(dispatcher, enableSlipstreaming=true, ?maxBatches=maxBatches, ?idleDelay=idleDelay)
+            Scheduling.StreamSchedulingEngine(dispatcher, enableSlipstreaming=true, ?maxBatches=maxBatches, ?idleDelay=idleDelay, ?purgeInterval=purgeInterval)
 
 type CosmosSink =
 
@@ -176,6 +176,9 @@ type CosmosSink =
             ?ingesterStatsInterval, ?maxSubmissionsPerPartition, ?pumpInterval,
             /// Tune the sleep time when there are no items to schedule or responses to process. Default 1ms.
             ?idleDelay,
+            /// Frequency with which to jettison Write Position information for inactive streams in order to limit memory consumption
+            /// NOTE: Can impair performance and/or increase costs of writes as it inhibits the ability of the ingester to discard redundant inputs
+            ?purgeInterval,
             /// Default: 16384
             ?maxEvents,
             /// Default: 1MB (limited by maximum size of a CosmosDB stored procedure invocation)
@@ -185,7 +188,7 @@ type CosmosSink =
         let stats = Internal.Stats(log.ForContext<Internal.Stats>(), statsInterval, stateInterval)
         let dispatcher = Propulsion.Streams.Scheduling.ItemDispatcher<_>(maxConcurrentStreams)
         let dumpStreams (s : Scheduling.StreamStates<_>) l = s.Dump(l, Propulsion.Streams.Buffering.StreamState.eventsSize)
-        let streamScheduler = Internal.StreamSchedulingEngine.Create(log, cosmosContexts, dispatcher, stats, dumpStreams, ?idleDelay=idleDelay, ?maxEvents=maxEvents, ?maxBytes=maxBytes)
+        let streamScheduler = Internal.StreamSchedulingEngine.Create(log, cosmosContexts, dispatcher, stats, dumpStreams, ?idleDelay=idleDelay, ?purgeInterval=purgeInterval, ?maxEvents=maxEvents, ?maxBytes=maxBytes)
         Propulsion.Streams.Projector.StreamsProjectorPipeline.Start(
             log, dispatcher.Pump(), streamScheduler.Pump, maxReadAhead, streamScheduler.Submit, statsInterval,
             ?ingesterStatsInterval=ingesterStatsInterval, ?maxSubmissionsPerPartition=maxSubmissionsPerPartition, ?pumpInterval=pumpInterval)

--- a/src/Propulsion.Kafka/ProducerSinks.fs
+++ b/src/Propulsion.Kafka/ProducerSinks.fs
@@ -24,6 +24,9 @@ type StreamsProducerSink =
             stats : Streams.Sync.Stats<'Outcome>, statsInterval,
             /// Default 1 ms
             ?idleDelay,
+            /// Frequency with which to jettison Write Position information for inactive streams in order to limit memory consumption
+            /// NOTE: Can impair performance and/or increase costs of writes as it inhibits the ability of the ingester to discard redundant inputs
+            ?purgeInterval,
             /// Default 1 MiB
             ?maxBytes,
             /// Default 16384
@@ -48,7 +51,7 @@ type StreamsProducerSink =
             Sync.StreamsSync.Start
                 (    log, maxReadAhead, maxConcurrentStreams, handle,
                      stats, statsInterval=statsInterval,
-                     maxBytes=maxBytes, ?idleDelay=idleDelay,
+                     maxBytes=maxBytes, ?idleDelay=idleDelay,?purgeInterval=purgeInterval,
                      ?maxEvents=maxEvents, ?maxBatches=maxBatches, ?maxCycles=maxCycles, dumpExternalStats=producer.DumpStats)
 
    static member Start
@@ -58,6 +61,9 @@ type StreamsProducerSink =
             stats : Streams.Sync.Stats<unit>, statsInterval,
             /// Default 1 ms
             ?idleDelay,
+            /// Frequency with which to jettison Write Position information for inactive streams in order to limit memory consumption
+            /// NOTE: Can impair performance and/or increase costs of writes as it inhibits the ability of the ingester to discard redundant inputs
+            ?purgeInterval,
             /// Default 1 MiB
             ?maxBytes,
             /// Default 16384
@@ -74,5 +80,5 @@ type StreamsProducerSink =
             StreamsProducerSink.Start
                 (    log, maxReadAhead, maxConcurrentStreams, prepare, producer,
                      stats, statsInterval,
-                     ?idleDelay=idleDelay, ?maxBytes=maxBytes,
+                     ?idleDelay=idleDelay, ?purgeInterval=purgeInterval, ?maxBytes=maxBytes,
                      ?maxEvents=maxEvents, ?maxBatches=maxBatches, ?maxCycles=maxCycles)

--- a/src/Propulsion/Streams.fs
+++ b/src/Propulsion/Streams.fs
@@ -299,6 +299,7 @@ module Buffering =
                 | Some w -> w
             { write = effWrite; queue = queue }
         member __.IsEmpty = obj.ReferenceEquals(null, __.queue)
+        member __.IsPurgeable = not __.IsMalformed && __.IsEmpty
         member __.IsMalformed = not __.IsEmpty && -3L = __.write
         member __.HasValid = not __.IsEmpty && not __.IsMalformed
         member __.Write = match __.write with -2L -> None | x -> Some x
@@ -392,6 +393,10 @@ module Scheduling =
         let merge (buffer : Streams<'Format>) =
             for x in buffer.Items do
                 update x.Key x.Value |> ignore
+        let purge () =
+            for x in states do
+                if x.Value.IsPurgeable then
+                    states.Remove x.Key |> ignore
 
         let busy = HashSet<StreamName>()
         let pending trySlipstreamed (requestedOrder : StreamName seq) : seq<DispatchItem<'Format>> = seq {
@@ -411,6 +416,7 @@ module Scheduling =
         let markNotBusy stream = busy.Remove stream |> ignore
 
         member __.InternalMerge buffer = merge buffer
+        member __.Purge() = purge ()
         member __.InternalUpdate stream pos queue = update stream (StreamState<'Format>.Create(Some pos,queue))
 
         member __.Add(stream, index, event, ?isMalformed) =
@@ -715,6 +721,9 @@ module Scheduling =
             ?maxCycles,
             /// Tune the sleep time when there are no items to schedule or responses to process. Default 1ms.
             ?idleDelay,
+            /// Frequency with which to jettison Write Position information for inactive streams in order to limit memory consumption
+            /// NOTE: Can impair performance and/or increase costs of writes as it inhibits the ability of the ingester to discard redundant inputs
+            ?purgeInterval,
             /// Opt-in to allowing items to be processed independent of batch sequencing - requires upstream/projection function to be able to identify gaps. Default false.
             ?enableSlipstreaming) =
         let idleDelay = defaultArg idleDelay (TimeSpan.FromMilliseconds 1.)
@@ -724,6 +733,7 @@ module Scheduling =
         let pending = ConcurrentQueue<StreamsBatch<byte[]>>() // Queue as need ordering
         let streams = StreamStates<byte[]>()
         let progressState = Progress.ProgressState()
+        let purgeDue = purgeInterval |> Option.map intervalCheck
 
         let weight stream =
             let state = streams.Item stream
@@ -829,7 +839,10 @@ module Scheduling =
                     // This loop can take a long time; attempt logging of stats per iteration
                     (fun () -> dispatcher.DumpStats pending.Count) |> accStopwatch <| fun t -> st <- st + t
                 // 3. Record completion state once per full iteration; dumping streams is expensive so needs to be done infrequently
-                if not (dispatcher.TryDumpState(dispatcherState, streams, (dt, ft, mt, it, st))) && idle then
+                if dispatcher.TryDumpState(dispatcherState, streams, (dt, ft, mt, it, st)) then
+                    // After we've dumped the state, it may also be due for pruning
+                    match purgeDue with Some dueNow when dueNow () -> streams.Purge() | _ -> ()
+                elif idle then
                     // 4. Do a minimal sleep so we don't run completely hot when empty (unless we did something non-trivial)
                     Thread.Sleep sleepIntervalMs } // Not Async.Sleep so we don't give up the thread
 
@@ -842,7 +855,7 @@ module Scheduling =
             (   itemDispatcher : ItemDispatcher<Choice<int64 * 'Metrics * 'Outcome, 'Metrics * exn>>,
                 stats : Stats<'Metrics * 'Outcome, 'Metrics * exn>,
                 prepare : StreamName*StreamSpan<byte[]> -> 'Metrics * 'Req, handle : 'Req -> Async<'Progress * 'Outcome>, toIndex : 'Req -> 'Progress -> int64,
-                dumpStreams, ?maxBatches, ?idleDelay, ?enableSlipstreaming)
+                dumpStreams, ?maxBatches, ?idleDelay, ?purgeInterval, ?enableSlipstreaming)
             : StreamSchedulingEngine<int64 * 'Metrics * 'Outcome, 'Metrics * 'Outcome, 'Metrics * exn> =
 
             let project (item : DispatchItem<byte[]>) : Async<Choice<int64 * 'Metrics * 'Outcome, 'Metrics * exn>> = async {
@@ -856,11 +869,11 @@ module Scheduling =
                 | Choice2Of2 (stats, exn) -> None, Choice2Of2 (stats, exn)
 
             let dispatcher = MultiDispatcher<int64 * 'Metrics * 'Outcome, 'Metrics * 'Outcome, 'Metrics * exn>(itemDispatcher, project, interpretProgress, stats, dumpStreams)
-            StreamSchedulingEngine<_, _, _>(dispatcher, ?maxBatches=maxBatches, ?idleDelay=idleDelay, ?enableSlipstreaming=enableSlipstreaming)
+            StreamSchedulingEngine<_, _, _>(dispatcher, ?maxBatches=maxBatches, ?idleDelay=idleDelay, ?purgeInterval=purgeInterval, ?enableSlipstreaming=enableSlipstreaming)
 
-        static member Create(dispatcher, ?maxBatches, ?idleDelay, ?enableSlipstreaming)
+        static member Create(dispatcher, ?maxBatches, ?idleDelay, ?purgeInterval, ?enableSlipstreaming)
             : StreamSchedulingEngine<int64 * ('Metrics * unit), 'Stats * unit, 'Stats * exn> =
-            StreamSchedulingEngine<_, _, _>(dispatcher, ?maxBatches=maxBatches, ?idleDelay=idleDelay, ?enableSlipstreaming=enableSlipstreaming)
+            StreamSchedulingEngine<_, _, _>(dispatcher, ?maxBatches=maxBatches, ?idleDelay=idleDelay, ?purgeInterval=purgeInterval, ?enableSlipstreaming=enableSlipstreaming)
 
 module Projector =
 
@@ -967,7 +980,10 @@ type StreamsProjector =
             prepare, handle, toIndex,
             stats, statsInterval, ?pumpInterval,
             /// Tune the sleep time when there are no items to schedule or responses to process. Default 1ms.
-            ?idleDelay)
+            ?idleDelay,
+            /// Frequency with which to jettison Write Position information for inactive streams in order to limit memory consumption
+            /// NOTE: Can impair performance and/or increase costs of writes as it inhibits the ability of the ingester to discard redundant inputs
+            ?purgeInterval)
         : ProjectorPipeline<_> =
         let dispatcher = Scheduling.ItemDispatcher<_>(maxConcurrentStreams)
         let streamScheduler =
@@ -975,34 +991,44 @@ type StreamsProjector =
                 (   dispatcher, stats,
                     prepare, handle, toIndex,
                     (fun s l -> s.Dump(l, Buffering.StreamState.eventsSize)),
-                    ?idleDelay=idleDelay)
+                    ?idleDelay=idleDelay, ?purgeInterval=purgeInterval)
         Projector.StreamsProjectorPipeline.Start(log, dispatcher.Pump(), streamScheduler.Pump, maxReadAhead, streamScheduler.Submit, statsInterval, ?pumpInterval=pumpInterval)
 
     /// Project StreamSpans using a <code>handle</code> function that yields a Write Position representing the next event that's to be handled on this Stream
     static member Start<'Outcome>
         (   log : ILogger, maxReadAhead, maxConcurrentStreams,
             handle : StreamName * StreamSpan<_> -> Async<SpanResult * 'Outcome>,
-            stats, statsInterval,
+            stats, statsInterval, ?pumpInterval,
             /// Tune the sleep time when there are no items to schedule or responses to process. Default 1ms.
-            ?idleDelay, ?pumpInterval)
+            ?idleDelay,
+            /// Frequency with which to jettison Write Position information for inactive streams in order to limit memory consumption
+            /// NOTE: Can impair performance and/or increase costs of writes as it inhibits the ability of the ingester to discard redundant inputs
+            ?purgeInterval)
         : ProjectorPipeline<_> =
         let prepare (streamName, span) =
             let stats = Buffering.StreamSpan.stats span
             stats, (streamName, span)
-        StreamsProjector.StartEx<SpanResult, 'Outcome>(log, maxReadAhead, maxConcurrentStreams, prepare, handle, SpanResult.toIndex, stats, statsInterval, ?pumpInterval=pumpInterval, ?idleDelay=idleDelay)
+        StreamsProjector.StartEx<SpanResult, 'Outcome>
+            (   log, maxReadAhead, maxConcurrentStreams, prepare, handle, SpanResult.toIndex, stats, statsInterval,
+                ?pumpInterval=pumpInterval, ?idleDelay=idleDelay, ?purgeInterval=purgeInterval)
 
     /// Project StreamSpans using a <code>handle</code> function that guarantees to always handles all events in the <code>span</code>
     static member Start<'Outcome>
         (   log : ILogger, maxReadAhead, maxConcurrentStreams,
             handle : StreamName * StreamSpan<_> -> Async<'Outcome>,
-            stats, statsInterval, ?pumpInterval,
+            stats, statsInterval, pumpInterval,
             /// Tune the sleep time when there are no items to schedule or responses to process. Default 1ms.
-            ?idleDelay)
+            ?idleDelay,
+            /// Frequency with which to jettison Write Position information for inactive streams in order to limit memory consumption
+            /// NOTE: Can impair performance and/or increase costs of writes as it inhibits the ability of the ingester to discard redundant inputs
+            ?purgeInterval)
         : ProjectorPipeline<_> =
         let handle (streamName, span : StreamSpan<_>) = async {
             let! res = handle (streamName, span)
             return SpanResult.AllProcessed, res }
-        StreamsProjector.Start<'Outcome>(log, maxReadAhead, maxConcurrentStreams, handle, stats, statsInterval, ?pumpInterval=pumpInterval, ?idleDelay=idleDelay)
+        StreamsProjector.Start<'Outcome>
+            (   log, maxReadAhead, maxConcurrentStreams, handle, stats, statsInterval,
+                ?pumpInterval=pumpInterval, ?idleDelay=idleDelay, ?purgeInterval=purgeInterval)
 
 module Sync =
 
@@ -1056,7 +1082,10 @@ module Sync =
                 /// Max inner cycles per loop. Default 128.
                 ?maxCycles,
                 /// Hook to wire in external stats
-                ?dumpExternalStats)
+                ?dumpExternalStats,
+                /// Frequency with which to jettison Write Position information for inactive streams in order to limit memory consumption
+                /// NOTE: Can impair performance and/or increase costs of writes as it inhibits the ability of the ingester to discard redundant inputs
+                ?purgeInterval)
             : ProjectorPipeline<_> =
 
             let maxBatches, maxEvents, maxBytes = defaultArg maxBatches 128, defaultArg maxEvents 16384, (defaultArg maxBytes (1024 * 1024 - (*fudge*)4096))
@@ -1085,7 +1114,7 @@ module Sync =
             let dispatcher = Scheduling.MultiDispatcher<_, _, _>(itemDispatcher, attemptWrite, interpretWriteResultProgress, stats, dumpStreams)
             let streamScheduler =
                 Scheduling.StreamSchedulingEngine<int64 * (EventMetrics * TimeSpan) * 'Outcome, (EventMetrics * TimeSpan) * 'Outcome, EventMetrics * exn>
-                    (   dispatcher, maxBatches=maxBatches, maxCycles=defaultArg maxCycles 128, ?idleDelay=idleDelay)
+                    (   dispatcher, maxBatches=maxBatches, maxCycles=defaultArg maxCycles 128, ?idleDelay=idleDelay, ?purgeInterval=purgeInterval)
 
             Projector.StreamsProjectorPipeline.Start(
                 log, itemDispatcher.Pump(), streamScheduler.Pump, maxReadAhead, streamScheduler.Submit, statsInterval, maxSubmissionsPerPartition=maxBatches, ?pumpInterval=pumpInterval)


### PR DESCRIPTION
Follow-up to #93 that periodically purges memory consumed by write positions for streams that don't presently have items queued for them.

This can be particularly valuable in constrained memory scenarios, i.e. containers etc.

However, there can be significant negatives to inhibiting the deduplication facility in any way:
- reduced throughput as a result of additional handler calls
- greater load placed on downstream/partner systems, i.e. more roundtrips to databases only to discover the work is redundant
- (where the handler is a producer that has no way of knowing the write position and/or determining whether an event is a repeat that made it through deduplication) redundant messages being produced, with impacts on downstream systems, storage cost or throughput

For these reasons, pruning is not enabled by default.