### PR TITLE
Purge interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 
+- Streams Scheduler: Add `purgeInterval` [#97](https://github.com/jet/propulsion/pull/97)
 - `Propulsion.EventStoreDb`: Ported `EventStore` to target `Equinox.EventStore` >= `4.0.0` (using the gRPC interface)  [#139](https://github.com/jet/propulsion/pull/139)
 - `Propulsion.CosmosStore3`: Special cased version of `Propulsion.CosmosStore` to target `Equinox.CosmosStore` v `[3.0.7`-`3.99.0]` **Deprecated; Please migrate to `Propulsion.CosmosStore` by updating `Equinox.CosmosStore` dependencies to `4.0.0`** [#139](https://github.com/jet/propulsion/pull/139)
 - `Propulsion.DynamoStore`: `Equinox.CosmosStore`-equivalent functionality for `Equinox.DynamoStore`. Combines elements of `CosmosStore`, `SqlStreamStore`, `Feed` [#140](https://github.com/jet/propulsion/pull/140)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - `Kafka`: Target `FsCodec.NewtonsoftJson` v `3.0.0` [#139](https://github.com/jet/propulsion/pull/139)
 
 ### Removed
+
+- `Destructurama.FSharp` dependency [#152](https://github.com/jet/propulsion/pull/152)
+
 ### Fixed
 
 - `Propulsion.SqlStreamStore`: Replaced incorrect/meaningless stream name for `SqlStreamStoreSource` [#139](https://github.com/jet/propulsion/pull/139)

--- a/src/Propulsion.Cosmos/CosmosPruner.fs
+++ b/src/Propulsion.Cosmos/CosmosPruner.fs
@@ -99,13 +99,13 @@ module Pruner =
 
     type StreamSchedulingEngine =
 
-        static member Create(pruneUntil, itemDispatcher, stats : Stats, dumpStreams, ?maxBatches, ?idleDelay)
+        static member Create(pruneUntil, itemDispatcher, stats : Stats, dumpStreams, ?maxBatches, ?idleDelay, ?purgeInterval)
             : Scheduling.StreamSchedulingEngine<_, _, _> =
             let interpret (stream, span) =
                 let stats = Buffering.StreamSpan.stats span
                 stats, (stream, span)
             let dispatcher = Scheduling.MultiDispatcher<_, _, _>.Create(itemDispatcher, handle pruneUntil, interpret, (fun _ -> id), stats, dumpStreams)
-            Scheduling.StreamSchedulingEngine(dispatcher, enableSlipstreaming=false, ?maxBatches=maxBatches, ?idleDelay=idleDelay)
+            Scheduling.StreamSchedulingEngine(dispatcher, enableSlipstreaming=false, ?maxBatches=maxBatches, ?idleDelay=idleDelay, ?purgeInterval=purgeInterval)
 
 /// DANGER: <c>CosmosPruner</c> DELETES events - use with care
 type CosmosPruner =
@@ -119,7 +119,10 @@ type CosmosPruner =
             // Default 5m
             ?stateInterval, ?ingesterStatsInterval, ?maxSubmissionsPerPartition, ?pumpInterval,
             // Delay when no items available. Default 10ms.
-            ?idleDelay)
+            ?idleDelay,
+            // Frequency with which to jettison Write Position information for inactive streams in order to limit memory consumption
+            // NOTE: Can impair performance and/or increase costs of writes as it inhibits the ability of the ingester to discard redundant inputs
+            ?purgeInterval)
         : Propulsion.ProjectorPipeline<_> =
         let idleDelay = defaultArg idleDelay (TimeSpan.FromMilliseconds 10.)
         let statsInterval, stateInterval = defaultArg statsInterval (TimeSpan.FromMinutes 5.), defaultArg stateInterval (TimeSpan.FromMinutes 5.)
@@ -127,7 +130,7 @@ type CosmosPruner =
         let dispatcher = Propulsion.Streams.Scheduling.ItemDispatcher<_>(maxConcurrentStreams)
         let dumpStreams (s : Scheduling.StreamStates<_>) l = s.Dump(l, Propulsion.Streams.Buffering.StreamState.eventsSize)
         let pruneUntil stream index = Equinox.Cosmos.Core.Events.pruneUntil context stream index
-        let streamScheduler = Pruner.StreamSchedulingEngine.Create(pruneUntil, dispatcher, stats, dumpStreams, idleDelay=idleDelay)
+        let streamScheduler = Pruner.StreamSchedulingEngine.Create(pruneUntil, dispatcher, stats, dumpStreams, idleDelay=idleDelay, ?purgeInterval=purgeInterval)
         Propulsion.Streams.Projector.StreamsProjectorPipeline.Start(
             log, dispatcher.Pump(), streamScheduler.Pump, maxReadAhead, streamScheduler.Submit, statsInterval,
             ?ingesterStatsInterval=ingesterStatsInterval, ?maxSubmissionsPerPartition=maxSubmissionsPerPartition, ?pumpInterval=pumpInterval)

--- a/src/Propulsion.Cosmos/CosmosSink.fs
+++ b/src/Propulsion.Cosmos/CosmosSink.fs
@@ -172,7 +172,6 @@ type CosmosSink =
             ?ingesterStatsInterval, ?maxSubmissionsPerPartition, ?pumpInterval,
             // Tune the sleep time when there are no items to schedule or responses to process. Default 1ms.
             ?idleDelay,
-            // Default: 16384
             // Frequency with which to jettison Write Position information for inactive streams in order to limit memory consumption
             // NOTE: Can impair performance and/or increase costs of writes as it inhibits the ability of the ingester to discard redundant inputs
             ?purgeInterval,

--- a/src/Propulsion.Cosmos/CosmosSink.fs
+++ b/src/Propulsion.Cosmos/CosmosSink.fs
@@ -133,7 +133,7 @@ module Internal =
 
     type StreamSchedulingEngine =
 
-        static member Create(log : ILogger, cosmosContexts : _ [], itemDispatcher, stats : Stats, dumpStreams, ?maxBatches, ?idleDelay, ?maxEvents, ?maxBytes)
+        static member Create(log : ILogger, cosmosContexts : _ [], itemDispatcher, stats : Stats, dumpStreams, ?maxBatches, ?idleDelay, ?purgeInterval, ?maxEvents, ?maxBytes)
             : Scheduling.StreamSchedulingEngine<_, _, _> =
             let maxEvents, maxBytes = defaultArg maxEvents 16384, defaultArg maxBytes (1024 * 1024 - (*fudge*)4096)
             let writerResultLog = log.ForContext<Writer.Result>()
@@ -158,7 +158,7 @@ module Internal =
                 Writer.logTo writerResultLog malformed (stream, res)
                 ss.Write, res
             let dispatcher = Scheduling.MultiDispatcher<_, _, _>.Create(itemDispatcher, attemptWrite, interpretWriteResultProgress, stats, dumpStreams)
-            Scheduling.StreamSchedulingEngine(dispatcher, enableSlipstreaming=true, ?maxBatches=maxBatches, ?idleDelay=idleDelay)
+            Scheduling.StreamSchedulingEngine(dispatcher, enableSlipstreaming=true, ?maxBatches=maxBatches, ?idleDelay=idleDelay, ?purgeInterval=purgeInterval)
 
 type CosmosSink =
 
@@ -173,6 +173,10 @@ type CosmosSink =
             // Tune the sleep time when there are no items to schedule or responses to process. Default 1ms.
             ?idleDelay,
             // Default: 16384
+            // Frequency with which to jettison Write Position information for inactive streams in order to limit memory consumption
+            // NOTE: Can impair performance and/or increase costs of writes as it inhibits the ability of the ingester to discard redundant inputs
+            ?purgeInterval,
+            // Default: 16384
             ?maxEvents,
             // Default: 1MB (limited by maximum size of a CosmosDB stored procedure invocation)
             ?maxBytes)
@@ -181,7 +185,7 @@ type CosmosSink =
         let stats = Internal.Stats(log.ForContext<Internal.Stats>(), statsInterval, stateInterval)
         let dispatcher = Propulsion.Streams.Scheduling.ItemDispatcher<_>(maxConcurrentStreams)
         let dumpStreams (s : Scheduling.StreamStates<_>) l = s.Dump(l, Propulsion.Streams.Buffering.StreamState.eventsSize)
-        let streamScheduler = Internal.StreamSchedulingEngine.Create(log, cosmosContexts, dispatcher, stats, dumpStreams, ?idleDelay=idleDelay, ?maxEvents=maxEvents, ?maxBytes=maxBytes)
+        let streamScheduler = Internal.StreamSchedulingEngine.Create(log, cosmosContexts, dispatcher, stats, dumpStreams, ?idleDelay=idleDelay, ?purgeInterval=purgeInterval, ?maxEvents=maxEvents, ?maxBytes=maxBytes)
         Propulsion.Streams.Projector.StreamsProjectorPipeline.Start(
             log, dispatcher.Pump(), streamScheduler.Pump, maxReadAhead, streamScheduler.Submit, statsInterval,
             ?ingesterStatsInterval=ingesterStatsInterval, ?maxSubmissionsPerPartition=maxSubmissionsPerPartition, ?pumpInterval=pumpInterval)

--- a/src/Propulsion.EventStore/EventStoreSink.fs
+++ b/src/Propulsion.EventStore/EventStoreSink.fs
@@ -133,7 +133,7 @@ module Internal =
         default _.HandleExn(_, _) : unit = ()
 
     type EventStoreSchedulingEngine =
-        static member Create(log : ILogger, storeLog, connections : _ [], itemDispatcher, stats : Stats, dumpStreams, ?maxBatches, ?idleDelay)
+        static member Create(log : ILogger, storeLog, connections : _ [], itemDispatcher, stats : Stats, dumpStreams, ?maxBatches, ?idleDelay, ?purgeInterval)
             : Scheduling.StreamSchedulingEngine<_, _, _> =
             let writerResultLog = log.ForContext<Writer.Result>()
             let mutable robin = 0
@@ -162,7 +162,7 @@ module Internal =
                 ss.Write, res
 
             let dispatcher = Scheduling.MultiDispatcher<_, _, _>.Create(itemDispatcher, attemptWrite, interpretWriteResultProgress, stats, dumpStreams)
-            Scheduling.StreamSchedulingEngine(dispatcher, enableSlipstreaming=true, ?maxBatches=maxBatches, ?idleDelay=idleDelay)
+            Scheduling.StreamSchedulingEngine(dispatcher, enableSlipstreaming=true, ?maxBatches=maxBatches, ?idleDelay=idleDelay, ?purgeInterval=purgeInterval)
 
 type EventStoreSink =
 
@@ -174,13 +174,16 @@ type EventStoreSink =
             // Default 5m
             ?stateInterval, ?ingesterStatsInterval, ?maxSubmissionsPerPartition, ?pumpInterval,
             // Tune the sleep time when there are no items to schedule or responses to process. Default 1ms.
-            ?idleDelay)
+            ?idleDelay,
+            // Frequency with which to jettison Write Position information for inactive streams in order to limit memory consumption
+            // NOTE: Can impair performance and/or increase costs of writes as it inhibits the ability of the ingester to discard redundant inputs
+            ?purgeInterval)
         : Propulsion.ProjectorPipeline<_> =
         let statsInterval, stateInterval = defaultArg statsInterval (TimeSpan.FromMinutes 5.), defaultArg stateInterval (TimeSpan.FromMinutes 5.)
         let stats = Internal.Stats(log.ForContext<Internal.Stats>(), statsInterval, stateInterval)
         let dispatcher = Propulsion.Streams.Scheduling.ItemDispatcher<_>(maxConcurrentStreams)
         let dumpStats (s : Scheduling.StreamStates<_>) l = s.Dump(l, Propulsion.Streams.Buffering.StreamState.eventsSize)
-        let streamScheduler = Internal.EventStoreSchedulingEngine.Create(log, storeLog, connections, dispatcher, stats, dumpStats, ?idleDelay=idleDelay)
+        let streamScheduler = Internal.EventStoreSchedulingEngine.Create(log, storeLog, connections, dispatcher, stats, dumpStats, ?idleDelay=idleDelay, ?purgeInterval=purgeInterval)
         Propulsion.Streams.Projector.StreamsProjectorPipeline.Start(
             log, dispatcher.Pump(), streamScheduler.Pump, maxReadAhead, streamScheduler.Submit, statsInterval,
             ?ingesterStatsInterval=ingesterStatsInterval, ?maxSubmissionsPerPartition=maxSubmissionsPerPartition, ?pumpInterval=pumpInterval)

--- a/src/Propulsion.Kafka/Consumers.fs
+++ b/src/Propulsion.Kafka/Consumers.fs
@@ -90,7 +90,7 @@ type KafkaIngestionEngine<'Info>
         let tp = result.TopicPartition
         let span =
             match acc.TryGetValue tp with
-            | false, _ -> let span = PartitionBuffer<'Info>.Create(sz, result, mapMessage) in acc.[tp] <- span; span
+            | false, _ -> let span = PartitionBuffer<'Info>.Create(sz, result, mapMessage) in acc[tp] <- span; span
             | true, span -> span.Enqueue(sz, result, mapMessage); span
         if span.messages.Count = maxBatchSize then
             acc.Remove tp |> ignore
@@ -234,12 +234,12 @@ module Core =
             (   log : ILogger, config : KafkaConsumerConfig, resultToInfo, infoToStreamEvents,
                 prepare, handle, maxDop,
                 stats : Streams.Scheduling.Stats<EventMetrics * 'Outcome, EventMetrics * exn>, statsInterval,
-                ?maxSubmissionsPerPartition, ?pumpInterval, ?logExternalState, ?idleDelay, ?maxBatches, ?maximizeOffsetWriting) =
+                ?maxSubmissionsPerPartition, ?pumpInterval, ?logExternalState, ?idleDelay, ?purgeInterval, ?maxBatches, ?maximizeOffsetWriting) =
             let dispatcher = Streams.Scheduling.ItemDispatcher<_> maxDop
             let dumpStreams (streams : Streams.Scheduling.StreamStates<_>) log =
                 logExternalState |> Option.iter (fun f -> f log)
                 streams.Dump(log, Streams.Buffering.StreamState.eventsSize)
-            let streamsScheduler = Streams.Scheduling.StreamSchedulingEngine.Create<_, _, _>(dispatcher, stats, prepare, handle, Streams.SpanResult.toIndex, dumpStreams, ?idleDelay=idleDelay, ?maxBatches=maxBatches)
+            let streamsScheduler = Streams.Scheduling.StreamSchedulingEngine.Create<_, _, _>(dispatcher, stats, prepare, handle, Streams.SpanResult.toIndex, dumpStreams, ?idleDelay=idleDelay, ?purgeInterval=purgeInterval, ?maxBatches=maxBatches)
             let mapConsumedMessagesToStreamsBatch onCompletion (x : Submission.SubmissionBatch<TopicPartition, 'Info>) : Streams.Scheduling.StreamsBatch<_> =
                 let onCompletion () = x.onCompletion(); onCompletion()
                 Streams.Scheduling.StreamsBatch.Create(onCompletion, Seq.collect infoToStreamEvents x.messages) |> fst
@@ -255,7 +255,7 @@ module Core =
             (   log : ILogger, config : KafkaConsumerConfig, consumeResultToInfo, infoToStreamEvents,
                 handle : StreamName * Streams.StreamSpan<_> -> Async<Streams.SpanResult * 'Outcome>, maxDop,
                 stats : Streams.Scheduling.Stats<EventMetrics * 'Outcome, EventMetrics * exn>, statsInterval,
-                ?maxSubmissionsPerPartition, ?pumpInterval, ?logExternalState, ?idleDelay, ?maxBatches, ?maximizeOffsetWriting) =
+                ?maxSubmissionsPerPartition, ?pumpInterval, ?logExternalState, ?idleDelay, ?purgeInterval, ?maxBatches, ?maximizeOffsetWriting) =
             let prepare (streamName, span) =
                 let stats = Streams.Buffering.StreamSpan.stats span
                 stats, (streamName, span)
@@ -265,7 +265,7 @@ module Core =
                 ?maxSubmissionsPerPartition=maxSubmissionsPerPartition,
                 ?pumpInterval=pumpInterval,
                 ?logExternalState=logExternalState,
-                ?idleDelay=idleDelay,
+                ?idleDelay=idleDelay, ?purgeInterval=purgeInterval,
                 ?maxBatches=maxBatches,
                 ?maximizeOffsetWriting=maximizeOffsetWriting)
 
@@ -282,14 +282,14 @@ module Core =
                 prepare, handle : StreamName * Streams.StreamSpan<_> -> Async<Streams.SpanResult * 'Outcome>,
                 maxDop,
                 stats : Streams.Scheduling.Stats<EventMetrics * 'Outcome, EventMetrics * exn>, statsInterval,
-                ?maximizeOffsetWriting, ?maxSubmissionsPerPartition, ?pumpInterval, ?logExternalState, ?idleDelay)=
+                ?maximizeOffsetWriting, ?maxSubmissionsPerPartition, ?pumpInterval, ?logExternalState, ?idleDelay, ?purgeInterval)=
             StreamsConsumer.Start<KeyValuePair<string, string>, 'Outcome>(
                 log, config, Binding.mapConsumeResult, keyValueToStreamEvents, prepare, handle, maxDop,
                 stats, statsInterval=statsInterval,
                 ?maxSubmissionsPerPartition=maxSubmissionsPerPartition,
                 ?pumpInterval=pumpInterval,
                 ?logExternalState=logExternalState,
-                ?idleDelay=idleDelay,
+                ?idleDelay=idleDelay, ?purgeInterval=purgeInterval,
                 ?maximizeOffsetWriting=maximizeOffsetWriting)
 
         /// Starts a Kafka Consumer running spans of events per stream through the `handle` function to `maxDop` concurrently
@@ -299,14 +299,14 @@ module Core =
                 keyValueToStreamEvents : KeyValuePair<string, string> -> Propulsion.Streams.StreamEvent<_> seq,
                 handle : StreamName * Streams.StreamSpan<_> -> Async<Streams.SpanResult * 'Outcome>, maxDop,
                 stats : Streams.Scheduling.Stats<EventMetrics * 'Outcome, EventMetrics * exn>, statsInterval,
-                ?maximizeOffsetWriting, ?maxSubmissionsPerPartition, ?pumpInterval, ?logExternalState, ?idleDelay, ?maxBatches) =
+                ?maximizeOffsetWriting, ?maxSubmissionsPerPartition, ?pumpInterval, ?logExternalState, ?idleDelay, ?purgeInterval, ?maxBatches) =
             StreamsConsumer.Start<KeyValuePair<string, string>, 'Outcome>(
                 log, config, Binding.mapConsumeResult, keyValueToStreamEvents, handle, maxDop,
                 stats, statsInterval,
                 ?maxSubmissionsPerPartition=maxSubmissionsPerPartition,
                 ?pumpInterval=pumpInterval,
                 ?logExternalState=logExternalState,
-                ?idleDelay=idleDelay,
+                ?idleDelay=idleDelay, ?purgeInterval=purgeInterval,
                 ?maxBatches=maxBatches,
                 ?maximizeOffsetWriting=maximizeOffsetWriting)
 
@@ -429,6 +429,9 @@ type StreamsConsumer =
             ?maxSubmissionsPerPartition, ?pumpInterval, ?logExternalState,
             // Tune the sleep time when there are no items to schedule or responses to process. Default 1ms.
             ?idleDelay,
+            // Frequency with which to jettison Write Position information for inactive streams in order to limit memory consumption
+            // NOTE: Can impair performance and/or increase costs of writes as it inhibits the ability of the ingester to discard redundant inputs
+            ?purgeInterval,
             ?maxBatches) =
         Core.StreamsConsumer.Start<ConsumeResult<_, _>, 'Outcome>(
             log, config, id, consumeResultToStreamEvents, handle, maxDop,
@@ -436,7 +439,7 @@ type StreamsConsumer =
             ?maxSubmissionsPerPartition=maxSubmissionsPerPartition,
             ?pumpInterval=pumpInterval,
             ?logExternalState=logExternalState,
-            ?idleDelay=idleDelay,
+            ?idleDelay=idleDelay, ?purgeInterval=purgeInterval,
             ?maxBatches=maxBatches,
             ?maximizeOffsetWriting=maximizeOffsetWriting)
 
@@ -473,7 +476,10 @@ type BatchesConsumer =
             ?pumpInterval,
             ?logExternalState,
             // Tune the sleep time when there are no items to schedule or responses to process. Default 1ms.
-            ?idleDelay) =
+            ?idleDelay,
+            // Frequency with which to jettison Write Position information for inactive streams in order to limit memory consumption
+            // NOTE: Can impair performance and/or increase costs of writes as it inhibits the ability of the ingester to discard redundant inputs
+            ?purgeInterval) =
         let maxBatches = defaultArg schedulerIngestionBatchCount 24
         let dumpStreams (streams : Streams.Scheduling.StreamStates<_>) log =
             logExternalState |> Option.iter (fun f -> f log)
@@ -503,7 +509,7 @@ type BatchesConsumer =
                         let s = Streams.Buffering.StreamSpan.stats x.span
                         ae, x.stream, false, Choice2Of2 (s, e) |] }
         let dispatcher = Streams.Scheduling.BatchedDispatcher(select, handle, stats, dumpStreams)
-        let streamsScheduler = Streams.Scheduling.StreamSchedulingEngine.Create(dispatcher, ?idleDelay=idleDelay, maxBatches=maxBatches)
+        let streamsScheduler = Streams.Scheduling.StreamSchedulingEngine.Create(dispatcher, ?idleDelay=idleDelay, ?purgeInterval=purgeInterval, maxBatches=maxBatches)
         let mapConsumedMessagesToStreamsBatch onCompletion (x : Submission.SubmissionBatch<TopicPartition, 'Info>) : Streams.Scheduling.StreamsBatch<_> =
             let onCompletion () = x.onCompletion(); onCompletion()
             Streams.Scheduling.StreamsBatch.Create(onCompletion, Seq.collect infoToStreamEvents x.messages) |> fst

--- a/src/Propulsion.Kafka/ProducerSinks.fs
+++ b/src/Propulsion.Kafka/ProducerSinks.fs
@@ -24,6 +24,9 @@ type StreamsProducerSink =
             stats : Sync.Stats<'Outcome>, statsInterval,
             // Default 1 ms
             ?idleDelay,
+            // Frequency with which to jettison Write Position information for inactive streams in order to limit memory consumption
+            // NOTE: Can impair performance and/or increase costs of writes as it inhibits the ability of the ingester to discard redundant inputs
+            ?purgeInterval,
             // Default 1 MiB
             ?maxBytes,
             // Default 16384
@@ -48,7 +51,7 @@ type StreamsProducerSink =
             Sync.StreamsSync.Start
                 (    log, maxReadAhead, maxConcurrentStreams, handle,
                      stats, statsInterval=statsInterval,
-                     maxBytes=maxBytes, ?idleDelay=idleDelay,
+                     maxBytes=maxBytes, ?idleDelay=idleDelay,?purgeInterval=purgeInterval,
                      ?maxEvents=maxEvents, ?maxBatches=maxBatches, ?maxCycles=maxCycles, dumpExternalStats=producer.DumpStats)
 
    static member Start
@@ -58,6 +61,9 @@ type StreamsProducerSink =
             stats : Sync.Stats<unit>, statsInterval,
             // Default 1 ms
             ?idleDelay,
+            // Frequency with which to jettison Write Position information for inactive streams in order to limit memory consumption
+            // NOTE: Can impair performance and/or increase costs of writes as it inhibits the ability of the ingester to discard redundant inputs
+            ?purgeInterval,
             // Default 1 MiB
             ?maxBytes,
             // Default 16384
@@ -74,5 +80,5 @@ type StreamsProducerSink =
             StreamsProducerSink.Start
                 (    log, maxReadAhead, maxConcurrentStreams, prepare, producer,
                      stats, statsInterval,
-                     ?idleDelay=idleDelay, ?maxBytes=maxBytes,
+                     ?idleDelay=idleDelay, ?purgeInterval=purgeInterval, ?maxBytes=maxBytes,
                      ?maxEvents=maxEvents, ?maxBatches=maxBatches, ?maxCycles=maxCycles)

--- a/src/Propulsion/Parallel.fs
+++ b/src/Propulsion/Parallel.fs
@@ -98,10 +98,10 @@ module Scheduling =
         let dumpStats () =
             let startedB, completedB = Array.ofSeq startedBatches.StatsDescending, Array.ofSeq completedBatches.StatsDescending
             let startedI, completedI = Array.ofSeq startedItems.StatsDescending, Array.ofSeq completedItems.StatsDescending
-            let totalItemsCompleted = Array.sumBy snd completedI
+            let totalItemsCompleted = statsTotal completedI
             let latencyMs = match totalItemsCompleted with 0L -> null | cnt -> box (processingDuration.TotalMilliseconds / float cnt)
             log.Information("Scheduler {cycles} cycles Started {startedBatches}b {startedItems}i Completed {completedBatches}b {completedItems}i latency {completedLatency:f1}ms Ready {readyitems} Waiting {waitingBatches}b",
-                cycles, Array.sumBy snd startedB, Array.sumBy snd startedI, Array.sumBy snd completedB, totalItemsCompleted, latencyMs, waiting.Count, incoming.Count)
+                cycles, statsTotal startedB, statsTotal startedI, statsTotal completedB, totalItemsCompleted, latencyMs, waiting.Count, incoming.Count)
             let active =
                 seq { for KeyValue(pid,q) in active -> pid, q |> Seq.sumBy (fun x -> x.remaining) }
                 |> Seq.filter (fun (_,snd) -> snd <> 0)

--- a/src/Propulsion/Streams.fs
+++ b/src/Propulsion/Streams.fs
@@ -971,7 +971,7 @@ module Scheduling =
                         let remaining, purged = streams.Purge()
                         totalPurged <- totalPurged + purged
                         let l = if purged = 0 then Events.LogEventLevel.Debug else Events.LogEventLevel.Information
-                        Log.Write(l, "Streams buffered {buffered} Purged now {count} Purged total {total}", remaining, purged, totalPurged)
+                        Log.Write(l, "Streams buffered {buffered:n0} Purged now {count:n0} Purged total {total:n0}", remaining, purged, totalPurged)
                     | _ -> ()
                 elif idle then
                     // 4. Do a minimal sleep so we don't run completely hot when empty (unless we did something non-trivial)

--- a/src/Propulsion/Streams.fs
+++ b/src/Propulsion/Streams.fs
@@ -312,7 +312,7 @@ module Buffering =
                 | Some w -> w
             { write = effWrite; queue = queue }
         member x.IsEmpty = obj.ReferenceEquals(null, x.queue)
-        member x.IsPurgeable = not x.IsMalformed && x.IsEmpty
+        member x.IsPurgeable = x.IsEmpty && not x.IsMalformed
         member x.IsMalformed = not x.IsEmpty && -3L = x.write
         member x.HasValid = not x.IsEmpty && not x.IsMalformed
         member x.Write = match x.write with -2L -> None | x -> Some x
@@ -845,8 +845,8 @@ module Scheduling =
             ?maxCycles,
             // Tune the sleep time when there are no items to schedule or responses to process. Default 1ms.
             ?idleDelay,
-            // Frequency with which to jettison Write Position information for inactive streams in order to limit memory consumption
-            // NOTE: Can impair performance and/or increase costs of writes as it inhibits the ability of the ingester to discard redundant inputs
+            // Frequency of jettisoning Write Position state of inactive streams (held by the scheduler for deduplication purposes) to limit memory consumption
+            // NOTE: Purging can impair performance, increase write costs or result in duplicate event emissions due to redundant inputs not being deduplicated
             ?purgeInterval,
             // Opt-in to allowing items to be processed independent of batch sequencing - requires upstream/projection function to be able to identify gaps. Default false.
             ?enableSlipstreaming) =
@@ -1107,8 +1107,8 @@ type StreamsProjector =
             ?maxSubmissionsPerPartition, ?pumpInterval,
             // Tune the sleep time when there are no items to schedule or responses to process. Default 1ms.
             ?idleDelay,
-            // Frequency with which to jettison Write Position information for inactive streams in order to limit memory consumption
-            // NOTE: Can impair performance and/or increase costs of writes as it inhibits the ability of the ingester to discard redundant inputs
+            // Frequency of jettisoning Write Position state of inactive streams (held by the scheduler for deduplication purposes) to limit memory consumption
+            // NOTE: Purging can impair performance, increase write costs or result in duplicate event emissions due to redundant inputs not being deduplicated
             ?purgeInterval)
         : ProjectorPipeline<_> =
         let dispatcher = Scheduling.ItemDispatcher<_>(maxConcurrentStreams)
@@ -1135,8 +1135,8 @@ type StreamsProjector =
             ?pumpInterval,
             // Tune the sleep time when there are no items to schedule or responses to process. Default 1ms.
             ?idleDelay,
-            // Frequency with which to jettison Write Position information for inactive streams in order to limit memory consumption
-            // NOTE: Can impair performance and/or increase costs of writes as it inhibits the ability of the ingester to discard redundant inputs
+            // Frequency of jettisoning Write Position state of inactive streams (held by the scheduler for deduplication purposes) to limit memory consumption
+            // NOTE: Purging can impair performance, increase write costs or result in duplicate event emissions due to redundant inputs not being deduplicated
             ?purgeInterval)
         : ProjectorPipeline<_> =
         let prepare (streamName, span) =
@@ -1158,8 +1158,8 @@ type StreamsProjector =
             ?maxSubmissionsPerPartition, ?pumpInterval,
             // Tune the sleep time when there are no items to schedule or responses to process. Default 1ms.
             ?idleDelay,
-            // Frequency with which to jettison Write Position information for inactive streams in order to limit memory consumption
-            // NOTE: Can impair performance and/or increase costs of writes as it inhibits the ability of the ingester to discard redundant inputs
+            // Frequency of jettisoning Write Position state of inactive streams (held by the scheduler for deduplication purposes) to limit memory consumption
+            // NOTE: Purging can impair performance, increase write costs or result in duplicate event emissions due to redundant inputs not being deduplicated
             ?purgeInterval)
         : ProjectorPipeline<_> =
         let handle (streamName, span : StreamSpan<_>) = async {
@@ -1222,8 +1222,8 @@ module Sync =
                 ?maxCycles,
                 // Hook to wire in external stats
                 ?dumpExternalStats,
-                // Frequency with which to jettison Write Position information for inactive streams in order to limit memory consumption
-                // NOTE: Can impair performance and/or increase costs of writes as it inhibits the ability of the ingester to discard redundant inputs
+                // Frequency of jettisoning Write Position state of inactive streams (held by the scheduler for deduplication purposes) to limit memory consumption
+                // NOTE: Purging can impair performance, increase write costs or result in duplicate event emissions due to redundant inputs not being deduplicated
                 ?purgeInterval)
             : ProjectorPipeline<_> =
 

--- a/src/Propulsion/Streams.fs
+++ b/src/Propulsion/Streams.fs
@@ -94,7 +94,7 @@ module Internal =
         member _.Count = cats.Count
         member _.Any = (not << Seq.isEmpty) cats
         member _.Clear() = cats.Clear()
-        member _.StatsDescending = cats |> Seq.sortBy (fun x -> -x.Value) |> Seq.map (|KeyValue|)
+        member _.StatsDescending = Internal.statsDescending cats
 
     type private Data =
         {   min    : TimeSpan

--- a/tests/Propulsion.Kafka.Integration/ConsumersIntegration.fs
+++ b/tests/Propulsion.Kafka.Integration/ConsumersIntegration.fs
@@ -32,7 +32,6 @@ module Helpers =
 
     let createLogger sink =
         LoggerConfiguration()
-            .Destructure.FSharpTypes()
             .WriteTo.Sink(sink)
             .WriteTo.Seq("http://localhost:5341")
             .CreateLogger()

--- a/tests/Propulsion.Kafka.Integration/Propulsion.Kafka.Integration.fsproj
+++ b/tests/Propulsion.Kafka.Integration/Propulsion.Kafka.Integration.fsproj
@@ -16,7 +16,6 @@
 
   <ItemGroup>
 	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="Destructurama.FSharp.NetCore" Version="1.0.14" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="unquote" Version="6.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/tools/Propulsion.Tool/Infrastructure.fs
+++ b/tools/Propulsion.Tool/Infrastructure.fs
@@ -26,7 +26,6 @@ type Logging() =
     [<System.Runtime.CompilerServices.Extension>]
     static member Configure(configuration : LoggerConfiguration, ?verbose) =
         configuration
-            .Destructure.FSharpTypes()
             .Enrich.FromLogContext()
         |> fun c -> if verbose = Some true then c.MinimumLevel.Debug() else c
 

--- a/tools/Propulsion.Tool/Propulsion.Tool.fsproj
+++ b/tools/Propulsion.Tool/Propulsion.Tool.fsproj
@@ -30,7 +30,6 @@
 	<PackageReference Include="Argu" Version="6.1.1" />
     <!-- Required or there'll be an exception at runtime re missing support DLLs when using RBAC -->
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.177" />
-    <PackageReference Include="Destructurama.FSharp.NetCore" Version="1.0.14" />
     <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
   </ItemGroup>


### PR DESCRIPTION
Adds an optional Purge Interval to streams scheduler, which removes synced streams immediately after the state has been emitted