### PR TITLE
Renamespace Streams.Projector.Stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 ### Changed
+
+- Moved `Propulsion.Streams.Projector.Stats` to `Propulsion.Streams.Stats` [#108](https://github.com/jet/propulsion/pull/108)
+
 ### Removed
 ### Fixed
 

--- a/src/Propulsion.Cosmos/CosmosPruner.fs
+++ b/src/Propulsion.Cosmos/CosmosPruner.fs
@@ -26,7 +26,7 @@ module Pruner =
         | Nop of int
 
     type Stats(log, statsInterval, stateInterval) =
-        inherit Propulsion.Streams.Projector.Stats<Outcome>(log, statsInterval, stateInterval)
+        inherit Propulsion.Streams.Stats<Outcome>(log, statsInterval, stateInterval)
 
         let mutable nops, totalRedundant, ops, totalDeletes, totalDeferred = 0, 0, 0, 0, 0
 

--- a/src/Propulsion.CosmosStore/CosmosStorePruner.fs
+++ b/src/Propulsion.CosmosStore/CosmosStorePruner.fs
@@ -24,7 +24,7 @@ module Pruner =
         | Nop of int
 
     type Stats(log, statsInterval, stateInterval) =
-        inherit Propulsion.Streams.Projector.Stats<Outcome>(log, statsInterval, stateInterval)
+        inherit Propulsion.Streams.Stats<Outcome>(log, statsInterval, stateInterval)
 
         let mutable nops, totalRedundant, ops, totalDeletes, totalDeferred = 0, 0, 0, 0, 0
 

--- a/src/Propulsion.EventStore/EventStoreSource.fs
+++ b/src/Propulsion.EventStore/EventStoreSource.fs
@@ -79,7 +79,7 @@ type EventStoreSource =
 
         let ingester = sink.StartIngester(log.ForContext("Tranche", "Ingester"), 0)
 
-        let initialSeriesId, conns, dop =  
+        let initialSeriesId, conns, dop =
             log.Information("Tailing every {intervalS:n1}s TODO with {streamReaders} stream catchup-readers", spec.tailInterval.TotalSeconds, spec.streamReaders)
             match spec.gorge with
             | Some factor ->


### PR DESCRIPTION
This is a breaking change, but a necessary one, as it's existing namespace is highly unintuitive 