### PR TITLE
Kafka: Remove StreamsConsumerStats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,10 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 ### Changed
-
-- `StreamsConsumerStats`: Deprecated [#110](https://github.com/jet/propulsion/pull/110)
-- `StreamsConsumerStats`: Standardized `HandleExn` signature and context [#110](https://github.com/jet/propulsion/pull/110)
-
 ### Removed
+
+- `Kafka.StreamsConsumerStats`: replaced by `Propulsion.Streams.Stats` [#111](https://github.com/jet/propulsion/pull/111)
+
 ### Fixed
 
 <a name="2.10.0-rc9"></a>


### PR DESCRIPTION
Replaced by `Propulsion.Streams.Stats` in order to remove unnecessary variance in metrics