### PR TITLE
Consistently use Reader/partitionId in CFP/Ingester

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 ### Changed
+
+- `Cosmos`: Replace incomplete/inconsistent usage of `partitionKeyRangeId` and `"Range"` with `partitionId` and `"Reader"` in ChangeFeed ingestion path [#112](https://github.com/jet/propulsion/pull/112)
+- `Ingester`: Replace `"Uncommitted" with "Reader" and "Ahead"` terminology, and include `partitionId` in all messages [#112](https://github.com/jet/propulsion/pull/112)
+
 ### Removed
 
 - `Kafka.StreamsConsumerStats`: replaced by `Propulsion.Streams.Stats` [#111](https://github.com/jet/propulsion/pull/111)
@@ -24,8 +28,6 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - `*.Prometheus.LogSink`: Generalized `app` tag to arbitrary custom tags as per Equinox [#287](https://github.com/jet/equinox/issues/287) [#109](https://github.com/jet/propulsion/pull/109) :pray: [@deviousasti](https://github.com/deviousasti)
 
 ### Changed
-
-- `Cosmos`: Add `partitionKeyRangeId` to ChangeFeed Read message
 
 <a name="2.10.0-rc8"></a>
 ## [2.10.0-rc8] - 2021-04-06

--- a/src/Propulsion.Cosmos/CosmosSource.fs
+++ b/src/Propulsion.Cosmos/CosmosSource.fs
@@ -64,8 +64,8 @@ type CosmosSource =
                 database = context.source.database; container = context.source.container; group = context.leasePrefix; rangeId = int ctx.PartitionKeyRangeId
                 token = epoch; latency = sw.Elapsed; rc = rc; age = age; docs = docs.Count
                 ingestLatency = pt.Elapsed; ingestQueued = cur }
-            (log |> Log.metric m).Information("Read {token,9}/{partitionKeyRangeId} age {age:dd\.hh\:mm\:ss} {count,4} docs {requestCharge,6:f1}RU {l,5:f1}s Ingest {pt:f3}s {cur}/{max}",
-                epoch, ctx.PartitionKeyRangeId, age, docs.Count, rc, readS, postS, cur, max)
+            (log |> Log.metric m).Information("Reader {partitionId} {token,9} age {age:dd\.hh\:mm\:ss} {count,4} docs {requestCharge,6:f1}RU {l,5:f1}s Wait {pausedS:f3}s Ahead {cur}/{max}",
+                ctx.PartitionKeyRangeId, epoch, age, docs.Count, rc, readS, postS, cur, max)
             sw.Restart() // restart the clock as we handoff back to the ChangeFeedProcessor
         }
         ChangeFeedObserver.Create(log, ingest, init=init, dispose=dispose)

--- a/src/Propulsion/Parallel.fs
+++ b/src/Propulsion/Parallel.fs
@@ -189,7 +189,7 @@ type ParallelIngester<'Item> =
             let items = Array.ofSeq items
             let batch : Submission.SubmissionBatch<_, 'Item> = { source = partitionId; onCompletion = onCompletion; messages = items }
             batch,(items.Length,items.Length)
-        Ingestion.Ingester<'Item seq,Submission.SubmissionBatch<_, 'Item>>.Start(log, maxRead, makeBatch, submit, ?statsInterval=statsInterval, ?sleepInterval=sleepInterval)
+        Ingestion.Ingester<'Item seq,Submission.SubmissionBatch<_, 'Item>>.Start(log, partitionId, maxRead, makeBatch, submit, ?statsInterval=statsInterval, ?sleepInterval=sleepInterval)
 
 type ParallelProjector =
     static member Start

--- a/src/Propulsion/Streams.fs
+++ b/src/Propulsion/Streams.fs
@@ -915,7 +915,7 @@ module Projector =
                 let streams = HashSet(seq { for x in items -> x.stream })
                 let batch : Submission.SubmissionBatch<_, _> = { source = partitionId; onCompletion = onCompletion; messages = items }
                 batch, (streams.Count, items.Length)
-            Ingestion.Ingester<StreamEvent<_> seq, Submission.SubmissionBatch<_, StreamEvent<_>>>.Start(log, maxRead, makeBatch, submit, ?statsInterval=statsInterval, ?sleepInterval=sleepInterval)
+            Ingestion.Ingester<StreamEvent<_> seq, Submission.SubmissionBatch<_, StreamEvent<_>>>.Start(log, partitionId, maxRead, makeBatch, submit, ?statsInterval=statsInterval, ?sleepInterval=sleepInterval)
 
     type StreamsSubmitter =
 

--- a/tools/Propulsion.Tool/Program.fs
+++ b/tools/Propulsion.Tool/Program.fs
@@ -230,7 +230,7 @@ let main argv =
 
                     if log.IsEnabled LogEventLevel.Debug then log.Debug("Response Headers {0}", let hs = ctx.FeedResponse.ResponseHeaders in [for h in hs -> h, hs.[h]])
                     let r = ctx.FeedResponse
-                    log.Information("{range} Fetch: {token} {requestCharge:n0}RU {count} docs {l:n1}s; Parse: s {streams} e {events} {p:n3}s; Emit: {e:n1}s",
+                    log.Information("Reader {partitionId} {token,9} {requestCharge:n0}RU {count} docs {l:n1}s; Parse: s {streams} e {events} {p:n3}s; Emit: {e:n1}s",
                         ctx.PartitionKeyRangeId, r.ResponseContinuation.Trim[|'"'|], r.RequestCharge, docs.Count, float sw.ElapsedMilliseconds / 1000.,
                         events.Length, (let e = pt.Elapsed in e.TotalSeconds), (let e = et.Elapsed in e.TotalSeconds))
                     sw.Restart() // restart the clock as we handoff back to the CFP


### PR DESCRIPTION
Ingester and Reader output was previously linked by having `partitionKeyRangeId` in the Serilog `ForContext` Properties. However this proves problematic unless one adds a token for that into the general message template.

This PR replaces messages that lean on the `partitionKeyRangeId` and/or messages from the Ingester using the term `"Uncommitted"` with consistent messages prefixes by `"Reader {partitionId}`

Consumers should remove specific reference to `partitionKeyRangeId`