### PR TITLE
CosmosStore: Prepare for V3 port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 ### Changed
+
+- `CosmosStore`: Clean/reorg in preparation for porting to V3 SDK; target `Equinox.CosmosStore` v `3.0.1` [#114](https://github.com/jet/propulsion/pull/114)
+
 ### Removed
 ### Fixed
 

--- a/src/Propulsion.Cosmos/EquinoxCosmosParser.fs
+++ b/src/Propulsion.Cosmos/EquinoxCosmosParser.fs
@@ -17,7 +17,7 @@ open Propulsion.Streams
 #if COSMOSV2 
 module EquinoxCosmosParser =
 #else
-module EquinoxNewtonsoftParser =
+module EquinoxCosmosStoreParser =
 #endif
     type Document with
         member document.Cast<'T>() =

--- a/src/Propulsion.Cosmos/EquinoxCosmosParser.fs
+++ b/src/Propulsion.Cosmos/EquinoxCosmosParser.fs
@@ -1,11 +1,11 @@
-#if COSMOSSTORE
-namespace Propulsion.CosmosStore
-
-open Equinox.CosmosStore.Core
-#else
+#if COSMOSV2
 namespace Propulsion.Cosmos
 
 open Equinox.Cosmos.Store
+#else
+namespace Propulsion.CosmosStore
+
+open Equinox.CosmosStore.Core
 #endif
 
 open Microsoft.Azure.Documents
@@ -14,10 +14,10 @@ open Propulsion.Streams
 /// Maps fields in an Event within an Equinox.Cosmos V1+ Event (in a Batch or Tip) to the interface defined by Propulsion.Streams
 /// <remarks>NOTE No attempt is made to filter out Tip (`id=-1`) batches from the ChangeFeed; Equinox versions >= 3, Tip batches can bear events.</remarks>
 [<RequireQualifiedAccess>]
-#if COSMOSSTORE
-module EquinoxCosmosStoreParser =
-#else
+#if COSMOSV2 
 module EquinoxCosmosParser =
+#else
+module EquinoxNewtonsoftParser =
 #endif
     type Document with
         member document.Cast<'T>() =
@@ -39,3 +39,4 @@ module EquinoxCosmosParser =
     let enumStreamEvents (d : Document) : StreamEvent<byte[]> seq =
         if isEquinoxBatch d then d.Cast<Batch>() |> enumEquinoxCosmosEvents
         else Seq.empty
+

--- a/src/Propulsion.Cosmos/Infrastructure.fs
+++ b/src/Propulsion.Cosmos/Infrastructure.fs
@@ -1,7 +1,7 @@
-﻿#if COSMOSSTORE
-namespace Propulsion.CosmosStore
-#else
+﻿#if COSMOSV2
 namespace Propulsion.Cosmos
+#else
+namespace Propulsion.CosmosStore
 #endif
 
 open System

--- a/src/Propulsion.Cosmos/Propulsion.Cosmos.fsproj
+++ b/src/Propulsion.Cosmos/Propulsion.Cosmos.fsproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <WarningLevel>5</WarningLevel>
+    <DefineConstants>COSMOSV2</DefineConstants>
     <IsTestProject>false</IsTestProject>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>

--- a/src/Propulsion.Cosmos/PropulsionCosmosPrometheus.fs
+++ b/src/Propulsion.Cosmos/PropulsionCosmosPrometheus.fs
@@ -1,9 +1,9 @@
 // This file implements a Serilog Sink `LogSink` that publishes metric values to Prometheus.
 
-#if COSMOSSTORE
-namespace Propulsion.CosmosStore.Prometheus
-#else
+#if COSMOSV2
 namespace Propulsion.Cosmos.Prometheus
+#else
+namespace Propulsion.CosmosStore.Prometheus
 #endif
 
 [<AutoOpen>]
@@ -87,10 +87,10 @@ module private Histogram =
     let latency = create' latencyBuckets secondsStat latencyDesc
     let charge = create' ruBuckets rusStat chargeDesc
 
-#if COSMOSSTORE
-open Propulsion.CosmosStore.Log
-#else
+#if COSMOSV2
 open Propulsion.Cosmos.Log
+#else
+open Propulsion.CosmosStore.Log
 #endif
 
 /// <summary>An ILogEventSink that publishes to Prometheus</summary>

--- a/src/Propulsion.CosmosStore/ChangeFeedProcessor.fs
+++ b/src/Propulsion.CosmosStore/ChangeFeedProcessor.fs
@@ -1,4 +1,4 @@
-namespace Propulsion.Cosmos
+namespace Propulsion.CosmosStore
 
 open Microsoft.Azure.Documents
 open Microsoft.Azure.Documents.Client

--- a/src/Propulsion.CosmosStore/Propulsion.CosmosStore.fsproj
+++ b/src/Propulsion.CosmosStore/Propulsion.CosmosStore.fsproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <WarningLevel>5</WarningLevel>
-    <DefineConstants>COSMOSSTORE</DefineConstants>
     <IsTestProject>false</IsTestProject>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -16,9 +15,7 @@
     <Compile Include="..\Propulsion.Cosmos\Infrastructure.fs">
       <Link>Infrastructure.fs</Link>
     </Compile>
-    <Compile Include="..\Propulsion.Cosmos\ChangeFeedProcessor.fs">
-      <Link>ChangeFeedProcessor.fs</Link>
-    </Compile>
+    <Compile Include="ChangeFeedProcessor.fs" />
     <Compile Include="..\Propulsion.Cosmos\CosmosSource.fs">
       <Link>CosmosSource.fs</Link>
     </Compile>
@@ -39,7 +36,7 @@
 
     <PackageReference Include="FSharp.Core" Version="4.3.4" />
 
-    <PackageReference Include="Equinox.CosmosStore" Version="3.0.0" />
+    <PackageReference Include="Equinox.CosmosStore" Version="3.0.1" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.ChangeFeedProcessor" Version="2.3.2" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.2.0" />
 	<PackageReference Include="Equinox.CosmosStore" Version="3.0.0" />


### PR DESCRIPTION
No breaking changes compared to 2.10.0; intended to reduce/simplify diffs in https://github.com/jet/propulsion/pull/113
- [x] flip from COSMOSSTORE whitelisting to COSMOSV2 blacklisting 
- [x] clone ChangeFeedProcessor.fs as changes will be significant and we want clean diffs
- [x] Target Equinox 3.0.1 as 3.0.0 is effectively delisted (does not affect this package materially) 
