### PR TITLE
Add AwaitWithStopOnCancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,14 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ## [Unreleased]
 
 ### Added
+
+- `Pipeline`: Added `AwaitWithStopOnCancellation` [#118](https://github.com/jet/propulsion/pull/118)
+
 ### Changed
 
 - `CosmosStore`: Target `Microsoft.Azure.Cosmos` (V3 CFP) `3.0.21`
 - `CosmosStore`: rename `maxDocuments` to `maxItems`
+- `Pipeline`: Renamed `AwaitCompletion` to `AwaitShutdown` [#118](https://github.com/jet/propulsion/pull/118)
 
 ### Removed
 ### Fixed

--- a/src/Propulsion.Kafka/Consumers.fs
+++ b/src/Propulsion.Kafka/Consumers.fs
@@ -144,7 +144,7 @@ type KafkaIngestionEngine<'Info>
             closeConsumer() (* Orderly Close() before Dispose() is critical *) }
 
 /// Consumes according to the `config` supplied to `Start`, until `Stop()` is requested or `handle` yields a fault.
-/// Conclusion of processing can be awaited by via `AwaitCompletion()`.
+/// Conclusion of processing can be awaited by via `AwaitShutdown` or `AwaitWithStopOnCancellation`.
 type ConsumerPipeline private (inner : IConsumer<string, string>, task : Task<unit>, triggerStop) =
     inherit Pipeline(task, triggerStop)
 

--- a/tests/Propulsion.Kafka.Integration/ConsumersIntegration.fs
+++ b/tests/Propulsion.Kafka.Integration/ConsumersIntegration.fs
@@ -106,7 +106,7 @@ module Helpers =
 
             timeout |> Option.iter consumer.StopAfter
 
-            do! consumer.AwaitCompletion()
+            do! consumer.AwaitShutdown()
         }
 
         do! Async.Parallel [for i in 1 .. numConsumers -> mkConsumer i] |> Async.Ignore
@@ -156,7 +156,7 @@ module Helpers =
 
             timeout |> Option.defaultValue (TimeSpan.FromMinutes 15.) |> consumer.StopAfter
 
-            do! consumer.AwaitCompletion()
+            do! consumer.AwaitShutdown()
         }
 
         do! Async.Parallel [for i in 1 .. numConsumers -> mkConsumer i] |> Async.Ignore
@@ -195,7 +195,7 @@ module Helpers =
 
             timeout |> Option.defaultValue (TimeSpan.FromMinutes 15.) |> consumer.StopAfter
 
-            do! consumer.AwaitCompletion()
+            do! consumer.AwaitShutdown()
         }
 
         do! Async.Parallel [for i in 1 .. numConsumers -> mkConsumer i] |> Async.Ignore


### PR DESCRIPTION
Equivalent of https://github.com/jet/FsKafka/pull/83 - enables one to cleanly share fate of a set of pipelines hosted in a single process