### PR TITLE
StreamsProjector: Fix handling of maxReadAhead Int32.MaxValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Removed
 ### Fixed
 
+- `StreamsProjector`: Fix failure to pump batches when using `maxReadAhead` of `Int32.MaxValue` [#124](https://github.com/jet/propulsion/pull/124)
+
 <a name="2.11.0"></a>
 ## [2.11.0] - 2021-10-19
 

--- a/src/Propulsion/Streams.fs
+++ b/src/Propulsion/Streams.fs
@@ -948,7 +948,7 @@ module Projector =
             let mapBatch onCompletion (x : Submission.SubmissionBatch<_, StreamEvent<_>>) : Scheduling.StreamsBatch<_> =
                 let onCompletion () = x.onCompletion(); onCompletion()
                 Scheduling.StreamsBatch.Create(onCompletion, x.messages) |> fst
-            let maxSubmissionsPerPartition = defaultArg maxSubmissionsPerPartition (maxReadAhead*4/5)
+            let maxSubmissionsPerPartition = defaultArg maxSubmissionsPerPartition (maxReadAhead - maxReadAhead/5) // NOTE needs to handle overflow if maxReadAhead is Int32.MaxValue
             let submitter = StreamsSubmitter.Create(log, maxSubmissionsPerPartition, mapBatch, submitStreamsBatch, statsInterval, ?pumpInterval=pumpInterval)
             let startIngester (rangeLog, projectionId) = StreamsIngester.Start(rangeLog, projectionId, maxReadAhead, submitter.Ingest, ?statsInterval=ingesterStatsInterval)
             ProjectorPipeline.Start(log, pumpDispatcher, pumpScheduler, submitter.Pump(), startIngester)


### PR DESCRIPTION
When using a high max read ahead value for test scenarios, the existing algorithm overflows, leading to no items entering the projector
This tweaks the computation to fix the problem