### PR TITLE
Feed.PeriodicSource: Support multiple Tranches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Changed
 
-- `PeriodicSource`: Add `readTranches` parameter to `Pump`
-- `PeriodicSource`: Add `TrancheId` parameter to `crawl`: [#128](https://github.com/jet/propulsion/pull/128)
+- `PeriodicSource`: Add `readTranches` parameter to `Pump` [#130](https://github.com/jet/propulsion/pull/130)  
+- `PeriodicSource`: Add `TrancheId` parameter to `crawl` [#130](https://github.com/jet/propulsion/pull/130)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - `Streams`: Added `propulsion_scheduler_busy` metrics: `count` and `seconds` [#126](https://github.com/jet/propulsion/pull/126)
 
 ### Changed
+
+- `PeriodicSource`: Add `readTranches` parameter to `Pump`
+- `PeriodicSource`: Add `TrancheId` parameter to `crawl`: [#128](https://github.com/jet/propulsion/pull/128)
+
 ### Removed
 
 - `net461` support [#123](https://github.com/jet/propulsion/pull/123)

--- a/src/Propulsion.Feed/FeedSource.fs
+++ b/src/Propulsion.Feed/FeedSource.fs
@@ -78,5 +78,6 @@ type FeedSource
     /// Drives the continual loop of reading and checkpointing each tranche until a fault occurs. <br/>
     /// The <c>readTranches</c> and <c>readPage</c> functions are expected to manage their own resilience strategies (retries etc). <br/>
     /// Any exception from <c>readTranches</c> or <c>readPage</c> will be propagated in order to enable termination of the overall projector loop
-    member _.Pump(readTranches : unit -> Async<TrancheId[]>) =
+    member _.Pump(?readTranches : unit -> Async<TrancheId[]>) =
+        let readTranches = match readTranches with Some f -> f | None -> fun () -> async { return [| TrancheId.parse "0" |] }
         base.Pump(readTranches, crawl)

--- a/src/Propulsion.Feed/FeedSource.fs
+++ b/src/Propulsion.Feed/FeedSource.fs
@@ -78,6 +78,5 @@ type FeedSource
     /// Drives the continual loop of reading and checkpointing each tranche until a fault occurs. <br/>
     /// The <c>readTranches</c> and <c>readPage</c> functions are expected to manage their own resilience strategies (retries etc). <br/>
     /// Any exception from <c>readTranches</c> or <c>readPage</c> will be propagated in order to enable termination of the overall projector loop
-    member _.Pump(?readTranches : unit -> Async<TrancheId[]>) =
-        let readTranches = match readTranches with Some f -> f | None -> fun () -> async { return [| TrancheId.parse "0" |] }
+    member _.Pump(readTranches : unit -> Async<TrancheId[]>) =
         base.Pump(readTranches, crawl)

--- a/src/Propulsion.Feed/PeriodicSource.fs
+++ b/src/Propulsion.Feed/PeriodicSource.fs
@@ -84,5 +84,6 @@ type PeriodicSource
     /// Drives the continual loop of reading and checkpointing each tranche until a fault occurs. <br/>
     /// The <c>readTranches</c> and <c>crawl</c> functions are expected to manage their own resilience strategies (retries etc). <br/>
     /// Any exception from <c>readTranches</c> or <c>crawl</c> will be propagated in order to enable termination of the overall projector loop
-    member _.Pump(readTranches : unit -> Async<TrancheId[]>) =
+    member _.Pump(?readTranches : unit -> Async<TrancheId[]>) =
+        let readTranches = match readTranches with Some f -> f | None -> fun () -> async { return [| TrancheId.parse "0" |] }
         base.Pump(readTranches, crawl)


### PR DESCRIPTION
Extend `PeriodicSource` to align with `Propulsion.Feed.FeedSource`, with each `TrancheId` yielded from `readTranches` spawning an individual instance of the `crawl` function (which receives a `TrancheId` to enable distinguishing the source)