### PR TITLE
CosmosStoreSource: Simplify lifetime management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 ### Changed
+
+- `CosmosStoreSource`: Generalize `Run` with integrated Ctrl-C handling to `Start` yielding a `Pipeline` [#133](https://github.com/jet/propulsion/pull/133)
+
 ### Removed
 ### Fixed
 

--- a/src/Propulsion.CosmosStore/ChangeFeedProcessor.fs
+++ b/src/Propulsion.CosmosStore/ChangeFeedProcessor.fs
@@ -41,13 +41,14 @@ type SourcePipeline private (task : Task<unit>, triggerStop) =
 
             // aka base.AwaitShutdown()
             do! Async.AwaitTaskCorrect tcs.Task
-            return! stop () }
+            do! stop ()
+            log.Information("... source stopped") }
 
         let task = Async.StartAsTask machine
         let triggerStop () =
             let level = if cts.IsCancellationRequested then Events.LogEventLevel.Debug else Events.LogEventLevel.Information
-            log.Write(level, "Stopping")
-            cts.Cancel();
+            log.Write(level, "Source stopping...")
+            cts.Cancel()
 
         new SourcePipeline(task, triggerStop)
 

--- a/src/Propulsion.CosmosStore/Infrastructure.fs
+++ b/src/Propulsion.CosmosStore/Infrastructure.fs
@@ -4,6 +4,7 @@ open System
 open System.Threading.Tasks
 
 type Async with
+
     /// Asynchronously awaits the next keyboard interrupt event, throwing a TaskCancelledException
     static member AwaitKeyboardInterruptAsTaskCancelledException() : Async<unit> =
         Async.FromContinuations <| fun (_, ec, _) ->

--- a/src/Propulsion.CosmosStore/Infrastructure.fs
+++ b/src/Propulsion.CosmosStore/Infrastructure.fs
@@ -1,0 +1,16 @@
+﻿module Propulsion.CosmosStore.Infrastructure
+
+open System
+open System.Threading.Tasks
+
+type Async with
+    /// Asynchronously awaits the next keyboard interrupt event, throwing a TaskCancelledException
+    static member AwaitKeyboardInterruptAsTaskCancelledException() : Async<unit> =
+        Async.FromContinuations <| fun (_, ec, _) ->
+            let mutable isDisposed = 0
+            let rec callback (a : ConsoleCancelEventArgs) = Task.Run(fun () ->
+                a.Cancel <- true // We're using this exception to drive a controlled shutdown so inhibit the standard behavior
+                if System.Threading.Interlocked.Increment &isDisposed = 1 then d.Dispose()
+                ec (TaskCanceledException("Execution cancelled; exiting..."))) |> ignore<Task>
+            and d : IDisposable = Console.CancelKeyPress.Subscribe callback
+            in ()

--- a/src/Propulsion.CosmosStore/Infrastructure.fs
+++ b/src/Propulsion.CosmosStore/Infrastructure.fs
@@ -11,6 +11,6 @@ type Async with
             let rec callback (a : ConsoleCancelEventArgs) = Task.Run(fun () ->
                 a.Cancel <- true // We're using this exception to drive a controlled shutdown so inhibit the standard behavior
                 if System.Threading.Interlocked.Increment &isDisposed = 1 then d.Dispose()
-                ec (TaskCanceledException("Execution cancelled; exiting..."))) |> ignore<Task>
+                ec (TaskCanceledException("Execution cancelled via Ctrl-C/Break; exiting..."))) |> ignore<Task>
             and d : IDisposable = Console.CancelKeyPress.Subscribe callback
             in ()

--- a/src/Propulsion.CosmosStore/Propulsion.CosmosStore.fsproj
+++ b/src/Propulsion.CosmosStore/Propulsion.CosmosStore.fsproj
@@ -13,11 +13,9 @@
     <Compile Include="..\Propulsion.Cosmos\EquinoxCosmosParser.fs">
       <Link>EquinoxCosmosParser.fs</Link>
     </Compile>
+    <Compile Include="Infrastructure.fs" />
     <Compile Include="..\Propulsion\Infrastructure.fs">
       <Link>PropulsionInfrastructure.fs</Link>
-    </Compile>
-    <Compile Include="..\Propulsion.Cosmos\Infrastructure.fs">
-      <Link>PropulsionCosmosInfrastructure.fs</Link>
     </Compile>
     <Compile Include="ChangeFeedProcessor.fs" />
     <Compile Include="..\Propulsion.Cosmos\CosmosSource.fs">

--- a/src/Propulsion/Projector.fs
+++ b/src/Propulsion/Projector.fs
@@ -63,12 +63,13 @@ type ProjectorPipeline<'Ingester> private (task : Task<unit>, triggerStop, start
             start "submitter" <| pumpSubmitter
 
             // await for either handler-driven abend or external cancellation via Stop()
-            do! Async.AwaitTaskCorrect tcs.Task }
+            do! Async.AwaitTaskCorrect tcs.Task
+            log.Information("... projector stopped") }
 
         let task = Async.StartAsTask machine
         let triggerStop () =
             let level = if cts.IsCancellationRequested then Events.LogEventLevel.Debug else Events.LogEventLevel.Information
-            log.Write(level, "Stopping")
+            log.Write(level, "Projector stopping...")
             cts.Cancel();
 
         new ProjectorPipeline<_>(task, triggerStop, startIngester)

--- a/src/Propulsion/Projector.fs
+++ b/src/Propulsion/Projector.fs
@@ -70,6 +70,6 @@ type ProjectorPipeline<'Ingester> private (task : Task<unit>, triggerStop, start
         let triggerStop () =
             let level = if cts.IsCancellationRequested then Events.LogEventLevel.Debug else Events.LogEventLevel.Information
             log.Write(level, "Projector stopping...")
-            cts.Cancel();
+            cts.Cancel()
 
         new ProjectorPipeline<_>(task, triggerStop, startIngester)

--- a/tools/Propulsion.Tool/Program.fs
+++ b/tools/Propulsion.Tool/Program.fs
@@ -212,9 +212,9 @@ let main argv =
                         let json = Propulsion.Codec.NewtonsoftJson.RenderedSpan.ofStreamSpan stream span |> Newtonsoft.Json.JsonConvert.SerializeObject
                         let! _ = producer.ProduceAsync(FsCodec.StreamName.toString stream, json) in () }
                 Propulsion.Streams.StreamsProjector.Start(log, maxReadAhead, maxConcurrentStreams, handle, stats, stats.StatsInterval)
-            let transformOrFilter = Propulsion.CosmosStore.EquinoxNewtonsoftParser.enumStreamEvents
-            use observer = Propulsion.CosmosStore.CosmosStoreSource.CreateObserver(log, sink.StartIngester, Seq.collect transformOrFilter)
             let source =
+                let transformOrFilter = Propulsion.CosmosStore.EquinoxNewtonsoftParser.enumStreamEvents
+                let observer = Propulsion.CosmosStore.CosmosStoreSource.CreateObserver(log, sink.StartIngester, Seq.collect transformOrFilter)
                 Propulsion.CosmosStore.CosmosStoreSource.Start
                   ( log, monitored, leases, group, observer,
                     startFromTail = startFromTail, ?maxItems = maxItems, ?lagReportFreq = maybeLogLagInterval)

--- a/tools/Propulsion.Tool/Program.fs
+++ b/tools/Propulsion.Tool/Program.fs
@@ -41,7 +41,7 @@ module Cosmos =
                 | Suffix _ ->               "Specify Container Name suffix (default: `-aux`)."
                 | LeaseContainer _ ->       "Specify full Lease Container Name (default: Container + Suffix)."
     type Equinox.CosmosStore.CosmosStoreConnector with
-        member private x.LogConfiguration(log : Serilog.ILogger, connectionName, databaseId, containerId) =
+        member private x.LogConfiguration(log : ILogger, connectionName, databaseId, containerId) =
             let o = x.Options
             let timeout, retries429, timeout429 = o.RequestTimeout, o.MaxRetryAttemptsOnRateLimitedRequests, o.MaxRetryWaitTimeOnRateLimitedRequests
             log.Information("CosmosDb {name} {mode} {endpointUri} timeout {timeout}s; Throttling retries {retries}, max wait {maxRetryWaitTime}s",
@@ -86,7 +86,7 @@ type Arguments =
             | Verbose ->                    "Include low level logging regarding specific test runs."
             | VerboseConsole ->             "Include low level test and store actions logging in on-screen output to console."
             | LocalSeq ->                   "Configures writing to a local Seq endpoint at http://localhost:5341, see https://getseq.net"
-            | Init _ ->                     "Initialize auxilliary store (presently only relevant for `cosmos`, when you intend to run the Projector)."
+            | Init _ ->                     "Initialize auxiliary store (presently only relevant for `cosmos`, when you intend to run the Projector)."
             | Project _ ->                  "Project from store specified as the last argument, storing state in the specified `aux` Store (see init)."
 and [<NoComparison; NoEquality>]InitDbArguments =
     | [<AltCommandLine("-ru"); Mandatory>]  Rus of int
@@ -226,6 +226,6 @@ let main argv =
             |> Async.RunSynchronously
         | _ -> failwith "Please specify a valid subcommand :- init or project"
         0
-    with :? Argu.ArguParseException as e -> eprintfn "%s" e.Message; 1
+    with :? ArguParseException as e -> eprintfn "%s" e.Message; 1
         | MissingArg msg -> eprintfn "%s" msg; 1
         | e -> eprintfn "%s" e.Message; 1


### PR DESCRIPTION
Replaces `CosmosStoreSource.Run`, which inherited semantics from `CosmosSource.Run` with `CosmosStoreSource.Start`, which offers a clear and more composable contract.

This allows one to compose a set of sources and sinks [just as one can do with `FsKafka`](https://github.com/jet/FsKafka/blob/master/README.md#running-and-awaiting-a-pair-of-consumers-until-either-throws).

Note that implementation of semantics regarding clean shutdown via Ctrl-C/Break will now involve explicit use of helpers such as `Async.AwaitKeyboardInterruptAsTaskCancelledException` (currently public in `Propulsion.CosmosStore.Infrastructure`; that does not make sense as a long term home for it)