### PR TITLE
Add config parameter support for FsKafka producer config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ## [Unreleased]
 
 ### Added
+
+- `Kafka.Producers`: optional constructor parameters [#315](https://github.com/jet/propulsion/pull/135)
+
 ### Changed
 ### Removed
 ### Fixed

--- a/src/Propulsion.Kafka/Producers.fs
+++ b/src/Propulsion.Kafka/Producers.fs
@@ -14,12 +14,13 @@ type Producer
         /// Default: LZ4
         ?compression,
         // Deprecated; there's a good chance this will be removed
-        ?degreeOfParallelism) =
+        ?degreeOfParallelism,
+        ?config) =
     let batching =
         let linger = defaultArg linger (TimeSpan.FromMilliseconds 5.)
         FsKafka.Batching.Linger linger
     let compression = defaultArg compression CompressionType.Lz4
-    let cfg = KafkaProducerConfig.Create(clientId, bootstrapServers, acks, batching, compression, ?customize=customize)
+    let cfg = KafkaProducerConfig.Create(clientId, bootstrapServers, acks, batching, compression, ?config = config, ?customize=customize)
     // NB having multiple producers has yet to be proved necessary at this point
     // - the theory is that because each producer gets a dedicated rdkafka context, compression thread and set of sockets, better throughput can be attained
     // - we should consider removing the degreeOfParallelism argument and this associated logic unless we actually get to the point of leaning on this


### PR DESCRIPTION
We need Propulsion to publish to secure Kafka clusters. For this, a `IDictionary<string, string> option` needs to be passed to FsKafka's Producer config. If connecting to secure host, this would contain paths of certificate files in the local file system needed for SSL encryption. Hence, adding an optional parameter here in the Producer type's constructor in Propulsion to support this.