### PR TITLE
Streams: Infer Prometheus group label via Log property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,13 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ## [Unreleased]
 
 ### Added
+
+- `Prometheus.LogSink`: Support indicating the consumer group name via a Serilog (`ForContext`) property `"group"` [#137](https://github.com/jet/propulsion/pull/137)
+
 ### Changed
+
+- `Prometheus.LogSink`: Replace mandatory `group` argument with optional `defaultGroup` to emphasize primacy of `"group"` Log property [#137](https://github.com/jet/propulsion/pull/137)
+
 ### Removed
 ### Fixed
 


### PR DESCRIPTION
The need to specify a `group` to `Propulsion.Prometheus.LogSink` for `Propulsion.Streams` worked, but causes two issues:
1. Wiring code needs to establish the consumer group earlier than it would ordinarily need to
2. Risk of metrics from >1 Streams Projectors would be hard to detect before things get ugly in your metrics store
3. Correctly Handling metrics where >1 Streams Projector is present in a single process would require manual management of multiple sinks in client wiring

This PR introduces an effectively-mandatory `"group"` Property (i.e. add it to loggers supplied to Propulsion.Streams.Projector via Serilog's `log.ForContext`) for metrics that are to be reported to Prometheus.

This is an intentional breaking change for users of [Prometheus and] `Propulsion.LogSink`, but not for other usage - the Log Property requirement is optional if not using the Prometheus integration.