### PR TITLE
Tool: Add checkpoint feature, project dynamo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - `Propulsion.EventStoreDb`: Ported `EventStore` to target `Equinox.EventStore` >= `4.0.0` (using the gRPC interface)  [#139](https://github.com/jet/propulsion/pull/139)
 - `Propulsion.CosmosStore3`: Special cased version of `Propulsion.CosmosStore` to target `Equinox.CosmosStore` v `[3.0.7`-`3.99.0]` **Deprecated; Please migrate to `Propulsion.CosmosStore` by updating `Equinox.CosmosStore` dependencies to `4.0.0`** [#139](https://github.com/jet/propulsion/pull/139)
 - `Propulsion.DynamoStore`: `Equinox.CosmosStore`-equivalent functionality for `Equinox.DynamoStore`. Combines elements of `CosmosStore`, `SqlStreamStore`, `Feed` [#140](https://github.com/jet/propulsion/pull/140)
+- `Propulsion.Tool`: `checkpoint` commandline option; enables viewing or overriding checkpoints [#141](https://github.com/jet/propulsion/pull/141)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ The relevant pieces of the above break down as follows, when we emphasize the [C
 
 ## QuickStart
 
-### 1. Use `propulsion` tool to run a CosmosDb ChangeFeedProcessor
+### 1. Use `propulsion` tool to run a CosmosDb ChangeFeedProcessor or DynamoStoreSource projector
 
 ```powershell
 dotnet tool uninstall Propulsion.Tool -g
@@ -159,9 +159,12 @@ propulsion init -ru 400 cosmos # generates a -aux container for the ChangeFeedPr
 # stats specifies one only wants stats regarding items (other options include `kafka` to project to Kafka)
 # cosmos specifies source overrides (using defaults in step 1 in this instance)
 propulsion -V project -g projector1 stats cosmos
+
+# load events with 2 parallel readers, detailed store logging and a read timeout of 20s
+propulsion -VS project -g projector1 stats dynamo -rt 20 -d 2
 ```
 
-### 2. Use `propulsion` tool to Run a CosmosDb ChangeFeedProcessor, emitting to a Kafka topic
+### 2. Use `propulsion` tool to Run a CosmosDb ChangeFeedProcessor or DynamoStoreSource projector, emitting to a Kafka topic 
 
 ```powershell
 $env:PROPULSION_KAFKA_BROKER="instance.kafka.mysite.com:9092" # or use -b

--- a/tools/Propulsion.Tool/Args.fs
+++ b/tools/Propulsion.Tool/Args.fs
@@ -1,0 +1,215 @@
+module Propulsion.Tool.Args
+
+open Argu
+open Serilog
+open System
+
+exception MissingArg of message : string with override this.Message = this.message
+let missingArg msg = raise (MissingArg msg)
+
+module Configuration =
+
+    module Cosmos =
+
+        let [<Literal>] CONNECTION =                "EQUINOX_COSMOS_CONNECTION"
+        let [<Literal>] DATABASE =                  "EQUINOX_COSMOS_DATABASE"
+        let [<Literal>] CONTAINER =                 "EQUINOX_COSMOS_CONTAINER"
+
+    module Dynamo =
+
+        let [<Literal>] SERVICE_URL =               "EQUINOX_DYNAMO_SERVICE_URL"
+        let [<Literal>] ACCESS_KEY =                "EQUINOX_DYNAMO_ACCESS_KEY_ID"
+        let [<Literal>] SECRET_KEY =                "EQUINOX_DYNAMO_SECRET_ACCESS_KEY"
+        let [<Literal>] TABLE =                     "EQUINOX_DYNAMO_TABLE"
+        let [<Literal>] INDEX_TABLE =               "EQUINOX_DYNAMO_TABLE_INDEX"
+
+    module Kafka =
+
+        let [<Literal>] BROKER =                    "PROPULSION_KAFKA_BROKER"
+        let [<Literal>] TOPIC =                     "PROPULSION_KAFKA_TOPIC"
+
+type Configuration(tryGet : string -> string option) =
+
+    member val tryGet =                             tryGet
+    member _.get key =                              match tryGet key with Some value -> value | None -> missingArg $"Missing Argument/Environment Variable %s{key}"
+
+    member x.CosmosConnection =                     x.get Configuration.Cosmos.CONNECTION
+    member x.CosmosDatabase =                       x.get Configuration.Cosmos.DATABASE
+    member x.CosmosContainer =                      x.get Configuration.Cosmos.CONTAINER
+
+    member x.DynamoServiceUrl =                     x.get Configuration.Dynamo.SERVICE_URL
+    member x.DynamoAccessKey =                      x.get Configuration.Dynamo.ACCESS_KEY
+    member x.DynamoSecretKey =                      x.get Configuration.Dynamo.SECRET_KEY
+    member x.DynamoTable =                          x.get Configuration.Dynamo.TABLE
+    member x.DynamoIndexTable =                     tryGet Configuration.Dynamo.INDEX_TABLE
+
+    member x.KafkaBroker =                          x.get Configuration.Kafka.BROKER
+    member x.KafkaTopic =                           x.get Configuration.Kafka.TOPIC
+
+module Cosmos =
+
+    open Configuration.Cosmos
+
+    module CosmosStoreContext =
+
+        /// Create with default packing and querying policies. Search for other `module CosmosStoreContext` impls for custom variations
+        let create (storeClient : Equinox.CosmosStore.CosmosStoreClient) =
+            let maxEvents = 256
+            Equinox.CosmosStore.CosmosStoreContext(storeClient, tipMaxEvents = maxEvents)
+
+    type Equinox.CosmosStore.CosmosStoreConnector with
+
+        member private x.LogConfiguration(log : ILogger, connectionName, databaseId, containerId) =
+            let o = x.Options
+            let timeout, retries429, timeout429 = o.RequestTimeout, o.MaxRetryAttemptsOnRateLimitedRequests, o.MaxRetryWaitTimeOnRateLimitedRequests
+            log.Information("CosmosDb {name} {mode} {endpointUri} timeout {timeout}s; Throttling retries {retries}, max wait {maxRetryWaitTime}s",
+                            connectionName, o.ConnectionMode, x.Endpoint, timeout.TotalSeconds, retries429, let t = timeout429.Value in t.TotalSeconds)
+            log.Information("CosmosDb {name} Database {database} Container {container}",
+                            connectionName, databaseId, containerId)
+
+        /// Use sparingly; in general one wants to use CreateAndInitialize to avoid slow first requests
+        member private x.CreateUninitialized(databaseId, containerId) =
+            x.CreateUninitialized().GetDatabase(databaseId).GetContainer(containerId)
+
+        /// Creates a CosmosClient suitable for running a CFP via CosmosStoreSource
+        member x.CreateClient(log, databaseId, containerId, ?connectionName) =
+            x.LogConfiguration(log, defaultArg connectionName "Source", databaseId, containerId)
+            x.CreateUninitialized(databaseId, containerId)
+
+        /// Connect a CosmosStoreClient, including warming up
+        member x.ConnectStore(log, connectionName, databaseId, containerId) =
+            x.LogConfiguration(log, connectionName, databaseId, containerId)
+            Equinox.CosmosStore.CosmosStoreClient.Connect(x.CreateAndInitialize, databaseId, containerId)
+
+//        /// Creates a CosmosClient suitable for running a CFP via CosmosStoreSource
+//        member x.ConnectMonitored(databaseId, containerId, ?connectionName) =
+//            x.LogConfiguration(defaultArg connectionName "Source", databaseId, containerId)
+//            x.CreateUninitialized(databaseId, containerId)
+//
+//        /// Connects to a Store as both a ChangeFeedProcessor Monitored Container and a CosmosStoreClient
+//        member x.ConnectStoreAndMonitored(databaseId, containerId) =
+//            let monitored = x.ConnectMonitored(databaseId, containerId, "Main")
+//            let storeClient = Equinox.CosmosStore.CosmosStoreClient(monitored.Database.Client, databaseId, containerId)
+//            storeClient, monitored
+
+    type [<NoEquality; NoComparison>] Parameters =
+        | [<AltCommandLine "-V"; Unique>]   Verbose
+        | [<AltCommandLine "-m">]           ConnectionMode of Microsoft.Azure.Cosmos.ConnectionMode
+        | [<AltCommandLine "-s">]           Connection of string
+        | [<AltCommandLine "-d">]           Database of string
+        | [<AltCommandLine "-c">]           Container of string
+        | [<AltCommandLine "-o">]           Timeout of float
+        | [<AltCommandLine "-r">]           Retries of int
+        | [<AltCommandLine "-rt">]          RetriesWaitTime of float
+        | [<AltCommandLine("-a"); Unique>]  LeaseContainer of string
+        | [<AltCommandLine("-as"); Unique>] Suffix of string
+        interface IArgParserTemplate with
+            member a.Usage = a |> function
+                | Verbose ->                "Include low level Store logging."
+                | ConnectionMode _ ->       "override the connection mode. Default: Direct."
+                | Connection _ ->           "specify a connection string for a Cosmos account. (optional if environment variable " + CONNECTION + " specified)"
+                | Database _ ->             "specify a database name for Cosmos store. (optional if environment variable " + DATABASE + " specified)"
+                | Container _ ->            "specify a container name for Cosmos store. (optional if environment variable " + CONTAINER + " specified)"
+                | Timeout _ ->              "specify operation timeout in seconds (default: 5)."
+                | Retries _ ->              "specify operation retries (default: 1)."
+                | RetriesWaitTime _ ->      "specify max wait-time for retry when being throttled by Cosmos in seconds (default: 5)"
+                | LeaseContainer _ ->       "Specify full Lease Container Name (default: Container + Suffix)."
+                | Suffix _ ->               "Specify Container Name suffix (default: `-aux`, if LeaseContainer not specified)."
+
+    type Arguments(c : Configuration, a : ParseResults<Parameters>) =
+        let connection =                    a.TryGetResult Connection |> Option.defaultWith (fun () -> c.CosmosConnection)
+        let discovery =                     Equinox.CosmosStore.Discovery.ConnectionString connection
+        let mode =                          a.TryGetResult ConnectionMode
+        let timeout =                       a.GetResult(Timeout, 5.) |> TimeSpan.FromSeconds
+        let retries =                       a.GetResult(Retries, 1)
+        let maxRetryWaitTime =              a.GetResult(RetriesWaitTime, 5.) |> TimeSpan.FromSeconds
+        let connector =                     Equinox.CosmosStore.CosmosStoreConnector(discovery, timeout, retries, maxRetryWaitTime, ?mode = mode)
+        let database =                      a.TryGetResult Database |> Option.defaultWith (fun () -> c.CosmosDatabase)
+        let checkpointInterval =            TimeSpan.FromHours 1.
+        member val ContainerId =            a.TryGetResult Container |> Option.defaultWith (fun () -> c.CosmosContainer)
+        member x.MonitoredContainer(log) =  connector.CreateClient(log, database, x.ContainerId)
+        member val Verbose =                a.Contains Verbose
+        member val LeaseContainerId =       a.TryGetResult LeaseContainer
+        member x.LeasesContainerName =      match x.LeaseContainerId with Some x -> x | None -> x.ContainerId + a.GetResult(Suffix, "-aux")
+        member x.ConnectLeases(log) =       connector.CreateClient(log, database, x.LeasesContainerName, "Leases")
+
+        member x.CreateCheckpointStore(log, group, cache) = async {
+            let! store = connector.ConnectStore(log, "Checkpoints", database, x.ContainerId)
+            let context = CosmosStoreContext.create store
+            return Propulsion.Feed.ReaderCheckpoint.CosmosStore.create log (group, checkpointInterval) (context, cache) }
+
+module Dynamo =
+
+    open Configuration.Dynamo
+
+    type Equinox.DynamoStore.DynamoStoreConnector with
+
+        member x.LogConfiguration(log : ILogger) =
+            log.Information("DynamoStore {endpoint} Timeout {timeoutS}s Retries {retries}",
+                            x.Endpoint, (let t = x.Timeout in t.TotalSeconds), x.Retries)
+
+    type Equinox.DynamoStore.DynamoStoreClient with
+
+        member internal x.LogConfiguration(log : ILogger, role) =
+            log.Information("DynamoStore {role:l} Table {table}", role, x.TableName)
+
+    type Amazon.DynamoDBv2.IAmazonDynamoDB with
+
+        /// Connects to a Store as both a ChangeFeedProcessor Monitored Container and a CosmosStoreClient
+        member x.ConnectStore(log, role, table) =
+            let storeClient = Equinox.DynamoStore.DynamoStoreClient(x, table)
+            storeClient.LogConfiguration(log, role)
+            storeClient
+
+    module DynamoStoreContext =
+
+        let create (storeClient : Equinox.DynamoStore.DynamoStoreClient) =
+            Equinox.DynamoStore.DynamoStoreContext(storeClient)
+
+    type [<NoEquality; NoComparison>] Parameters =
+        | [<AltCommandLine "-V">]           Verbose
+        | [<AltCommandLine "-s">]           ServiceUrl of string
+        | [<AltCommandLine "-sa">]          AccessKey of string
+        | [<AltCommandLine "-ss">]          SecretKey of string
+        | [<AltCommandLine "-t">]           Table of string
+        | [<AltCommandLine "-r">]           Retries of int
+        | [<AltCommandLine "-rt">]          RetriesTimeoutS of float
+        | [<AltCommandLine "-i">]           IndexTable of string
+        | [<AltCommandLine "-is">]          IndexSuffix of string
+        interface IArgParserTemplate with
+            member a.Usage = a |> function
+                | Verbose ->                "Include low level Store logging."
+                | ServiceUrl _ ->           "specify a server endpoint for a Dynamo account. (optional if environment variable " + SERVICE_URL + " specified)"
+                | AccessKey _ ->            "specify an access key id for a Dynamo account. (optional if environment variable " + ACCESS_KEY + " specified)"
+                | SecretKey _ ->            "specify a secret access key for a Dynamo account. (optional if environment variable " + SECRET_KEY + " specified)"
+                | Table _ ->                "specify a table name for the primary store. (optional if environment variable " + TABLE + ", or `IndexTable` specified)"
+                | Retries _ ->              "specify operation retries (default: 1)."
+                | RetriesTimeoutS _ ->      "specify max wait-time including retries in seconds (default: 5)"
+                | IndexTable _ ->           "specify a table name for the index store. (optional if environment variable " + INDEX_TABLE + " specified. default: `Table`+`IndexSuffix`)"
+                | IndexSuffix _ ->          "specify a suffix for the index store. (not relevant if `Table` or `IndexTable` specified. default: \"-index\")"
+
+    type Arguments(c : Configuration, a : ParseResults<Parameters>) =
+        let serviceUrl =                    a.TryGetResult ServiceUrl |> Option.defaultWith (fun () -> c.DynamoServiceUrl)
+        let accessKey =                     a.TryGetResult AccessKey  |> Option.defaultWith (fun () -> c.DynamoAccessKey)
+        let secretKey =                     a.TryGetResult SecretKey  |> Option.defaultWith (fun () -> c.DynamoSecretKey)
+//        let table =                         a.TryGetResult Table      |> Option.orElseWith  (fun () -> c.DynamoTable)
+        let indexSuffix =                   a.GetResult(IndexSuffix, "-index")
+        let indexTable =                    a.TryGetResult IndexTable
+                                            |> Option.orElseWith  (fun () -> c.DynamoIndexTable)
+                                            |> Option.defaultWith (fun () -> c.DynamoTable + indexSuffix)
+        let retries =                       a.GetResult(Retries, 1)
+        let timeout =                       a.GetResult(RetriesTimeoutS, 5.) |> TimeSpan.FromSeconds
+        let connector =                     Equinox.DynamoStore.DynamoStoreConnector(serviceUrl, accessKey, secretKey, timeout, retries)
+        let client =                        connector.CreateClient()
+        let checkpointInterval =            TimeSpan.FromHours 1.
+        member val Verbose =                a.Contains Verbose
+//        member _.Connect() =                connector.LogConfiguration()
+//                                            client.ConnectStore("Main", table) |> DynamoStoreContext.create
+        member _.CreateCheckpointStore(log, group, cache) =
+            connector.LogConfiguration(log)
+            let context = client.ConnectStore(log, "Index", indexTable) |> DynamoStoreContext.create
+            Propulsion.Feed.ReaderCheckpoint.DynamoStore.create log (group, checkpointInterval) (context, cache)
+//        member _.MonitoringParams(log : ILogger) =
+//            log.Information("DynamoStoreSource MaxItems {maxItems} Hydrater parallelism {streamsDop}", maxItems, streamsDop)
+//            if fromTail then log.Warning("(If new projector group) Skipping projection of all existing events.")
+//            indexStoreClient.Value, fromTail, maxItems, streamsDop

--- a/tools/Propulsion.Tool/Args.fs
+++ b/tools/Propulsion.Tool/Args.fs
@@ -31,7 +31,9 @@ module Configuration =
 type Configuration(tryGet : string -> string option) =
 
     member val tryGet =                             tryGet
-    member _.get key =                              match tryGet key with Some value -> value | None -> missingArg $"Missing Argument/Environment Variable %s{key}"
+    member _.get key =                              match tryGet key with
+                                                    | Some value -> value
+                                                    | None -> missingArg $"Missing Argument/Environment Variable %s{key}"
 
     member x.CosmosConnection =                     x.get Configuration.Cosmos.CONNECTION
     member x.CosmosDatabase =                       x.get Configuration.Cosmos.DATABASE
@@ -93,7 +95,7 @@ module Cosmos =
 //            storeClient, monitored
 
     type [<NoEquality; NoComparison>] Parameters =
-        | [<AltCommandLine "-V"; Unique>]   Verbose
+//        | [<AltCommandLine "-V"; Unique>]   Verbose
         | [<AltCommandLine "-m">]           ConnectionMode of Microsoft.Azure.Cosmos.ConnectionMode
         | [<AltCommandLine "-s">]           Connection of string
         | [<AltCommandLine "-d">]           Database of string
@@ -105,7 +107,7 @@ module Cosmos =
         | [<AltCommandLine("-as"); Unique>] Suffix of string
         interface IArgParserTemplate with
             member a.Usage = a |> function
-                | Verbose ->                "Include low level Store logging."
+//                | Verbose ->                "Include low level Store logging."
                 | ConnectionMode _ ->       "override the connection mode. Default: Direct."
                 | Connection _ ->           "specify a connection string for a Cosmos account. (optional if environment variable " + CONNECTION + " specified)"
                 | Database _ ->             "specify a database name for Cosmos store. (optional if environment variable " + DATABASE + " specified)"
@@ -128,7 +130,7 @@ module Cosmos =
         let checkpointInterval =            TimeSpan.FromHours 1.
         member val ContainerId =            a.TryGetResult Container |> Option.defaultWith (fun () -> c.CosmosContainer)
         member x.MonitoredContainer(log) =  connector.CreateClient(log, database, x.ContainerId)
-        member val Verbose =                a.Contains Verbose
+//        member val Verbose =                a.Contains Verbose
         member val LeaseContainerId =       a.TryGetResult LeaseContainer
         member x.LeasesContainerName =      match x.LeaseContainerId with Some x -> x | None -> x.ContainerId + a.GetResult(Suffix, "-aux")
         member x.ConnectLeases(log) =       connector.CreateClient(log, database, x.LeasesContainerName, "Leases")
@@ -167,7 +169,7 @@ module Dynamo =
             Equinox.DynamoStore.DynamoStoreContext(storeClient)
 
     type [<NoEquality; NoComparison>] Parameters =
-        | [<AltCommandLine "-V">]           Verbose
+//        | [<AltCommandLine "-V">]           Verbose
         | [<AltCommandLine "-s">]           ServiceUrl of string
         | [<AltCommandLine "-sa">]          AccessKey of string
         | [<AltCommandLine "-ss">]          SecretKey of string
@@ -178,7 +180,7 @@ module Dynamo =
         | [<AltCommandLine "-is">]          IndexSuffix of string
         interface IArgParserTemplate with
             member a.Usage = a |> function
-                | Verbose ->                "Include low level Store logging."
+//                | Verbose ->                "Include low level Store logging."
                 | ServiceUrl _ ->           "specify a server endpoint for a Dynamo account. (optional if environment variable " + SERVICE_URL + " specified)"
                 | AccessKey _ ->            "specify an access key id for a Dynamo account. (optional if environment variable " + ACCESS_KEY + " specified)"
                 | SecretKey _ ->            "specify a secret access key for a Dynamo account. (optional if environment variable " + SECRET_KEY + " specified)"

--- a/tools/Propulsion.Tool/Infrastructure.fs
+++ b/tools/Propulsion.Tool/Infrastructure.fs
@@ -1,0 +1,55 @@
+[<AutoOpen>]
+module Propulsion.Tool.Infrastructure
+
+open Serilog
+
+module Log =
+
+    let private l = Log.ForContext("isMetric", true)
+    // NB this needs to lazy-init after the Log.Logger is assigned in app startup...
+    let forMetrics () = l
+
+    let isStoreMetrics x = Serilog.Filters.Matching.WithProperty("isMetric").Invoke x
+
+module Sinks =
+
+    let equinoxMetricsOnly (l : LoggerConfiguration) =
+        l.WriteTo.Sink(Equinox.CosmosStore.Core.Log.InternalMetrics.Stats.LogSink())
+         .WriteTo.Sink(Equinox.DynamoStore.Core.Log.InternalMetrics.Stats.LogSink())
+    let console verbose (configuration : LoggerConfiguration) =
+        let outputTemplate =
+            let t = "{Timestamp:HH:mm:ss} {Level:u1} {Message:lj} {SourceContext} {Properties}{NewLine}{Exception}"
+            if verbose then t else t.Replace("{Properties}", "")
+        configuration.WriteTo.Console(theme = Sinks.SystemConsole.Themes.AnsiConsoleTheme.Code, outputTemplate = outputTemplate)
+
+[<System.Runtime.CompilerServices.Extension>]
+type Logging() =
+
+    [<System.Runtime.CompilerServices.Extension>]
+    static member Configure(configuration : LoggerConfiguration, ?verbose) =
+        configuration
+            .Destructure.FSharpTypes()
+            .Enrich.FromLogContext()
+        |> fun c -> if verbose = Some true then c.MinimumLevel.Debug() else c
+
+    [<System.Runtime.CompilerServices.Extension>]
+    static member private Sinks(configuration : LoggerConfiguration, configureMetricsSinks, configureConsoleSink, ?isMetric) =
+        let removeMetricsProps (c : LoggerConfiguration) : LoggerConfiguration =
+            let trim (e : Serilog.Events.LogEvent) =
+                e.RemovePropertyIfPresent(Propulsion.Streams.Log.PropertyTag)
+                e.RemovePropertyIfPresent(Propulsion.Feed.Internal.Log.PropertyTag)
+                e.RemovePropertyIfPresent(Propulsion.CosmosStore.Log.PropertyTag)
+                e.RemovePropertyIfPresent(Equinox.CosmosStore.Core.Log.PropertyTag)
+                e.RemovePropertyIfPresent(Equinox.DynamoStore.Core.Log.PropertyTag)
+            c.Enrich.With({ new Serilog.Core.ILogEventEnricher with member _.Enrich(evt,_) = trim evt })
+        let configure (a : Configuration.LoggerSinkConfiguration) : unit =
+            a.Logger(configureMetricsSinks >> ignore) |> ignore // unconditionally feed all log events to the metrics sinks
+            a.Logger(fun l -> // but filter what gets emitted to the console sink
+                let l = match isMetric with None -> l | Some predicate -> l.Filter.ByExcluding(System.Func<Serilog.Events.LogEvent, bool> predicate)
+                l |> removeMetricsProps |> configureConsoleSink |> ignore)
+            |> ignore
+        configuration.WriteTo.Async(bufferSize = 65536, blockWhenFull = true, configure = System.Action<_> configure)
+
+    [<System.Runtime.CompilerServices.Extension>]
+    static member Sinks(configuration : LoggerConfiguration, configureMetricsSinks, verboseStore, verboseConsole) =
+        configuration.Sinks(configureMetricsSinks, Sinks.console verboseConsole, ?isMetric = if verboseStore then None else Some Log.isStoreMetrics)

--- a/tools/Propulsion.Tool/Infrastructure.fs
+++ b/tools/Propulsion.Tool/Infrastructure.fs
@@ -5,9 +5,7 @@ open Serilog
 
 module Log =
 
-    let private l = Log.ForContext("isMetric", true)
-    // NB this needs to lazy-init after the Log.Logger is assigned in app startup...
-    let forMetrics () = l
+    let forMetrics = Log.ForContext("isMetric", true)
 
     let isStoreMetrics x = Serilog.Filters.Matching.WithProperty("isMetric").Invoke x
 

--- a/tools/Propulsion.Tool/Program.fs
+++ b/tools/Propulsion.Tool/Program.fs
@@ -115,10 +115,10 @@ module Checkpoints =
             let cache = Equinox.Cache (appName, sizeMb = 1)
             match args.StoreArgs with
             | Choice1Of2 a ->
-                let! store = a.CreateCheckpointStore(group, cache, Log.forMetrics())
+                let! store = a.CreateCheckpointStore(group, cache, Log.forMetrics)
                 return (store : Propulsion.Feed.IFeedCheckpointStore), "cosmos", fun pos -> store.Override(source, tranche, pos)
             | Choice2Of2 a ->
-                let store = a.CreateCheckpointStore(group, cache, Log.forMetrics())
+                let store = a.CreateCheckpointStore(group, cache, Log.forMetrics)
                 return store, $"dynamo -t {a.IndexTable}", fun pos -> store.Override(source, tranche, pos) }
         Log.Information("Checkpoint Source {source} Tranche {tranche} Consumer Group {group}", source, tranche, group)
         match a.TryGetResult OverridePosition with
@@ -210,7 +210,7 @@ module Project =
                 let indexStore, maybeHydrate = sa.MonitoringParams()
                 let checkpoints =
                     let cache = Equinox.Cache (appName, sizeMb = 1)
-                    sa.CreateCheckpointStore(group, cache, Log.forMetrics())
+                    sa.CreateCheckpointStore(group, cache, Log.forMetrics)
                 let loadMode =
                     match maybeHydrate with
                     | Some (context, streamsDop) ->
@@ -220,7 +220,7 @@ module Project =
                 Propulsion.DynamoStore.DynamoStoreSource(
                     Log.Logger, stats.StatsInterval,
                     indexStore, defaultArg maxItems 100, TimeSpan.FromSeconds 0.5,
-                    checkpoints, sink, loadMode, fromTail = startFromTail, storeLog = Log.forMetrics()
+                    checkpoints, sink, loadMode, fromTail = startFromTail, storeLog = Log.forMetrics
                 ).Start()
         let work = [
             Async.AwaitKeyboardInterruptAsTaskCancelledException()

--- a/tools/Propulsion.Tool/Propulsion.Tool.fsproj
+++ b/tools/Propulsion.Tool/Propulsion.Tool.fsproj
@@ -13,6 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="Infrastructure.fs" />
     <Compile Include="Args.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
@@ -28,8 +29,8 @@
 
 	<PackageReference Include="Argu" Version="6.1.1" />
     <PackageReference Include="Destructurama.FSharp.NetCore" Version="1.0.14" />
+    <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
-    <PackageReference Include="Serilog.Sinks.Seq" Version="5.1.1" />
   </ItemGroup>
 
 </Project>

--- a/tools/Propulsion.Tool/Propulsion.Tool.fsproj
+++ b/tools/Propulsion.Tool/Propulsion.Tool.fsproj
@@ -13,11 +13,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="Args.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Propulsion.CosmosStore\Propulsion.CosmosStore.fsproj" />
+    <ProjectReference Include="..\..\src\Propulsion.DynamoStore\Propulsion.DynamoStore.fsproj" />
     <ProjectReference Include="..\..\src\Propulsion.Kafka\Propulsion.Kafka.fsproj" />
   </ItemGroup>
 


### PR DESCRIPTION
- Implements inspecting or resetting checkpoints in Cosmos or Dynamo (for DynamoStoreSource, EventStoreDb.EventStoreSource, and Propulsion.Feed)
- Supports `dynamo` and `cosmos` stores
- Added support for `dynamo` to `project ... kafka` and project .. stats`