### PR TITLE
Propulsion.Tool: Add support for Cosmos Autoscaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - `Propulsion.CosmosStore3`: Special cased version of `Propulsion.CosmosStore` to target `Equinox.CosmosStore` v `[3.0.7`-`3.99.0]` **Deprecated; Please migrate to `Propulsion.CosmosStore` by updating `Equinox.CosmosStore` dependencies to `4.0.0`** [#139](https://github.com/jet/propulsion/pull/139)
 - `Propulsion.DynamoStore`: `Equinox.CosmosStore`-equivalent functionality for `Equinox.DynamoStore`. Combines elements of `CosmosStore`, `SqlStreamStore`, `Feed` [#140](https://github.com/jet/propulsion/pull/140)
 - `Propulsion.Tool`: `checkpoint` commandline option; enables viewing or overriding checkpoints [#141](https://github.com/jet/propulsion/pull/141)
+- `Propulsion.Tool`: Add support for [autoscaling throughput](https://docs.microsoft.com/en-us/azure/cosmos-db/provision-throughput-autoscale) of Cosmos containers and databases [#142](https://github.com/jet/propulsion/pull/142) 
 
 ### Changed
 

--- a/src/Propulsion.CosmosStore/Propulsion.CosmosStore.fsproj
+++ b/src/Propulsion.CosmosStore/Propulsion.CosmosStore.fsproj
@@ -23,7 +23,7 @@
 
     <PackageReference Include="FSharp.Core" Version="4.5.4" />
 
-    <PackageReference Include="Equinox.CosmosStore" Version="4.0.0-beta.5" />
+    <PackageReference Include="Equinox.CosmosStore" Version="4.0.0-beta.6" />
     <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.0-rc.2.2" />
   </ItemGroup>
 

--- a/tools/Propulsion.Tool/Program.fs
+++ b/tools/Propulsion.Tool/Program.fs
@@ -114,7 +114,6 @@ module CosmosInit =
             let args = Args.Cosmos.Arguments(c, sa)
             let mode = (CosmosInitInfo a).ProvisioningMode
             let client = args.ConnectLeases()
-            let rus = a.GetResult(InitAuxParameters.Rus)
             match mode with
             | Equinox.CosmosStore.Core.Initialization.Provisioning.Container ru ->
                 let modeStr = "Container"

--- a/tools/Propulsion.Tool/Program.fs
+++ b/tools/Propulsion.Tool/Program.fs
@@ -115,15 +115,23 @@ module CosmosInit =
             let mode = (CosmosInitInfo a).ProvisioningMode
             let client = args.ConnectLeases()
             match mode with
-            | Equinox.CosmosStore.Core.Initialization.Provisioning.Container ru ->
+            | Equinox.CosmosStore.Core.Initialization.Provisioning.Container throughput ->
                 let modeStr = "Container"
-                Log.Information("Provisioning Leases Container for {rus:n0} RU/s", modeStr, ru)
-            | Equinox.CosmosStore.Core.Initialization.Provisioning.Database ru ->
+                match throughput with
+                | Equinox.CosmosStore.Core.Initialization.Throughput.Autoscale rus ->
+                    Log.Information("Provisioning Leases Container having autoscale throughput of max {rus:n0} RU/s", rus)
+                | Equinox.CosmosStore.Core.Initialization.Throughput.Manual rus ->
+                    Log.Information("Provisioning Leases Container having manual throughput of {rus:n0} RU/s", rus)
+            | Equinox.CosmosStore.Core.Initialization.Provisioning.Database throughput ->
                 let modeStr = "Database"
-                Log.Information("Provisioning Leases Container at {mode:l} level for {rus:n0} RU/s", modeStr, ru)
+                match throughput with
+                | Equinox.CosmosStore.Core.Initialization.Throughput.Autoscale rus ->
+                    Log.Information("Provisioning Leases Container at {modeStr:l} level having autoscale throughput of max {rus:n0} RU/s", modeStr, rus)
+                | Equinox.CosmosStore.Core.Initialization.Throughput.Manual rus ->
+                    Log.Information("Provisioning Leases Container at {modeStr:l} level having manual mode with {rus:n0} RU/s", modeStr, rus)
             | Equinox.CosmosStore.Core.Initialization.Provisioning.Serverless ->
                 let modeStr = "Serverless"
-                Log.Information("Provisioning Leases Container in {mode:l} mode with automatic RU/s as configured in account", modeStr)
+                Log.Information("Provisioning Leases Container in {modeStr:l} mode with automatic throughput RU/s as configured in account", modeStr)
             return! Equinox.CosmosStore.Core.Initialization.initAux client.Database.Client (client.Database.Id, client.Id) mode
         | _ -> return failwith "please specify a `cosmos` endpoint" }
 

--- a/tools/Propulsion.Tool/Program.fs
+++ b/tools/Propulsion.Tool/Program.fs
@@ -49,7 +49,7 @@ and CosmosInitInfo(args : ParseResults<InitAuxParameters>) =
         | CosmosModeType.Container ->       Equinox.CosmosStore.Core.Initialization.Provisioning.Container throughputSpec
         | CosmosModeType.Db ->              Equinox.CosmosStore.Core.Initialization.Provisioning.Database throughputSpec
         | CosmosModeType.Serverless ->
-            if args.Contains Rus || args.Contains Autoscale then raise (MissingArg "Cannot specify RU/s or Autoscale in Serverless mode")
+            if args.Contains Rus || args.Contains Autoscale then missingArg "Cannot specify RU/s or Autoscale in Serverless mode"
             Equinox.CosmosStore.Core.Initialization.Provisioning.Serverless
 and [<NoEquality; NoComparison>] CheckpointParameters =
     | [<AltCommandLine "-s"; Mandatory>]    Source of Propulsion.Feed.SourceId

--- a/tools/Propulsion.Tool/Program.fs
+++ b/tools/Propulsion.Tool/Program.fs
@@ -2,6 +2,7 @@
 
 open Argu
 open Propulsion.CosmosStore.Infrastructure // AwaitKeyboardInterruptAsTaskCancelledException
+open Propulsion.Tool.Args
 open Serilog
 open System
 
@@ -23,30 +24,32 @@ type Parameters =
             | Project _ ->                  "Project from store specified as the last argument, storing state in the specified `aux` Store (see init)."
 
 and [<NoComparison; NoEquality>] InitAuxParameters =
-    | [<AltCommandLine("-ru"); Mandatory>]  Rus of int
-    | [<AltCommandLine "-A">]               Autoscale
-    | [<AltCommandLine "-m">]               Mode of CosmosModeType
-    | [<AltCommandLine("-s")>]              Suffix of string
-    | [<CliPrefix(CliPrefix.None)>]         Cosmos of ParseResults<Args.Cosmos.Parameters>
+    | [<AltCommandLine("-ru"); Unique>]  Rus of int
+    | [<AltCommandLine "-A"; Unique>]    Autoscale
+    | [<AltCommandLine "-m"; Unique>]    Mode of CosmosModeType
+    | [<AltCommandLine("-s")>]           Suffix of string
+    | [<CliPrefix(CliPrefix.None)>]      Cosmos of ParseResults<Args.Cosmos.Parameters>
     interface IArgParserTemplate with
         member a.Usage = a |> function
-            | Rus _ ->                      "Specify RU/s level to provision for the Aux Container."
+            | Rus _ ->                      "Specify RU/s level to provision for the Aux Container. (with AutoScale, the value represents the maximum RU/s to AutoScale based on)."
             | Autoscale ->                  "Autoscale provisioned throughput. Use --rus to specify the maximum RU/s."
             | Mode _ ->                     "Configure RU mode to use Container-level RU, Database-level RU, or Serverless allocations (Default: Use Container-level allocation)."
             | Suffix _ ->                   "Specify Container Name suffix (default: `-aux`)."
             | Cosmos _ ->                   "Cosmos Connection parameters."
 
 and CosmosInitInfo(args : ParseResults<InitAuxParameters>) =
+
+    let throughputSpec =
+        match args.Contains Autoscale with
+        | true -> Equinox.CosmosStore.Core.Initialization.Throughput.Autoscale (args.GetResult(Rus, 4000))
+        | false -> Equinox.CosmosStore.Core.Initialization.Throughput.Manual (args.GetResult(Rus, 400))
+
     member _.ProvisioningMode =
-        let throughput () =
-            if args.Contains Autoscale
-            then Equinox.CosmosStore.Core.Initialization.Throughput.Autoscale (args.GetResult(Rus, 4000))
-            else Equinox.CosmosStore.Core.Initialization.Throughput.Manual (args.GetResult(Rus, 400))
         match args.GetResult(Mode, CosmosModeType.Container) with
-        | CosmosModeType.Container ->       Equinox.CosmosStore.Core.Initialization.Provisioning.Container (throughput ())
-        | CosmosModeType.Db ->              Equinox.CosmosStore.Core.Initialization.Provisioning.Database (throughput ())
+        | CosmosModeType.Container ->       Equinox.CosmosStore.Core.Initialization.Provisioning.Container throughputSpec
+        | CosmosModeType.Db ->              Equinox.CosmosStore.Core.Initialization.Provisioning.Database throughputSpec
         | CosmosModeType.Serverless ->
-            if args.Contains Rus || args.Contains Autoscale then raise (failwith "Cannot specify RU/s or Autoscale in Serverless mode")
+            if args.Contains Rus || args.Contains Autoscale then raise (MissingArg "Cannot specify RU/s or Autoscale in Serverless mode")
             Equinox.CosmosStore.Core.Initialization.Provisioning.Serverless
 and [<NoEquality; NoComparison>] CheckpointParameters =
     | [<AltCommandLine "-s"; Mandatory>]    Source of Propulsion.Feed.SourceId


### PR DESCRIPTION
Adds an --autoscale/-A switch to the propulsion tool to support autoscaling throughput of Cosmos containers and databases. Specifying this flag causes the --rus parameter to be interpreted as "Maximum RU/s" and changes the default value to 4000 RU/s (the minimum MaxRUs value allowed by Cosmos).

The hardcoding which existed in 'Equinox.CosmosStore.Core.Initialization.initAux' to enforce a default behavior of 'Manual throughput with 400 RU/s' has been brought into the propulsion tool.