### PR TITLE
Hardwire reader for well-known DynamoStore AppendsEpochId

### DIFF
--- a/src/Propulsion.DynamoStore/DynamoStoreSource.fs
+++ b/src/Propulsion.DynamoStore/DynamoStoreSource.fs
@@ -38,7 +38,9 @@ module private Impl =
     let readTranches log context = async {
         let index = AppendsIndex.Reader.create log context
         let! res = index.ReadKnownTranches()
-        return res |> Array.map AppendsTrancheId.toTrancheId }
+        // TODO remove this hard-coding if/when FeedSourceBase.Pump starts to periodically pick up new tranches
+        let appendsTrancheIds = match res with [||] -> [| AppendsTrancheId.wellKnownId |] | ids -> ids
+        return appendsTrancheIds |> Array.map AppendsTrancheId.toTrancheId }
 
     let readTailPositionForTranche log context (AppendsTrancheId.Parse trancheId) = async {
         let index = AppendsIndex.Reader.create log context

--- a/src/Propulsion.Feed/FeedSource.fs
+++ b/src/Propulsion.Feed/FeedSource.fs
@@ -34,6 +34,8 @@ type FeedSourceBase internal
         (   readTranches : unit -> Async<TrancheId[]>,
             // Responsible for managing retries and back offs; yielding an exception will result in abend of the read loop
             crawl : TrancheId -> bool * Position -> AsyncSeq<TimeSpan * Batch<byte[]>>) = async {
+        // TODO implement behavior to pick up newly added tranches by periodically re-running readTranches
+        // TODO when that's done, remove workaround in readTranches
         try let! tranches = readTranches ()
             log.Information("Starting {tranches} tranche readers...", tranches.Length)
             return! Async.Parallel(tranches |> Seq.mapi (pumpPartition crawl)) |> Async.Ignore<unit[]>


### PR DESCRIPTION
At present, `FeedSourceBase` does not have logic to pick up new `trancheId`s that become available after a source starts.

The main scenario this affects is the generic `FeedSource` - the source needs restarting whenever a TrancheId is added.

This PR works around this shortcoming by defaulting to the well-known `DynamoStore.AppendsIndexId` when no events have yet been indexed, which covers all the cases for the current implementation.

resolves https://github.com/jet/propulsion/issues/146