### PR TITLE
Remove FSharp.Core 6.0.4 bug workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Changed
 
-- Targeted `net6.0` with `6.0.300` SDK, `FSharp.Control.AsyncSeq` v `3.2.1`, `MathNet.Numerics` v `4.15.0`
+- Targeted `net6.0` with `6.0.300` SDK, `FSharp.Core` v `6.0.5`, `FSharp.Control.AsyncSeq` v `3.2.1`, `MathNet.Numerics` v `4.15.0`
 - `Propulsion.CosmosStore`: Changed to target `Equinox.CosmosStore` v `4.0.0` [#139](https://github.com/jet/propulsion/pull/139)
 - `Propulsion.CosmosStore.CosmosSource`: Changed parsing to use `System.Text.Json` [#139](https://github.com/jet/propulsion/pull/139)
 - `Propulsion.EventStore`: Pinned to target `Equinox.EventStore` v `[3.0.7`-`3.99.0]` **Deprecated; Please migrate to `Propulsion.EventStoreDb`** [#139](https://github.com/jet/propulsion/pull/139)

--- a/src/Propulsion.DynamoStore.Lambda/Propulsion.DynamoStore.Lambda.fsproj
+++ b/src/Propulsion.DynamoStore.Lambda/Propulsion.DynamoStore.Lambda.fsproj
@@ -27,8 +27,6 @@
     <ItemGroup>
       <PackageReference Include="MinVer" Version="4.0.0" PrivateAssets="All" />
         
-      <PackageReference Include="FSharp.Core" Version="6.0.5" />
-        
       <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
       <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.1" />
       <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />

--- a/src/Propulsion.DynamoStore.Lambda/Propulsion.DynamoStore.Lambda.fsproj
+++ b/src/Propulsion.DynamoStore.Lambda/Propulsion.DynamoStore.Lambda.fsproj
@@ -1,6 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
+        <!-- Ordinarily we'd let the base Targets pick the FSharp.Core,
+             but that clashes with Propulsion.DynamoStore's need for FSharp.Core 6.0.5 and errors out on publish -->
+        <!-- <DisableImplicitFSharpCoreReference>false</DisableImplicitFSharpCoreReference>-->
         
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
         <AWSProjectType>Lambda</AWSProjectType>
@@ -23,6 +26,8 @@
     
     <ItemGroup>
       <PackageReference Include="MinVer" Version="4.0.0" PrivateAssets="All" />
+        
+      <PackageReference Include="FSharp.Core" Version="6.0.5" />
         
       <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
       <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.1" />

--- a/src/Propulsion.DynamoStore.Lambda/Propulsion.DynamoStore.Lambda.fsproj
+++ b/src/Propulsion.DynamoStore.Lambda/Propulsion.DynamoStore.Lambda.fsproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <DisableImplicitFSharpCoreReference>false</DisableImplicitFSharpCoreReference>
         
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
         <AWSProjectType>Lambda</AWSProjectType>

--- a/src/Propulsion.DynamoStore/Propulsion.DynamoStore.fsproj
+++ b/src/Propulsion.DynamoStore/Propulsion.DynamoStore.fsproj
@@ -27,6 +27,7 @@
         
       <!-- NOTE Code here leans on the fact that https://github.com/dotnet/fsharp/issues/13165 is resolved in 6.0.5 -->
       <PackageReference Include="FSharp.Core" Version="6.0.5" />
+        
       <PackageReference Include="Equinox.DynamoStore" Version="4.0.0-beta.10.3" />
       <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.0-rc.4" />
     </ItemGroup>

--- a/src/Propulsion.DynamoStore/Propulsion.DynamoStore.fsproj
+++ b/src/Propulsion.DynamoStore/Propulsion.DynamoStore.fsproj
@@ -26,7 +26,7 @@
       <PackageReference Include="MinVer" Version="4.0.0" PrivateAssets="All" />
         
       <!-- NOTE Code here leans on the fact that https://github.com/dotnet/fsharp/issues/13165 is resolved in 6.0.5 -->
-      <PackageReference Include="FSharp.Core" Version="6.0.5" />
+      <!-- <PackageReference Include="FSharp.Core" Version="6.0.5" />-->
         
       <PackageReference Include="Equinox.DynamoStore" Version="4.0.0-beta.10.3" />
       <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.0-rc.4" />

--- a/src/Propulsion.DynamoStore/Propulsion.DynamoStore.fsproj
+++ b/src/Propulsion.DynamoStore/Propulsion.DynamoStore.fsproj
@@ -24,7 +24,9 @@
     
     <ItemGroup>
       <PackageReference Include="MinVer" Version="4.0.0" PrivateAssets="All" />
-
+        
+      <!-- NOTE Code here leans on the fact that https://github.com/dotnet/fsharp/issues/13165 is resolved in 6.0.5 -->
+      <PackageReference Include="FSharp.Core" Version="6.0.5" />
       <PackageReference Include="Equinox.DynamoStore" Version="4.0.0-beta.10.3" />
       <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.0-rc.4" />
     </ItemGroup>

--- a/src/Propulsion.DynamoStore/Types.fs
+++ b/src/Propulsion.DynamoStore/Types.fs
@@ -86,25 +86,7 @@ module internal EventCodec =
 
 module internal Async =
 
-    open Propulsion.Infrastructure // AwaitTaskCorrect
-
-    type Async with
-        static member Throttle degreeOfParallelism =
-            let s = new System.Threading.SemaphoreSlim(degreeOfParallelism)
-            fun computation -> async {
-                let! ct = Async.CancellationToken
-                do! s.WaitAsync ct |> Async.AwaitTaskCorrect
-                try return! computation
-                finally s.Release() |> ignore }
-    let private parallelThrottledUnsafe dop computations = // https://github.com/dotnet/fsharp/issues/13165
+    let parallelThrottled dop computations =
+        // NOTE this requires FSharp.Core 6.0.5 as there can be > 1200 computations and v <= 6.0.4 had a tail recursion bug
+        // https://github.com/dotnet/fsharp/issues/13165
         Async.Parallel(computations, maxDegreeOfParallelism = dop)
-    let parallelThrottled dop computations = async {
-        let throttle = Async.Throttle dop // each batch of 1200 gets the full potential dop - we internally limit what actually gets to run concurrently here
-        let! allResults =
-            computations
-            |> Seq.map throttle
-            |> Seq.chunkBySize 1200
-            |> Seq.map (parallelThrottledUnsafe dop)
-            |> Async.Parallel
-        return Array.concat allResults
-    }

--- a/src/Propulsion/Propulsion.fsproj
+++ b/src/Propulsion/Propulsion.fsproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="MinVer" Version="4.0.0" PrivateAssets="All" />
 
-    <PackageReference Include="FSharp.Core" Version="6.0.0" />
+    <PackageReference Include="FSharp.Core" Version="6.0.5" />
 
     <!-- We only depend on the ITimelineEvent contracts, so going to v3 is not useful/necessary -->
     <PackageReference Include="FsCodec" Version="2.0.0" />
@@ -26,7 +26,6 @@
     <!--    NB TEMP; needs to be shipped out-->
     <PackageReference Include="prometheus-net" Version="3.6.0" />
     <PackageReference Include="Serilog" Version="2.7.1" />
-    <PackageReference Include="System.Threading.Channels" Version="6.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Can't find any obvious way to remove the error (maybe a higher SDK ver will bring 6.0.5 so I don't need to add it explicitly?)

Would prefer not to add a 6.0.5 dep at top level like last commit does