### PR TITLE
Ingester/Submitter: Remove sleeps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - `Propulsion.DynamoStore`: `Equinox.CosmosStore`-equivalent functionality for `Equinox.DynamoStore`. Combines elements of `CosmosStore`, `SqlStreamStore`, `Feed` [#140](https://github.com/jet/propulsion/pull/140)
 - `Propulsion.Tool`: `checkpoint` commandline option; enables viewing or overriding checkpoints [#141](https://github.com/jet/propulsion/pull/141)
 - `Propulsion.Tool`: Add support for [autoscaling throughput](https://docs.microsoft.com/en-us/azure/cosmos-db/provision-throughput-autoscale) of Cosmos containers and databases [#142](https://github.com/jet/propulsion/pull/142) :pray: [@brihadish](https://github.com/brihadish)
+- `Ingester`: Expose optional `ingesterStatsInterval` control [#154](https://github.com/jet/propulsion/pull/154)
 
 ### Changed
 
@@ -25,6 +26,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - `Propulsion.EventStore`: Pinned to target `Equinox.EventStore` v `[3.0.7`-`3.99.0]` **Deprecated; Please migrate to `Propulsion.EventStoreDb`** [#139](https://github.com/jet/propulsion/pull/139)
 - `Propulsion.EventStoreDb.EventStoreSource`: Changed API to match`Propulsion.SqlStreamStore` API rather than`Propulsion.EventStore` [#139](https://github.com/jet/propulsion/pull/139)
 - `Kafka`: Target `FsCodec.NewtonsoftJson` v `3.0.0` [#139](https://github.com/jet/propulsion/pull/139)
+- `Ingester`,`Submitter`: Replaced `Async.Sleep` with `Task.WhenAny`; Condensed logging [#154](https://github.com/jet/propulsion/pull/154)
 
 ### Removed
 
@@ -34,6 +36,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 - `Propulsion.SqlStreamStore`: Replaced incorrect/meaningless stream name for `SqlStreamStoreSource` [#139](https://github.com/jet/propulsion/pull/139)
 - Synced [`AwaitTaskCorrect`](http://www.fssnip.net/7Rc/title/AsyncAwaitTaskCorrect) with official version [3c11142](https://github.com/jet/propulsion/commit/3c11142b75bf3b0ef2181fd106a4b17c0b2313ef)
+- `Projector`,`Ingester`,`Submitter`, `Scheduler`: Deterministic shutdown via Cancellation and/or unhandled exceptions [#154](https://github.com/jet/propulsion/pull/154)
 
 <a name="2.12.2"></a>
 ## [2.12.2] - 2022-03-10

--- a/src/Propulsion.Cosmos/CosmosPruner.fs
+++ b/src/Propulsion.Cosmos/CosmosPruner.fs
@@ -117,7 +117,7 @@ type CosmosPruner =
             // Default 5m
             ?statsInterval,
             // Default 5m
-            ?stateInterval, ?ingesterStatsInterval, ?maxSubmissionsPerPartition, ?pumpInterval,
+            ?stateInterval, ?ingesterStatsInterval, ?maxSubmissionsPerPartition,
             // Delay when no items available. Default 10ms.
             ?idleDelay,
             // Frequency with which to jettison Write Position information for inactive streams in order to limit memory consumption
@@ -133,4 +133,4 @@ type CosmosPruner =
         let streamScheduler = Pruner.StreamSchedulingEngine.Create(pruneUntil, dispatcher, stats, dumpStreams, idleDelay=idleDelay, ?purgeInterval=purgeInterval)
         Propulsion.Streams.Projector.StreamsProjectorPipeline.Start(
             log, dispatcher.Pump(), streamScheduler.Pump, maxReadAhead, streamScheduler.Submit, statsInterval,
-            ?ingesterStatsInterval=ingesterStatsInterval, ?maxSubmissionsPerPartition=maxSubmissionsPerPartition, ?pumpInterval=pumpInterval)
+            ?ingesterStatsInterval=ingesterStatsInterval, ?maxSubmissionsPerPartition=maxSubmissionsPerPartition)

--- a/src/Propulsion.Cosmos/CosmosPruner.fs
+++ b/src/Propulsion.Cosmos/CosmosPruner.fs
@@ -117,12 +117,15 @@ type CosmosPruner =
             // Default 5m
             ?statsInterval,
             // Default 5m
-            ?stateInterval, ?ingesterStatsInterval, ?maxSubmissionsPerPartition,
+            ?stateInterval,
+            ?maxSubmissionsPerPartition,
             // Delay when no items available. Default 10ms.
             ?idleDelay,
             // Frequency with which to jettison Write Position information for inactive streams in order to limit memory consumption
             // NOTE: Can impair performance and/or increase costs of writes as it inhibits the ability of the ingester to discard redundant inputs
-            ?purgeInterval)
+            ?purgeInterval,
+            // Defaults to statsInterval
+            ?ingesterStatsInterval)
         : Propulsion.ProjectorPipeline<_> =
         let idleDelay = defaultArg idleDelay (TimeSpan.FromMilliseconds 10.)
         let statsInterval, stateInterval = defaultArg statsInterval (TimeSpan.FromMinutes 5.), defaultArg stateInterval (TimeSpan.FromMinutes 5.)
@@ -133,4 +136,5 @@ type CosmosPruner =
         let streamScheduler = Pruner.StreamSchedulingEngine.Create(pruneUntil, dispatcher, stats, dumpStreams, idleDelay=idleDelay, ?purgeInterval=purgeInterval)
         Propulsion.Streams.Projector.StreamsProjectorPipeline.Start(
             log, dispatcher.Pump(), streamScheduler.Pump, maxReadAhead, streamScheduler.Submit, statsInterval,
-            ?ingesterStatsInterval=ingesterStatsInterval, ?maxSubmissionsPerPartition=maxSubmissionsPerPartition)
+            ?maxSubmissionsPerPartition = maxSubmissionsPerPartition,
+            ?ingesterStatsInterval = ingesterStatsInterval)

--- a/src/Propulsion.Cosmos/CosmosSink.fs
+++ b/src/Propulsion.Cosmos/CosmosSink.fs
@@ -169,7 +169,7 @@ type CosmosSink =
             ?statsInterval,
             // Default 5m
             ?stateInterval,
-            ?ingesterStatsInterval, ?maxSubmissionsPerPartition, ?pumpInterval,
+            ?ingesterStatsInterval, ?maxSubmissionsPerPartition,
             // Tune the sleep time when there are no items to schedule or responses to process. Default 1ms.
             ?idleDelay,
             // Frequency with which to jettison Write Position information for inactive streams in order to limit memory consumption
@@ -187,4 +187,4 @@ type CosmosSink =
         let streamScheduler = Internal.StreamSchedulingEngine.Create(log, cosmosContexts, dispatcher, stats, dumpStreams, ?idleDelay=idleDelay, ?purgeInterval=purgeInterval, ?maxEvents=maxEvents, ?maxBytes=maxBytes)
         Propulsion.Streams.Projector.StreamsProjectorPipeline.Start(
             log, dispatcher.Pump(), streamScheduler.Pump, maxReadAhead, streamScheduler.Submit, statsInterval,
-            ?ingesterStatsInterval=ingesterStatsInterval, ?maxSubmissionsPerPartition=maxSubmissionsPerPartition, ?pumpInterval=pumpInterval)
+            ?ingesterStatsInterval=ingesterStatsInterval, ?maxSubmissionsPerPartition=maxSubmissionsPerPartition)

--- a/src/Propulsion.Cosmos/CosmosSink.fs
+++ b/src/Propulsion.Cosmos/CosmosSink.fs
@@ -169,7 +169,7 @@ type CosmosSink =
             ?statsInterval,
             // Default 5m
             ?stateInterval,
-            ?ingesterStatsInterval, ?maxSubmissionsPerPartition,
+            ?maxSubmissionsPerPartition,
             // Tune the sleep time when there are no items to schedule or responses to process. Default 1ms.
             ?idleDelay,
             // Frequency with which to jettison Write Position information for inactive streams in order to limit memory consumption
@@ -178,7 +178,8 @@ type CosmosSink =
             // Default: 16384
             ?maxEvents,
             // Default: 1MB (limited by maximum size of a CosmosDB stored procedure invocation)
-            ?maxBytes)
+            ?maxBytes,
+            ?ingesterStatsInterval)
         : Propulsion.ProjectorPipeline<_> =
         let statsInterval, stateInterval = defaultArg statsInterval (TimeSpan.FromMinutes 5.), defaultArg stateInterval (TimeSpan.FromMinutes 5.)
         let stats = Internal.Stats(log.ForContext<Internal.Stats>(), statsInterval, stateInterval)
@@ -187,4 +188,5 @@ type CosmosSink =
         let streamScheduler = Internal.StreamSchedulingEngine.Create(log, cosmosContexts, dispatcher, stats, dumpStreams, ?idleDelay=idleDelay, ?purgeInterval=purgeInterval, ?maxEvents=maxEvents, ?maxBytes=maxBytes)
         Propulsion.Streams.Projector.StreamsProjectorPipeline.Start(
             log, dispatcher.Pump(), streamScheduler.Pump, maxReadAhead, streamScheduler.Submit, statsInterval,
-            ?ingesterStatsInterval=ingesterStatsInterval, ?maxSubmissionsPerPartition=maxSubmissionsPerPartition)
+            ?maxSubmissionsPerPartition = maxSubmissionsPerPartition,
+            ?ingesterStatsInterval = ingesterStatsInterval)

--- a/src/Propulsion.CosmosStore/CosmosStorePruner.fs
+++ b/src/Propulsion.CosmosStore/CosmosStorePruner.fs
@@ -115,7 +115,7 @@ type CosmosStorePruner =
             /// Default 5m
             ?statsInterval,
             /// Default 5m
-            ?stateInterval, ?ingesterStatsInterval, ?maxSubmissionsPerPartition, ?pumpInterval,
+            ?stateInterval, ?ingesterStatsInterval, ?maxSubmissionsPerPartition,
             /// Delay when no items available. Default 10ms.
             ?idleDelay)
         : Propulsion.ProjectorPipeline<_> =
@@ -128,4 +128,4 @@ type CosmosStorePruner =
         let streamScheduler = Pruner.StreamSchedulingEngine.Create(pruneUntil, dispatcher, stats, dumpStreams, idleDelay=idleDelay)
         Propulsion.Streams.Projector.StreamsProjectorPipeline.Start(
             log, dispatcher.Pump(), streamScheduler.Pump, maxReadAhead, streamScheduler.Submit, statsInterval,
-            ?ingesterStatsInterval=ingesterStatsInterval, ?maxSubmissionsPerPartition=maxSubmissionsPerPartition, ?pumpInterval=pumpInterval)
+            ?ingesterStatsInterval=ingesterStatsInterval, ?maxSubmissionsPerPartition=maxSubmissionsPerPartition)

--- a/src/Propulsion.CosmosStore/CosmosStorePruner.fs
+++ b/src/Propulsion.CosmosStore/CosmosStorePruner.fs
@@ -115,9 +115,12 @@ type CosmosStorePruner =
             /// Default 5m
             ?statsInterval,
             /// Default 5m
-            ?stateInterval, ?ingesterStatsInterval, ?maxSubmissionsPerPartition,
+            ?stateInterval,
+            ?maxSubmissionsPerPartition,
             /// Delay when no items available. Default 10ms.
-            ?idleDelay)
+            ?idleDelay,
+            // Defaults to statsInterval
+            ?ingesterStatsInterval)
         : Propulsion.ProjectorPipeline<_> =
         let idleDelay = defaultArg idleDelay (TimeSpan.FromMilliseconds 10.)
         let statsInterval, stateInterval = defaultArg statsInterval (TimeSpan.FromMinutes 5.), defaultArg stateInterval (TimeSpan.FromMinutes 5.)
@@ -128,4 +131,5 @@ type CosmosStorePruner =
         let streamScheduler = Pruner.StreamSchedulingEngine.Create(pruneUntil, dispatcher, stats, dumpStreams, idleDelay=idleDelay)
         Propulsion.Streams.Projector.StreamsProjectorPipeline.Start(
             log, dispatcher.Pump(), streamScheduler.Pump, maxReadAhead, streamScheduler.Submit, statsInterval,
-            ?ingesterStatsInterval=ingesterStatsInterval, ?maxSubmissionsPerPartition=maxSubmissionsPerPartition)
+            ?maxSubmissionsPerPartition = maxSubmissionsPerPartition,
+            ?ingesterStatsInterval = ingesterStatsInterval)

--- a/src/Propulsion.CosmosStore/CosmosStoreSink.fs
+++ b/src/Propulsion.CosmosStore/CosmosStoreSink.fs
@@ -174,13 +174,14 @@ type CosmosStoreSink =
             ?statsInterval,
             /// Default 5m
             ?stateInterval,
-            ?ingesterStatsInterval, ?maxSubmissionsPerPartition,
+            ?maxSubmissionsPerPartition,
             /// Tune the sleep time when there are no items to schedule or responses to process. Default 1ms.
             ?idleDelay,
             /// Default: 16384
             ?maxEvents,
             /// Default: 1MB (limited by maximum size of a CosmosDB stored procedure invocation)
-            ?maxBytes)
+            ?maxBytes,
+            ?ingesterStatsInterval)
         : Propulsion.ProjectorPipeline<_> =
         let statsInterval, stateInterval = defaultArg statsInterval (TimeSpan.FromMinutes 5.), defaultArg stateInterval (TimeSpan.FromMinutes 5.)
         let stats = Internal.Stats(log.ForContext<Internal.Stats>(), statsInterval, stateInterval)
@@ -189,4 +190,5 @@ type CosmosStoreSink =
         let streamScheduler = Internal.StreamSchedulingEngine.Create(log, eventsContext, dispatcher, stats, dumpStreams, ?idleDelay=idleDelay, ?maxEvents=maxEvents, ?maxBytes=maxBytes)
         Propulsion.Streams.Projector.StreamsProjectorPipeline.Start(
             log, dispatcher.Pump(), streamScheduler.Pump, maxReadAhead, streamScheduler.Submit, statsInterval,
-            ?ingesterStatsInterval=ingesterStatsInterval, ?maxSubmissionsPerPartition=maxSubmissionsPerPartition)
+            ?maxSubmissionsPerPartition = maxSubmissionsPerPartition,
+            ?ingesterStatsInterval = ingesterStatsInterval)

--- a/src/Propulsion.CosmosStore/CosmosStoreSink.fs
+++ b/src/Propulsion.CosmosStore/CosmosStoreSink.fs
@@ -174,7 +174,7 @@ type CosmosStoreSink =
             ?statsInterval,
             /// Default 5m
             ?stateInterval,
-            ?ingesterStatsInterval, ?maxSubmissionsPerPartition, ?pumpInterval,
+            ?ingesterStatsInterval, ?maxSubmissionsPerPartition,
             /// Tune the sleep time when there are no items to schedule or responses to process. Default 1ms.
             ?idleDelay,
             /// Default: 16384
@@ -189,4 +189,4 @@ type CosmosStoreSink =
         let streamScheduler = Internal.StreamSchedulingEngine.Create(log, eventsContext, dispatcher, stats, dumpStreams, ?idleDelay=idleDelay, ?maxEvents=maxEvents, ?maxBytes=maxBytes)
         Propulsion.Streams.Projector.StreamsProjectorPipeline.Start(
             log, dispatcher.Pump(), streamScheduler.Pump, maxReadAhead, streamScheduler.Submit, statsInterval,
-            ?ingesterStatsInterval=ingesterStatsInterval, ?maxSubmissionsPerPartition=maxSubmissionsPerPartition, ?pumpInterval=pumpInterval)
+            ?ingesterStatsInterval=ingesterStatsInterval, ?maxSubmissionsPerPartition=maxSubmissionsPerPartition)

--- a/src/Propulsion.DynamoStore/Propulsion.DynamoStore.fsproj
+++ b/src/Propulsion.DynamoStore/Propulsion.DynamoStore.fsproj
@@ -24,7 +24,7 @@
     
     <ItemGroup>
       <PackageReference Include="MinVer" Version="4.0.0" PrivateAssets="All" />
-        
+
       <!-- NOTE Code here leans on the fact that https://github.com/dotnet/fsharp/issues/13165 is resolved in 6.0.5 -->
       <!-- <PackageReference Include="FSharp.Core" Version="6.0.5" />-->
         

--- a/src/Propulsion.EventStore/EventStoreSink.fs
+++ b/src/Propulsion.EventStore/EventStoreSink.fs
@@ -172,12 +172,14 @@ type EventStoreSink =
             // Default 5m
             ?statsInterval,
             // Default 5m
-            ?stateInterval, ?ingesterStatsInterval, ?maxSubmissionsPerPartition,
+            ?stateInterval,
+            ?maxSubmissionsPerPartition,
             // Tune the sleep time when there are no items to schedule or responses to process. Default 1ms.
             ?idleDelay,
             // Frequency with which to jettison Write Position information for inactive streams in order to limit memory consumption
             // NOTE: Can impair performance and/or increase costs of writes as it inhibits the ability of the ingester to discard redundant inputs
-            ?purgeInterval)
+            ?purgeInterval,
+            ?ingesterStatsInterval)
         : Propulsion.ProjectorPipeline<_> =
         let statsInterval, stateInterval = defaultArg statsInterval (TimeSpan.FromMinutes 5.), defaultArg stateInterval (TimeSpan.FromMinutes 5.)
         let stats = Internal.Stats(log.ForContext<Internal.Stats>(), statsInterval, stateInterval)
@@ -186,4 +188,5 @@ type EventStoreSink =
         let streamScheduler = Internal.EventStoreSchedulingEngine.Create(log, storeLog, connections, dispatcher, stats, dumpStats, ?idleDelay=idleDelay, ?purgeInterval=purgeInterval)
         Propulsion.Streams.Projector.StreamsProjectorPipeline.Start(
             log, dispatcher.Pump(), streamScheduler.Pump, maxReadAhead, streamScheduler.Submit, statsInterval,
-            ?ingesterStatsInterval=ingesterStatsInterval, ?maxSubmissionsPerPartition=maxSubmissionsPerPartition)
+            ?maxSubmissionsPerPartition = maxSubmissionsPerPartition,
+            ?ingesterStatsInterval = ingesterStatsInterval)

--- a/src/Propulsion.EventStore/EventStoreSink.fs
+++ b/src/Propulsion.EventStore/EventStoreSink.fs
@@ -172,7 +172,7 @@ type EventStoreSink =
             // Default 5m
             ?statsInterval,
             // Default 5m
-            ?stateInterval, ?ingesterStatsInterval, ?maxSubmissionsPerPartition, ?pumpInterval,
+            ?stateInterval, ?ingesterStatsInterval, ?maxSubmissionsPerPartition,
             // Tune the sleep time when there are no items to schedule or responses to process. Default 1ms.
             ?idleDelay,
             // Frequency with which to jettison Write Position information for inactive streams in order to limit memory consumption
@@ -186,4 +186,4 @@ type EventStoreSink =
         let streamScheduler = Internal.EventStoreSchedulingEngine.Create(log, storeLog, connections, dispatcher, stats, dumpStats, ?idleDelay=idleDelay, ?purgeInterval=purgeInterval)
         Propulsion.Streams.Projector.StreamsProjectorPipeline.Start(
             log, dispatcher.Pump(), streamScheduler.Pump, maxReadAhead, streamScheduler.Submit, statsInterval,
-            ?ingesterStatsInterval=ingesterStatsInterval, ?maxSubmissionsPerPartition=maxSubmissionsPerPartition, ?pumpInterval=pumpInterval)
+            ?ingesterStatsInterval=ingesterStatsInterval, ?maxSubmissionsPerPartition=maxSubmissionsPerPartition)

--- a/src/Propulsion.Kafka/Consumers.fs
+++ b/src/Propulsion.Kafka/Consumers.fs
@@ -176,7 +176,7 @@ type ConsumerPipeline private (inner : IConsumer<string, string>, task : Task<un
             start "dispatcher" <| pumpDispatcher
             // ... fault results from dispatched tasks result in the `machine` concluding with an exception
             start "scheduler" <| pumpScheduler abend
-            start "submitter" <| pumpSubmitter
+            start "submitter" <| Async.AwaitTaskCorrect(pumpSubmitter ct)
             start "ingester" <| ingester.Pump()
 
             // await for either handler-driven abend or external cancellation via Stop()
@@ -194,7 +194,7 @@ type ParallelConsumer private () =
             mapResult : ConsumeResult<string, string> -> 'Msg,
             handle : 'Msg -> Async<Choice<unit, exn>>,
             // Default 5
-            ?maxSubmissionsPerPartition, ?pumpInterval,
+            ?maxSubmissionsPerPartition,
             // Default 5m
             ?statsInterval, ?logExternalStats) =
         let statsInterval = defaultArg statsInterval (TimeSpan.FromMinutes 5.)
@@ -208,19 +208,19 @@ type ParallelConsumer private () =
         let submitBatch (x : Parallel.Scheduling.Batch<_, _>) : int =
             scheduler.Submit x
             x.messages.Length
-        let submitter = Submission.SubmissionEngine(log, maxSubmissionsPerPartition, mapBatch, submitBatch, statsInterval, ?pumpInterval=pumpInterval)
-        ConsumerPipeline.Start(log, config, mapResult, submitter.Ingest, submitter.Pump(), scheduler.Pump, dispatcher.Pump(), statsInterval)
+        let submitter = Submission.SubmissionEngine(log, maxSubmissionsPerPartition, mapBatch, submitBatch, statsInterval)
+        ConsumerPipeline.Start(log, config, mapResult, submitter.Ingest, submitter.Pump, scheduler.Pump, dispatcher.Pump(), statsInterval)
 
     /// Builds a processing pipeline per the `config` running up to `dop` instances of `handle` concurrently to maximize global throughput across partitions.
     /// Processor pumps until `handle` yields a `Choice2Of2` or `Stop()` is requested.
     static member Start
         (   log : ILogger, config : KafkaConsumerConfig, maxDop, handle : KeyValuePair<string, string> -> Async<unit>,
             // Default 5
-            ?maxSubmissionsPerPartition, ?pumpInterval,
+            ?maxSubmissionsPerPartition,
             // Default 5m
             ?statsInterval, ?logExternalStats) =
         ParallelConsumer.Start<KeyValuePair<string, string>>(log, config, maxDop, Binding.mapConsumeResult, handle >> Async.Catch,
-            ?maxSubmissionsPerPartition=maxSubmissionsPerPartition, ?pumpInterval=pumpInterval, ?statsInterval=statsInterval, ?logExternalStats=logExternalStats)
+            ?maxSubmissionsPerPartition=maxSubmissionsPerPartition, ?statsInterval=statsInterval, ?logExternalStats=logExternalStats)
 
 type EventMetrics = Streams.EventMetrics
 
@@ -234,7 +234,7 @@ module Core =
             (   log : ILogger, config : KafkaConsumerConfig, resultToInfo, infoToStreamEvents,
                 prepare, handle, maxDop,
                 stats : Streams.Scheduling.Stats<EventMetrics * 'Outcome, EventMetrics * exn>, statsInterval,
-                ?maxSubmissionsPerPartition, ?pumpInterval, ?logExternalState, ?idleDelay, ?purgeInterval, ?maxBatches, ?maximizeOffsetWriting) =
+                ?maxSubmissionsPerPartition, ?logExternalState, ?idleDelay, ?purgeInterval, ?maxBatches, ?maximizeOffsetWriting) =
             let dispatcher = Streams.Scheduling.ItemDispatcher<_> maxDop
             let dumpStreams (streams : Streams.Scheduling.StreamStates<_>) log =
                 logExternalState |> Option.iter (fun f -> f log)
@@ -247,15 +247,14 @@ module Core =
                 Streams.Projector.StreamsSubmitter.Create
                     (   log, defaultArg maxSubmissionsPerPartition 5, mapConsumedMessagesToStreamsBatch,
                         streamsScheduler.Submit, statsInterval,
-                        ?pumpInterval=pumpInterval,
                         ?disableCompaction=maximizeOffsetWriting)
-            ConsumerPipeline.Start(log, config, resultToInfo, submitter.Ingest, submitter.Pump(), streamsScheduler.Pump, dispatcher.Pump(), statsInterval)
+            ConsumerPipeline.Start(log, config, resultToInfo, submitter.Ingest, submitter.Pump, streamsScheduler.Pump, dispatcher.Pump(), statsInterval)
 
         static member Start<'Info, 'Outcome>
             (   log : ILogger, config : KafkaConsumerConfig, consumeResultToInfo, infoToStreamEvents,
                 handle : StreamName * Streams.StreamSpan<_> -> Async<Streams.SpanResult * 'Outcome>, maxDop,
                 stats : Streams.Scheduling.Stats<EventMetrics * 'Outcome, EventMetrics * exn>, statsInterval,
-                ?maxSubmissionsPerPartition, ?pumpInterval, ?logExternalState, ?idleDelay, ?purgeInterval, ?maxBatches, ?maximizeOffsetWriting) =
+                ?maxSubmissionsPerPartition, ?logExternalState, ?idleDelay, ?purgeInterval, ?maxBatches, ?maximizeOffsetWriting) =
             let prepare (streamName, span) =
                 let stats = Streams.Buffering.StreamSpan.stats span
                 stats, (streamName, span)
@@ -263,7 +262,6 @@ module Core =
                 log, config, consumeResultToInfo, infoToStreamEvents, prepare, handle, maxDop,
                 stats, statsInterval,
                 ?maxSubmissionsPerPartition=maxSubmissionsPerPartition,
-                ?pumpInterval=pumpInterval,
                 ?logExternalState=logExternalState,
                 ?idleDelay=idleDelay, ?purgeInterval=purgeInterval,
                 ?maxBatches=maxBatches,
@@ -282,12 +280,11 @@ module Core =
                 prepare, handle : StreamName * Streams.StreamSpan<_> -> Async<Streams.SpanResult * 'Outcome>,
                 maxDop,
                 stats : Streams.Scheduling.Stats<EventMetrics * 'Outcome, EventMetrics * exn>, statsInterval,
-                ?maximizeOffsetWriting, ?maxSubmissionsPerPartition, ?pumpInterval, ?logExternalState, ?idleDelay, ?purgeInterval)=
+                ?maximizeOffsetWriting, ?maxSubmissionsPerPartition, ?logExternalState, ?idleDelay, ?purgeInterval)=
             StreamsConsumer.Start<KeyValuePair<string, string>, 'Outcome>(
                 log, config, Binding.mapConsumeResult, keyValueToStreamEvents, prepare, handle, maxDop,
                 stats, statsInterval=statsInterval,
                 ?maxSubmissionsPerPartition=maxSubmissionsPerPartition,
-                ?pumpInterval=pumpInterval,
                 ?logExternalState=logExternalState,
                 ?idleDelay=idleDelay, ?purgeInterval=purgeInterval,
                 ?maximizeOffsetWriting=maximizeOffsetWriting)
@@ -299,12 +296,11 @@ module Core =
                 keyValueToStreamEvents : KeyValuePair<string, string> -> Propulsion.Streams.StreamEvent<_> seq,
                 handle : StreamName * Streams.StreamSpan<_> -> Async<Streams.SpanResult * 'Outcome>, maxDop,
                 stats : Streams.Scheduling.Stats<EventMetrics * 'Outcome, EventMetrics * exn>, statsInterval,
-                ?maximizeOffsetWriting, ?maxSubmissionsPerPartition, ?pumpInterval, ?logExternalState, ?idleDelay, ?purgeInterval, ?maxBatches) =
+                ?maximizeOffsetWriting, ?maxSubmissionsPerPartition, ?logExternalState, ?idleDelay, ?purgeInterval, ?maxBatches) =
             StreamsConsumer.Start<KeyValuePair<string, string>, 'Outcome>(
                 log, config, Binding.mapConsumeResult, keyValueToStreamEvents, handle, maxDop,
                 stats, statsInterval,
                 ?maxSubmissionsPerPartition=maxSubmissionsPerPartition,
-                ?pumpInterval=pumpInterval,
                 ?logExternalState=logExternalState,
                 ?idleDelay=idleDelay, ?purgeInterval=purgeInterval,
                 ?maxBatches=maxBatches,
@@ -426,7 +422,8 @@ type StreamsConsumer =
             stats : Streams.Scheduling.Stats<EventMetrics * 'Outcome, EventMetrics * exn>, statsInterval,
             // Prevent batches being consolidated prior to scheduling in order to maximize granularity of consumer offset updates
             ?maximizeOffsetWriting,
-            ?maxSubmissionsPerPartition, ?pumpInterval, ?logExternalState,
+            ?maxSubmissionsPerPartition,
+            ?logExternalState,
             // Tune the sleep time when there are no items to schedule or responses to process. Default 1ms.
             ?idleDelay,
             // Frequency with which to jettison Write Position information for inactive streams in order to limit memory consumption
@@ -437,7 +434,6 @@ type StreamsConsumer =
             log, config, id, consumeResultToStreamEvents, handle, maxDop,
             stats, statsInterval,
             ?maxSubmissionsPerPartition=maxSubmissionsPerPartition,
-            ?pumpInterval=pumpInterval,
             ?logExternalState=logExternalState,
             ?idleDelay=idleDelay, ?purgeInterval=purgeInterval,
             ?maxBatches=maxBatches,
@@ -472,8 +468,6 @@ type BatchesConsumer =
             // Holding items back makes scheduler processing more efficient as less state needs to be traversed.
             // Default 5
             ?maxSubmissionsPerPartition,
-            // Default 5ms
-            ?pumpInterval,
             ?logExternalState,
             // Tune the sleep time when there are no items to schedule or responses to process. Default 1ms.
             ?idleDelay,
@@ -481,6 +475,7 @@ type BatchesConsumer =
             // NOTE: Can impair performance and/or increase costs of writes as it inhibits the ability of the ingester to discard redundant inputs
             ?purgeInterval) =
         let maxBatches = defaultArg schedulerIngestionBatchCount 24
+        let mspp = defaultArg maxSubmissionsPerPartition 5
         let dumpStreams (streams : Streams.Scheduling.StreamStates<_>) log =
             logExternalState |> Option.iter (fun f -> f log)
             streams.Dump(log, Streams.Buffering.StreamState.eventsSize)
@@ -513,8 +508,5 @@ type BatchesConsumer =
         let mapConsumedMessagesToStreamsBatch onCompletion (x : Submission.SubmissionBatch<TopicPartition, 'Info>) : Streams.Scheduling.StreamsBatch<_> =
             let onCompletion () = x.onCompletion(); onCompletion()
             Streams.Scheduling.StreamsBatch.Create(onCompletion, Seq.collect infoToStreamEvents x.messages) |> fst
-        let submitter =
-            Streams.Projector.StreamsSubmitter.Create
-                (   log, defaultArg maxSubmissionsPerPartition 5, mapConsumedMessagesToStreamsBatch, streamsScheduler.Submit, statsInterval,
-                    ?pumpInterval=pumpInterval)
-        ConsumerPipeline.Start(log, config, consumeResultToInfo, submitter.Ingest, submitter.Pump(), streamsScheduler.Pump, dispatcher.Pump(), statsInterval)
+        let submitter = Streams.Projector.StreamsSubmitter.Create(log, mspp, mapConsumedMessagesToStreamsBatch, streamsScheduler.Submit, statsInterval)
+        ConsumerPipeline.Start(log, config, consumeResultToInfo, submitter.Ingest, submitter.Pump, streamsScheduler.Pump, dispatcher.Pump(), statsInterval)

--- a/src/Propulsion/Ingestion.fs
+++ b/src/Propulsion/Ingestion.fs
@@ -121,8 +121,7 @@ type Ingester<'Items, 'Batch> private
     /// Starts an independent Task that handles
     /// a) `unpack`ing of `incoming` items
     /// b) `submit`ting them onward (assuming there is capacity within the `readLimit`)
-    static member Start<'Item>(log, partitionId, maxRead, makeBatch, submit, ?statsInterval) =
-        let statsInterval = defaultArg statsInterval (TimeSpan.FromMinutes 5.)
+    static member Start<'Item>(log, partitionId, maxRead, makeBatch, submit, statsInterval) =
         let cts = new CancellationTokenSource()
         let stats = Stats(log, partitionId, statsInterval)
         let instance = Ingester<_, _>(stats, maxRead, makeBatch, submit, cts)

--- a/src/Propulsion/Ingestion.fs
+++ b/src/Propulsion/Ingestion.fs
@@ -57,7 +57,7 @@ type private Stats(log : ILogger, partitionId, statsInterval : TimeSpan) =
         cycles <- 0; batchesPended <- 0; streamsPended <- 0; eventsPended <- 0
         if commitFails <> 0 || commits <> 0 then
             if commits = 0 then log.Error("Ingester {partitionId} Commits failing: {failures} failures", partitionId, commitFails)
-            else log.Warning("Ingester {partitionId} Commits {failures} failures, {commits} successes", partitionId, commitFails, commits)
+            else log.Information("Ingester {partitionId} Commits failed {failures} succeeded {commits}", partitionId, commitFails, commits)
             commits <- 0; commitFails <- 0
 
     member _.Handle : InternalMessage -> unit = function

--- a/src/Propulsion/Ingestion.fs
+++ b/src/Propulsion/Ingestion.fs
@@ -109,7 +109,7 @@ type Ingester<'Items, 'Batch> private
 
     member private _.Pump ct = task {
         use _ = progressWriter.Result.Subscribe(ProgressResult >> enqueueMessage)
-        Task.start (progressWriter.Pump ct)
+        Task.start (fun () -> progressWriter.Pump ct)
         while true do
             while applyIncoming handleIncoming || applyMessages stats.Handle do ()
             let nextStatsIntervalMs = stats.TryDump(maxRead.State)
@@ -125,7 +125,7 @@ type Ingester<'Items, 'Batch> private
         let cts = new CancellationTokenSource()
         let stats = Stats(log, partitionId, statsInterval)
         let instance = Ingester<_, _>(stats, maxRead, makeBatch, submit, cts)
-        Task.start (instance.Pump cts.Token)
+        Task.start (fun () -> instance.Pump cts.Token)
         instance
 
     /// Submits a batch as read for unpacking and submission; will only return after the in-flight reads drops below the limit

--- a/src/Propulsion/Ingestion.fs
+++ b/src/Propulsion/Ingestion.fs
@@ -3,18 +3,26 @@
 open Propulsion.Internal // Helpers
 open Serilog
 open System
-open System.Collections.Concurrent
 open System.Threading
+open System.Threading.Tasks
 
 /// Manages writing of progress
 /// - Each write attempt is always of the newest token (each update is assumed to also count for all preceding ones)
 /// - retries until success or a new item is posted
-type ProgressWriter<'Res when 'Res : equality>(?period, ?sleep) =
-    let writeInterval, sleepPeriod = defaultArg period (TimeSpan.FromSeconds 5.), defaultArg sleep (TimeSpan.FromMilliseconds 100.)
-    let due = intervalCheck writeInterval
+type ProgressWriter<'Res when 'Res : equality>(?period) =
+    let commitInterval = defaultArg period (TimeSpan.FromSeconds 5.)
     let mutable committedEpoch = None
     let mutable validatedPos = None
     let result = Event<Choice<'Res, exn>>()
+
+    let commitIfDirty ct = task {
+        match Volatile.Read &validatedPos with
+        | Some (v,f) when Volatile.Read(&committedEpoch) <> Some v ->
+            try do! Async.StartAsTask(f, cancellationToken = ct)
+                Volatile.Write(&committedEpoch, Some v)
+                result.Trigger (Choice1Of2 v)
+            with e -> result.Trigger (Choice2Of2 e)
+        | _ -> () }
 
     [<CLIEvent>] member _.Result = result.Publish
 
@@ -23,16 +31,10 @@ type ProgressWriter<'Res when 'Res : equality>(?period, ?sleep) =
 
     member _.CommittedEpoch = Volatile.Read(&committedEpoch)
 
-    member _.Pump = async {
-        let! ct = Async.CancellationToken
+    member _.Pump(ct : CancellationToken) = task {
         while not ct.IsCancellationRequested do
-            match Volatile.Read &validatedPos with
-            | Some (v,f) when Volatile.Read(&committedEpoch) <> Some v && due () ->
-                try do! f
-                    Volatile.Write(&committedEpoch, Some v)
-                    result.Trigger (Choice1Of2 v)
-                with e -> result.Trigger (Choice2Of2 e)
-            | _ -> do! Async.Sleep sleepPeriod }
+            do! commitIfDirty ct
+            do! Task.sleep commitInterval ct }
 
 [<NoComparison; NoEquality>]
 type private InternalMessage =
@@ -47,27 +49,16 @@ type private Stats(log : ILogger, partitionId, statsInterval : TimeSpan) =
     let mutable validatedEpoch, committedEpoch : int64 option * int64 option = None, None
     let mutable commitFails, commits = 0, 0
     let mutable cycles, batchesPended, streamsPended, eventsPended = 0, 0, 0, 0
-    let statsDue = intervalCheck statsInterval
+    let statsInterval = timeRemaining statsInterval
 
     let dumpStats (activeReads, maxReads) =
-        log.Information("Reader {partitionId} Cycles {cycles} Ingested {batches} ({streams:n0}s {events:n0}e)",
-               partitionId, cycles, batchesPended, streamsPended, eventsPended)
+        log.Information("Ingester {partitionId} Ahead {activeReads}/{maxReads} @ {validated} (committed: {committed}, {commits} commits) Ingested {batches} ({streams:n0}s {events:n0}e) Cycles {cycles}",
+                        partitionId, activeReads, maxReads, Option.toNullable validatedEpoch, Option.toNullable committedEpoch, commits, batchesPended, streamsPended, eventsPended, cycles)
         cycles <- 0; batchesPended <- 0; streamsPended <- 0; eventsPended <- 0
         if commitFails <> 0 || commits <> 0 then
-            match committedEpoch with
-            | None ->
-                log.Error("Reader {partitionId} Ahead {activeReads}/{maxReads} @ {validated}; writing failing: {failures} failures ({commits} successful commits)",
-                        partitionId, activeReads, maxReads, Option.toNullable validatedEpoch, commitFails, commits)
-            | Some committed when commitFails <> 0 ->
-                log.Warning("Reader {partitionId} Ahead {activeReads}/{maxReads} @ {validated} (committed: {committed}, {commits} commits, {failures} failures)",
-                        partitionId, activeReads, maxReads, Option.toNullable validatedEpoch, committed, commits, commitFails)
-            | Some committed ->
-                log.Information("Reader {partitionId} Ahead {activeReads}/{maxReads} @ {validated} (committed: {committed}, {commits} commits)",
-                        partitionId, activeReads, maxReads, Option.toNullable validatedEpoch, committed, commits)
+            if commits = 0 then log.Error("Ingester {partitionId} Commits failing: {failures} failures", partitionId, commitFails)
+            else log.Warning("Ingester {partitionId} Commits {failures} failures, {commits} successes", partitionId, commitFails, commits)
             commits <- 0; commitFails <- 0
-        else
-            log.Information("Reader {partitionId} Ahead {activeReads}/{maxReads} @ {validated} (committed: {committed})",
-                    partitionId, activeReads, maxReads, Option.toNullable validatedEpoch, Option.toNullable committedEpoch)
 
     member _.Handle : InternalMessage -> unit = function
         | Validated epoch ->
@@ -84,70 +75,58 @@ type private Stats(log : ILogger, partitionId, statsInterval : TimeSpan) =
 
     member _.TryDump(readState) =
         cycles <- cycles + 1
-        let due = statsDue ()
+        let due, remaining = statsInterval ()
         if due then dumpStats readState
-        due
+        remaining
 
 /// Buffers items read from a range, unpacking them out of band from the reading so that can overlap
 /// On completion of the unpacking, they get submitted onward to the Submitter which will buffer them for us
 type Ingester<'Items, 'Batch> private
-    (   stats : Stats, maxRead, sleepInterval : TimeSpan,
+    (   stats : Stats, maxRead,
         makeBatch : (unit -> unit) -> 'Items -> 'Batch * (int * int),
         submit : 'Batch -> unit,
         cts : CancellationTokenSource) =
 
     let maxRead = Sem maxRead
-    let incoming = ConcurrentQueue<_>()
-    let messages = ConcurrentQueue<InternalMessage>()
-
-    let tryDequeue (x : ConcurrentQueue<_>) =
-        let mutable tmp = Unchecked.defaultof<_>
-        if x.TryDequeue &tmp then Some tmp
-        else None
+    let awaitIncoming, applyIncoming, enqueueIncoming =
+        let c = Channel.unboundedSwSr
+        Channel.awaitRead c, Channel.apply c, Channel.write c
+    let awaitMessage, applyMessages, enqueueMessage =
+        let c = Channel.unboundedSr
+        Channel.awaitRead c, Channel.apply c, Channel.write c
 
     let progressWriter = ProgressWriter<_>()
 
-    let tryIncoming () =
-        match tryDequeue incoming with
-        | None -> false
-        | Some (epoch, checkpoint, items, outerMarkCompleted) ->
-            let markCompleted () =
-                maxRead.Release()
-                outerMarkCompleted |> Option.iter (fun f -> f ()) // we guarantee this happens before checkpoint can be called
-                messages.Enqueue (Validated epoch)
-                progressWriter.Post(epoch, checkpoint)
-            let batch, (streamCount, itemCount) = makeBatch markCompleted items
-            submit batch
-            messages.Enqueue(Added (streamCount,itemCount))
-            true
+    let handleIncoming (epoch, checkpoint, items, outerMarkCompleted) =
+        let markCompleted () =
+            maxRead.Release()
+            outerMarkCompleted |> Option.iter (fun f -> f ()) // we guarantee this happens before checkpoint can be called
+            enqueueMessage <| Validated epoch
+            progressWriter.Post(epoch, checkpoint)
+        let batch, (streamCount, itemCount) = makeBatch markCompleted items
+        submit batch
+        enqueueMessage <| Added (streamCount,itemCount)
 
-    let tryHandle () =
-        match tryDequeue messages with
-        | None -> false
-        | Some x ->
-            stats.Handle x
-            true
-
-    member private _.Pump() = async {
-        let! ct = Async.CancellationToken
-        use _ = progressWriter.Result.Subscribe(ProgressResult >> messages.Enqueue)
-        let! _ = Async.StartChild(progressWriter.Pump)
+    member private _.Pump(ct) = task {
+        use _ = progressWriter.Result.Subscribe(ProgressResult >> enqueueMessage)
+        Task.start (progressWriter.Pump ct)
         while not ct.IsCancellationRequested do
+            while applyIncoming handleIncoming || applyMessages stats.Handle do ()
+            let nextStatsMs = stats.TryDump(maxRead.State)
+            let! _ = Task.WhenAny(awaitIncoming (), awaitMessage (), Task.Delay(int nextStatsMs, ct)) in () }
             // arguably the impl should be submitting while unpacking but
             // - maintaining consistency between incoming order and submit order is required
             // - in general maxRead will be double maxSubmit so this will only be relevant in catchup situations
-            let worked = tryHandle () || tryIncoming () || stats.TryDump(maxRead.State)
-            if not worked then do! Async.Sleep sleepInterval }
 
     /// Starts an independent Task that handles
     /// a) `unpack`ing of `incoming` items
     /// b) `submit`ting them onward (assuming there is capacity within the `readLimit`)
-    static member Start<'Item>(log, partitionId, maxRead, makeBatch, submit, ?statsInterval, ?sleepInterval) =
-        let maxWait, statsInterval = defaultArg sleepInterval (TimeSpan.FromMilliseconds 5.), defaultArg statsInterval (TimeSpan.FromMinutes 5.)
+    static member Start<'Item>(log, partitionId, maxRead, makeBatch, submit, ?statsInterval) =
+        let statsInterval = defaultArg statsInterval (TimeSpan.FromMinutes 5.)
         let cts = new CancellationTokenSource()
         let stats = Stats(log, partitionId, statsInterval)
-        let instance = Ingester<_, _>(stats, maxRead, maxWait, makeBatch, submit, cts)
-        Async.Start(instance.Pump(), cts.Token)
+        let instance = Ingester<_, _>(stats, maxRead, makeBatch, submit, cts)
+        Task.start (instance.Pump(cts.Token))
         instance
 
     /// Submits a batch as read for unpacking and submission; will only return after the in-flight reads drops below the limit
@@ -156,7 +135,7 @@ type Ingester<'Items, 'Batch> private
     ///   (but prior to the calling of the checkpoint method, which will take place asynchronously)
     member _.Submit(epoch, checkpoint, items, ?markCompleted) = async {
         // If we've read it, feed it into the queue for unpacking
-        incoming.Enqueue (epoch, checkpoint, items, markCompleted)
+        enqueueIncoming (epoch, checkpoint, items, markCompleted)
         // ... but we might hold off on yielding if we're at capacity
         do! maxRead.Await(cts.Token)
         return maxRead.State }

--- a/src/Propulsion/Parallel.fs
+++ b/src/Propulsion/Parallel.fs
@@ -184,12 +184,12 @@ module Scheduling =
             incoming.Enqueue batches
 
 type ParallelIngester<'Item> =
-    static member Start(log, partitionId, maxRead, submit, ?statsInterval, ?sleepInterval) =
+    static member Start(log, partitionId, maxRead, submit, ?statsInterval) =
         let makeBatch onCompletion (items : 'Item seq) =
             let items = Array.ofSeq items
             let batch : Submission.SubmissionBatch<_, 'Item> = { source = partitionId; onCompletion = onCompletion; messages = items }
             batch,(items.Length,items.Length)
-        Ingestion.Ingester<'Item seq,Submission.SubmissionBatch<_, 'Item>>.Start(log, partitionId, maxRead, makeBatch, submit, ?statsInterval=statsInterval, ?sleepInterval=sleepInterval)
+        Ingestion.Ingester<'Item seq,Submission.SubmissionBatch<_, 'Item>>.Start(log, partitionId, maxRead, makeBatch, submit, ?statsInterval=statsInterval)
 
 type ParallelProjector =
     static member Start

--- a/src/Propulsion/Parallel.fs
+++ b/src/Propulsion/Parallel.fs
@@ -184,23 +184,24 @@ module Scheduling =
             incoming.Enqueue batches
 
 type ParallelIngester<'Item> =
-    static member Start(log, partitionId, maxRead, submit, ?statsInterval) =
+
+    static member Start(log, partitionId, maxRead, submit, statsInterval) =
         let makeBatch onCompletion (items : 'Item seq) =
             let items = Array.ofSeq items
             let batch : Submission.SubmissionBatch<_, 'Item> = { source = partitionId; onCompletion = onCompletion; messages = items }
             batch,(items.Length,items.Length)
-        Ingestion.Ingester<'Item seq,Submission.SubmissionBatch<_, 'Item>>.Start(log, partitionId, maxRead, makeBatch, submit, ?statsInterval=statsInterval)
+        Ingestion.Ingester<'Item seq,Submission.SubmissionBatch<_, 'Item>>.Start(log, partitionId, maxRead, makeBatch, submit, statsInterval)
 
 type ParallelProjector =
+
     static member Start
             (    log : ILogger, maxReadAhead, maxDop, handle,
-                 /// Default 5m
-                 ?statsInterval,
-                 /// Default 5
-                 ?maxSubmissionsPerPartition, ?logExternalStats, ?pumpInterval)
+                 statsInterval, ?ingesterStatsInterval,
+                 // Default 5
+                 ?maxSubmissionsPerPartition, ?logExternalStats)
             : ProjectorPipeline<_> =
 
-        let statsInterval = defaultArg statsInterval (TimeSpan.FromMinutes 5.)
+        let ingesterStatsInterval = defaultArg ingesterStatsInterval statsInterval
         let dispatcher = Scheduling.Dispatcher maxDop
         let scheduler = Scheduling.PartitionedSchedulingEngine<_, 'Item>(log, handle, dispatcher.TryAdd, statsInterval, ?logExternalStats=logExternalStats)
         let maxSubmissionsPerPartition = defaultArg maxSubmissionsPerPartition 5
@@ -213,6 +214,6 @@ type ParallelProjector =
             scheduler.Submit x
             0
 
-        let submitter = Submission.SubmissionEngine<_, _, _>(log, maxSubmissionsPerPartition, mapBatch, submitBatch, statsInterval, ?pumpInterval=pumpInterval)
-        let startIngester (rangeLog, partitionId) = ParallelIngester<'Item>.Start(rangeLog, partitionId, maxReadAhead, submitter.Ingest)
-        ProjectorPipeline.Start(log, dispatcher.Pump(), scheduler.Pump, submitter.Pump(), startIngester)
+        let submitter = Submission.SubmissionEngine<_, _, _>(log, maxSubmissionsPerPartition, mapBatch, submitBatch, statsInterval)
+        let startIngester (rangeLog, partitionId) = ParallelIngester<'Item>.Start(rangeLog, partitionId, maxReadAhead, submitter.Ingest, ingesterStatsInterval)
+        ProjectorPipeline.Start(log, dispatcher.Pump(), scheduler.Pump, submitter.Pump, startIngester)

--- a/src/Propulsion/Parallel.fs
+++ b/src/Propulsion/Parallel.fs
@@ -196,15 +196,16 @@ type ParallelProjector =
 
     static member Start
             (    log : ILogger, maxReadAhead, maxDop, handle,
-                 statsInterval, ?ingesterStatsInterval,
+                 statsInterval,
                  // Default 5
-                 ?maxSubmissionsPerPartition, ?logExternalStats)
+                 ?maxSubmissionsPerPartition, ?logExternalStats,
+                 ?ingesterStatsInterval)
             : ProjectorPipeline<_> =
 
+        let maxSubmissionsPerPartition = defaultArg maxSubmissionsPerPartition 5
         let ingesterStatsInterval = defaultArg ingesterStatsInterval statsInterval
         let dispatcher = Scheduling.Dispatcher maxDop
         let scheduler = Scheduling.PartitionedSchedulingEngine<_, 'Item>(log, handle, dispatcher.TryAdd, statsInterval, ?logExternalStats=logExternalStats)
-        let maxSubmissionsPerPartition = defaultArg maxSubmissionsPerPartition 5
 
         let mapBatch onCompletion (x : Submission.SubmissionBatch<_, 'Item>) : Scheduling.Batch<_, 'Item> =
             let onCompletion () = x.onCompletion(); onCompletion()

--- a/src/Propulsion/Projector.fs
+++ b/src/Propulsion/Projector.fs
@@ -37,16 +37,13 @@ type ProjectorPipeline<'Ingester> private (task : Task<unit>, triggerStop, start
 
     static member Start(log : ILogger, pumpDispatcher, pumpScheduler, pumpSubmitter, startIngester) =
         let cts = new CancellationTokenSource()
+        let triggerStop () =
+            let level = if cts.IsCancellationRequested then Events.LogEventLevel.Debug else Events.LogEventLevel.Information
+            log.Write(level, "Projector stopping...")
+            cts.Cancel()
         let ct = cts.Token
+
         let tcs = TaskCompletionSource<unit>()
-
-        let start name f =
-            let wrap (name : string) computation = async {
-                try do! computation
-                    log.Information("Exiting {name}", name)
-                with e -> log.Fatal(e, "Abend from {name}", name) }
-            Async.Start(wrap name f, ct)
-
         // if scheduler encounters a faulted handler, we propagate that as the consumer's Result
         let abend (exns : AggregateException) =
             if tcs.TrySetException(exns) then log.Warning(exns, "Cancelling processing due to {count} faulted handlers", exns.InnerExceptions.Count)
@@ -54,22 +51,28 @@ type ProjectorPipeline<'Ingester> private (task : Task<unit>, triggerStop, start
             // NB cancel needs to be after TSE or the Register(TSE) will win
             cts.Cancel()
 
-        let machine = async {
+        let start (name : string) comp =
+            let wrap () = task {
+                try do! Async.StartAsTask(comp, cancellationToken = ct)
+                    log.Information("Exiting {name}", name)
+                with e ->
+                    log.Fatal(e, "Abend from {name}", name)
+                    triggerStop () }
+            Internal.Task.start wrap
+
+        let supervise () = task {
             // external cancellation should yield a success result
             use _ = ct.Register(fun _ -> tcs.TrySetResult () |> ignore)
-            start "dispatcher" <| pumpDispatcher
+
+            start "dispatcher" pumpDispatcher
             // ... fault results from dispatched tasks result in the `machine` concluding with an exception
-            start "scheduler" <| pumpScheduler abend
-            start "submitter" <| Async.AwaitTaskCorrect(pumpSubmitter ct)
+            start "scheduler" (pumpScheduler abend)
+            start "submitter" (Async.AwaitTaskCorrect(pumpSubmitter ct))
 
             // await for either handler-driven abend or external cancellation via Stop()
-            do! Async.AwaitTaskCorrect tcs.Task
-            log.Information("... projector stopped") }
+            try return! tcs.Task
+            finally log.Information("... projector stopped") }
 
-        let task = Async.StartAsTask machine
-        let triggerStop () =
-            let level = if cts.IsCancellationRequested then Events.LogEventLevel.Debug else Events.LogEventLevel.Information
-            log.Write(level, "Projector stopping...")
-            cts.Cancel()
+        let task = Task.Run<unit>(supervise)
 
         new ProjectorPipeline<_>(task, triggerStop, startIngester)

--- a/src/Propulsion/Projector.fs
+++ b/src/Propulsion/Projector.fs
@@ -60,7 +60,7 @@ type ProjectorPipeline<'Ingester> private (task : Task<unit>, triggerStop, start
             start "dispatcher" <| pumpDispatcher
             // ... fault results from dispatched tasks result in the `machine` concluding with an exception
             start "scheduler" <| pumpScheduler abend
-            start "submitter" <| pumpSubmitter
+            start "submitter" <| Async.AwaitTaskCorrect(pumpSubmitter ct)
 
             // await for either handler-driven abend or external cancellation via Stop()
             do! Async.AwaitTaskCorrect tcs.Task

--- a/src/Propulsion/Streams.fs
+++ b/src/Propulsion/Streams.fs
@@ -676,6 +676,7 @@ module Scheduling =
         let work = new BlockingCollection<_>(ConcurrentQueue<_>())
         let result = Event<'R>()
         let dop = Sem maxDop
+        // NOTE this obviously depends on the passed computation never throwing, or we'd leak dop
         let dispatch computation = async {
             let! res = computation
             result.Trigger res

--- a/src/Propulsion/Streams.fs
+++ b/src/Propulsion/Streams.fs
@@ -1044,7 +1044,7 @@ module Projector =
                 let streams = HashSet(seq { for x in items -> x.stream })
                 let batch : Submission.SubmissionBatch<_, _> = { source = partitionId; onCompletion = onCompletion; messages = items }
                 batch, (streams.Count, items.Length)
-            Ingestion.Ingester<StreamEvent<_> seq, Submission.SubmissionBatch<_, StreamEvent<_>>>.Start(log, partitionId, maxRead, makeBatch, submit, ?statsInterval=statsInterval, ?sleepInterval=sleepInterval)
+            Ingestion.Ingester<StreamEvent<_> seq, Submission.SubmissionBatch<_, StreamEvent<_>>>.Start(log, partitionId, maxRead, makeBatch, submit, ?statsInterval=statsInterval)
 
     type StreamsSubmitter =
 

--- a/src/Propulsion/Submission.fs
+++ b/src/Propulsion/Submission.fs
@@ -2,10 +2,10 @@
 
 open Serilog
 open System
-open System.Collections.Concurrent
 open System.Collections.Generic
 open System.Diagnostics
 open System.Threading
+open System.Threading.Tasks
 
 module Internal =
 
@@ -64,8 +64,6 @@ module Internal =
 
     module Task =
 
-        open System.Threading.Tasks
-
         let start t = Task.Run(Action(fun () -> t |> ignore<Task>)) |> ignore
         let sleep (ts : TimeSpan) ct = Task.Delay(int ts.TotalMilliseconds, cancellationToken = ct)
 
@@ -74,6 +72,7 @@ module Internal =
         member _.HasCapacity = inner.CurrentCount <> 0
         member _.State = max-inner.CurrentCount,max
         member _.Await(ct : CancellationToken) = inner.WaitAsync(ct) |> Async.AwaitTaskCorrect
+        member x.AwaitButRelease() = inner.WaitAsync().ContinueWith(fun _t -> x.Release())
         member _.Release() = inner.Release() |> ignore
         member _.TryTake() = inner.Wait 0
 
@@ -95,47 +94,46 @@ module Submission =
     /// Holds the stream of incoming batches, grouping by partition
     /// Manages the submission of batches into the Scheduler in a fair manner
     type SubmissionEngine<'S, 'M, 'B when 'S : equality>
-        (   log : ILogger, maxSubmitsPerPartition, mapBatch : (unit -> unit) -> SubmissionBatch<'S, 'M> -> 'B, submitBatch : 'B -> int, statsInterval, ?pumpInterval : TimeSpan,
+        (   log : ILogger, maxSubmitsPerPartition, mapBatch : (unit -> unit) -> SubmissionBatch<'S, 'M> -> 'B, submitBatch : 'B -> int, statsInterval,
             ?tryCompactQueue) =
 
-        let pumpInterval = defaultArg pumpInterval (TimeSpan.FromMilliseconds 5.)
-        let incoming = new BlockingCollection<SubmissionBatch<'S, 'M>[]>(ConcurrentQueue())
+        let awaitIncoming, applyIncoming, enqueueIncoming =
+            let c = Channel.unboundedSr
+            Channel.awaitRead c, Channel.apply c, Channel.write c
         let buffer = Dictionary<'S, PartitionQueue<'B>>()
+
         let mutable cycles, ingested, completed, compacted = 0, 0, 0, 0
         let submittedBatches,submittedMessages = PartitionStats(), PartitionStats()
-
+        let statsInterval = timeRemaining statsInterval
         let dumpStats () =
             let waiting = seq { for x in buffer do if x.Value.queue.Count <> 0 then yield struct (x.Key, x.Value.queue.Count) } |> sortByVsndDescending
-            log.Information("Submitter {cycles} cycles {ingested} accepted {compactions} compactions Holding {@waiting}", cycles, ingested, compacted, waiting)
-            log.Information(" Submitted {@batches} Completed {completed} Messages {@messages}", submittedBatches.StatsDescending, completed, submittedMessages.StatsDescending)
+            log.Information("Submitter ingested {ingested} compacted {compacted} completed {completed} Events {items} Batches {batches} Holding {holding} Cycles {cycles}",
+                            ingested, compacted, completed, submittedMessages.StatsDescending, submittedBatches.StatsDescending, waiting, cycles)
             cycles <- 0; ingested <- 0; compacted <- 0; completed <- 0; submittedBatches.Clear(); submittedMessages.Clear()
-
-        let maybeLogStats =
-            let due = intervalCheck statsInterval
-            fun () ->
-                cycles <- cycles + 1
-                if due () then dumpStats ()
+        let maybeDumpStats () =
+            cycles <- cycles + 1
+            let due, remaining = statsInterval ()
+            if due then dumpStats ()
+            int remaining
 
         // Loop, submitting 0 or 1 item per partition per iteration to ensure
         // - each partition has a controlled maximum number of entrants in the scheduler queue
         // - a fair ordering of batch submissions
-        let propagate () =
-            let mutable more, worked = true, false
-            while more do
-                more <- false
-                for KeyValue (pi, pq) in buffer do
-                    if pq.queue.Count <> 0 then
-                        if pq.submissions.TryTake() then
-                            worked <- true
-                            more <- true
-                            let count = submitBatch <| pq.queue.Dequeue()
-                            submittedBatches.Record(pi)
-                            submittedMessages.Record(pi, int64 count)
+        let tryPropagate (waiting : ResizeArray<Task>) =
+            waiting.Clear()
+            let mutable worked = false
+            for KeyValue (pi, pq) in buffer do
+                if pq.queue.Count <> 0 then
+                    if pq.submissions.TryTake() then
+                        worked <- true
+                        let count = submitBatch <| pq.queue.Dequeue()
+                        submittedBatches.Record(pi)
+                        submittedMessages.Record(pi, int64 count)
+                    else waiting.Add(pq.submissions.AwaitButRelease())
             worked
 
-        /// Take one timeslice worth of ingestion and add to relevant partition queues
-        /// When ingested, we allow one propagation submission per partition
         let ingest (partitionBatches : SubmissionBatch<'S, 'M>[]) =
+            ingested <- ingested + 1
             for { source = pid } as batch in partitionBatches do
                 let pq =
                     match buffer.TryGetValue pid with
@@ -146,7 +144,6 @@ module Submission =
                     pq.submissions.Release()
                 let mapped = mapBatch markCompleted batch
                 pq.Append(mapped)
-            propagate()
 
         /// We use timeslices where we're we've fully provisioned the scheduler to index any waiting Batches
         let compact f =
@@ -154,31 +151,25 @@ module Submission =
             for KeyValue(_, pq) in buffer do
                 if f pq.queue then
                     worked <- true
-            if worked then compacted <- compacted + 1; true
-            else false
+            if worked then compacted <- compacted + 1
+            worked
+        let maybeCompact () =
+            match tryCompactQueue with
+            | Some f -> compact f
+            | None -> false
 
         /// Processing loop, continuously splitting `Submit`ted items into per-partition queues and ensuring enough items are provided to the Scheduler
-        member _.Pump() = async {
-            let! ct = Async.CancellationToken
+        member _.Pump(ct : CancellationToken) = task {
+            // Holds a Task per partition that's reached its submission limit; if capacity becomes available, we want to wake to submit
+            let waitingSubmissions = ResizeArray<Task>()
             while not ct.IsCancellationRequested do
-                let mutable items = Unchecked.defaultof<_>
-                let mutable propagated = false
-                if incoming.TryTake(&items, pumpInterval) then
-                    propagated <- ingest items
-                    while incoming.TryTake(&items) do
-                        if ingest items then propagated <- true
-                else propagated <- propagate ()
-                match propagated, tryCompactQueue with
-                | false, None -> Thread.Sleep 2
-                | false, Some f when not (compact f) -> Thread.Sleep 2
-                | _ -> ()
-
-                maybeLogStats () }
+                while applyIncoming ingest || tryPropagate waitingSubmissions || maybeCompact () do ()
+                let nextStatsIntervalMs = maybeDumpStats ()
+                let! _ = Task.WhenAny[| awaitIncoming () :> Task; yield! waitingSubmissions; Task.Delay(nextStatsIntervalMs, ct) |] in () }
 
         /// Supplies a set of Batches for holding and forwarding to scheduler at the right time
         member _.Ingest(items : SubmissionBatch<'S, 'M>[]) =
-            Interlocked.Increment(&ingested) |> ignore
-            incoming.Add items
+            enqueueIncoming items
 
         /// Supplies an incoming Batch for holding and forwarding to scheduler at the right time
         member x.Ingest(batch : SubmissionBatch<'S, 'M>) =

--- a/src/Propulsion/Submission.fs
+++ b/src/Propulsion/Submission.fs
@@ -51,8 +51,8 @@ module Internal =
 
         open System.Threading.Channels
 
-        let unboundedSwSr<'t> = Channel.CreateUnbounded<'t>(UnboundedChannelOptions(SingleWriter = true, SingleReader = true))
         let unboundedSr<'t> = Channel.CreateUnbounded<'t>(UnboundedChannelOptions(SingleReader = true))
+        let unboundedSwSr<'t> = Channel.CreateUnbounded<'t>(UnboundedChannelOptions(SingleWriter = true, SingleReader = true))
         let write (c : Channel<_>) = c.Writer.TryWrite >> ignore
         let awaitRead (c : Channel<_>) ct = let vt = c.Reader.WaitToReadAsync(ct) in vt.AsTask()
         let apply (c : Channel<_>) f =
@@ -64,7 +64,7 @@ module Internal =
 
     module Task =
 
-        let start t = Task.Run(Action(fun () -> t |> ignore<Task>)) |> ignore
+        let start create = Task.Run<unit>(Func<Task<unit>> create) |> ignore<Task>
 
     type Sem(max) =
         let inner = new SemaphoreSlim(max)

--- a/src/Propulsion/Submission.fs
+++ b/src/Propulsion/Submission.fs
@@ -162,7 +162,7 @@ module Submission =
             // Semaphores for partitions that have reached their submit limit; if capacity becomes available, we want to wake to submit
             let waitingSubmissions = ResizeArray<Sem>()
             let submitCapacityAvailable : seq<Task> = seq { for w in waitingSubmissions -> w.AwaitButRelease() }
-            while true do
+            while not ct.IsCancellationRequested do
                 while applyIncoming ingest || tryPropagate waitingSubmissions || maybeCompact () do ()
                 let nextStatsIntervalMs = maybeDumpStats ()
                 do! Task.WhenAny[| awaitIncoming ct :> Task; yield! submitCapacityAvailable; Task.Delay(nextStatsIntervalMs) |] :> Task }


### PR DESCRIPTION
Improves the baseline impl of two key components in the Propulsion pipeline:
- Ingester: per Reader (Partition, Tranche etc) loop that manages:
  - accepting data from a single partition's Reader
  - managing the checkpointing as batches are confirmed complete
- Submitter: single loop that manages:
  - ingesting items supplied by the Ingester instances
  - propagating items into the Scheduler promptly and fairly

The key improvement is that the `Pump` methods now sleep until a trigger wakes them, rather than using a short sleep time and proactively checking whether some propagation activity has become possible. This provides the following benefits:
- there's no need to consider/tune the sleep interval
- under low load, there's dramatically less activity (CPU usage)
- under high load, there's never an overly long sleep (which might waste potential processing time for a downstream activity)

Also:
- Consolidated logging to have a single line of output
- de-emphasizing cycle counts and/or other information that was previously an input to troubleshooting and/or tuning sleep intervals etc
- Replaced defaulting of `ingesterStatsInterval` to 5 minutes with an explicit argument (which defaults to the `statsInterval` in some cases)