### PR TITLE
Downgrade FSharp.Core to 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Changed
 
-- Targeted `net6.0` with `6.0.300` SDK, `FSharp.Core` v `6.0.5`, `FSharp.Control.AsyncSeq` v `3.2.1`, `MathNet.Numerics` v `4.15.0`
+- Targeted `net6.0` with `6.0.300` SDK, `FSharp.Core` v `6.0.0`, `FSharp.Control.AsyncSeq` v `3.2.1`, `MathNet.Numerics` v `4.15.0`
 - `Propulsion.CosmosStore`: Changed to target `Equinox.CosmosStore` v `4.0.0` [#139](https://github.com/jet/propulsion/pull/139)
 - `Propulsion.CosmosStore.CosmosSource`: Changed parsing to use `System.Text.Json` [#139](https://github.com/jet/propulsion/pull/139)
 - `Propulsion.EventStore`: Pinned to target `Equinox.EventStore` v `[3.0.7`-`3.99.0]` **Deprecated; Please migrate to `Propulsion.EventStoreDb`** [#139](https://github.com/jet/propulsion/pull/139)

--- a/src/Propulsion.DynamoStore.Lambda/Propulsion.DynamoStore.Lambda.fsproj
+++ b/src/Propulsion.DynamoStore.Lambda/Propulsion.DynamoStore.Lambda.fsproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <!-- Ordinarily we'd let the base Targets pick the FSharp.Core,
-             but that clashes with Propulsion.DynamoStore's need for FSharp.Core 6.0.5 and errors out on publish -->
-        <!-- <DisableImplicitFSharpCoreReference>false</DisableImplicitFSharpCoreReference>-->
         
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
         <AWSProjectType>Lambda</AWSProjectType>

--- a/src/Propulsion.DynamoStore/Propulsion.DynamoStore.fsproj
+++ b/src/Propulsion.DynamoStore/Propulsion.DynamoStore.fsproj
@@ -25,9 +25,6 @@
     <ItemGroup>
       <PackageReference Include="MinVer" Version="4.0.0" PrivateAssets="All" />
 
-      <!-- NOTE Code here leans on the fact that https://github.com/dotnet/fsharp/issues/13165 is resolved in 6.0.5 -->
-      <!-- <PackageReference Include="FSharp.Core" Version="6.0.5" />-->
-        
       <PackageReference Include="Equinox.DynamoStore" Version="4.0.0-beta.10.3" />
       <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.0-rc.4" />
     </ItemGroup>

--- a/src/Propulsion.DynamoStore/Types.fs
+++ b/src/Propulsion.DynamoStore/Types.fs
@@ -99,11 +99,8 @@ module internal Async =
                 finally s.Release() |> ignore }
     let private parallelThrottledUnsafe dop computations = // https://github.com/dotnet/fsharp/issues/13165
         Async.Parallel(computations, maxDegreeOfParallelism = dop)
-    // NB this should not be necessary if targeting FSharp.Core 6.0.5 as we do
-    // However my eyes say otherwise so this stays until someone figures out what the problem is, i.e.
-    // - if we are getting the wrong version
-    // - the patch did not make it into 6.0.5
-    // - or there is some other secondary issue in play
+    // NOTE as soon as a non-preview Async.Parallel impl in FSharp.Core includes the fix (e.g. 6.0.5 does not, 6.0.5-beta.22329.3 does),
+    // we can remove this shimming and replace it with the body of parallelThrottledUnsafe
     let parallelThrottled dop computations = async {
         let throttle = Async.Throttle dop // each batch of 1200 gets the full potential dop - we internally limit what actually gets to run concurrently here
         let! allResults =

--- a/src/Propulsion/Propulsion.fsproj
+++ b/src/Propulsion/Propulsion.fsproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="MinVer" Version="4.0.0" PrivateAssets="All" />
 
-    <PackageReference Include="FSharp.Core" Version="6.0.5" />
+    <PackageReference Include="FSharp.Core" Version="6.0.0" />
 
     <!-- We only depend on the ITimelineEvent contracts, so going to v3 is not useful/necessary -->
     <PackageReference Include="FsCodec" Version="2.0.0" />

--- a/tests/Propulsion.Tests/ParallelThrottledValidation.fs
+++ b/tests/Propulsion.Tests/ParallelThrottledValidation.fs
@@ -1,0 +1,20 @@
+module Propulsion.Tests.ParallelThrottledValidation
+
+open Swensen.Unquote
+open Xunit
+
+// Fixed in 6.0.5-beta.22329.3 (which we explicitly target in this test suite)
+// 6.0.5 is built from a 6.0.4 tag so does not include the fix (but it would win over the beta version in semver)
+// => Propulsion.DynamoStore needs to depend on on 6.0.0 for now
+let [<Fact>] ``Async.Parallel blows stack when cancelling many <= in FSharp.Core 6.0.5`` () =
+    let gen (i : int) = async {
+        if i = 0 then
+            do! Async.Sleep 1000
+            return failwith (string i)
+        else do! Async.Sleep (i+3000) }
+    let count = 3000
+    let comps = Seq.init count gen
+    let result = Async.Parallel(comps, 16) |> Async.Catch |> Async.RunSynchronously
+    test <@ match result with
+            | Choice2Of2 e -> int e.Message < count
+            | x -> failwithf "unexpected %A" x @>

--- a/tests/Propulsion.Tests/Propulsion.Tests.fsproj
+++ b/tests/Propulsion.Tests/Propulsion.Tests.fsproj
@@ -11,17 +11,18 @@
     <Compile Include="FsKafkaCodec.fs" />
     <Compile Include="DynamoImportTests.fs" />
     <Compile Include="SpanQueueTests.fs" />
+    <Compile Include="ParallelThrottledValidation.fs" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Propulsion.DynamoStore\Propulsion.DynamoStore.fsproj" />
     <ProjectReference Include="..\..\src\Propulsion.Kafka\Propulsion.Kafka.fsproj" />
-    <ProjectReference Include="..\..\src\Propulsion\Propulsion.fsproj" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="FsCheck.Xunit" Version="2.16.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+	<PackageReference Include="FSharp.Core" Version="6.0.5-beta.22329.3" />
 	<PackageReference Include="unquote" Version="6.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">


### PR DESCRIPTION
After much analysis...
- FSharp.Core `6.0.5` does not include the fix for https://github.com/dotnet/fsharp/issues/13165
- FSharp.Core `6.0.5-beta.22329.3` does

This PR downgrades to referencing 6.0.0, with the intention of requiring 6.0.x when it includes the fix

(Key reason to not even temporarily reference the beta is that 6.0.5 wins over the beta in semver, which would be very confusing)