### PR TITLE
Bulk scheduling: struct/task optimizations

### DIFF
--- a/src/Propulsion.Cosmos/CosmosPruner.fs
+++ b/src/Propulsion.Cosmos/CosmosPruner.fs
@@ -131,15 +131,15 @@ type CosmosPruner =
         let idleDelay = defaultArg idleDelay (TimeSpan.FromMilliseconds 10.)
         let statsInterval, stateInterval = defaultArg statsInterval (TimeSpan.FromMinutes 5.), defaultArg stateInterval (TimeSpan.FromMinutes 5.)
         let stats = Pruner.Stats(log.ForContext<Pruner.Stats>(), statsInterval, stateInterval)
-        let dispatcher = Propulsion.Streams.Scheduling.ItemDispatcher<_>(maxConcurrentStreams)
-        let dumpStreams (s : Scheduling.StreamStates<_>, totalPruned) log =
-            s.Dump(log, totalPruned, Propulsion.Streams.Buffering.StreamState.eventsSize)
+        let dispatcher = Scheduling.ItemDispatcher<_>(maxConcurrentStreams)
+        let dumpStreams struct (s : Scheduling.StreamStates<_>, totalPruned) log =
+            s.Dump(log, totalPruned, Buffering.StreamState.eventsSize)
         let pruneUntil stream index = Equinox.Cosmos.Core.Events.pruneUntil context stream index
         let streamScheduler =
             Pruner.StreamSchedulingEngine.Create(
                 pruneUntil, dispatcher, stats, dumpStreams,
                 ?maxBatches = maxBatches, ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, idleDelay = idleDelay)
-        Propulsion.Streams.Projector.StreamsProjectorPipeline.Start(
+        Projector.StreamsProjectorPipeline.Start(
             log, dispatcher.Pump, streamScheduler.Pump, maxReadAhead, streamScheduler.Submit, statsInterval,
             ?maxSubmissionsPerPartition = maxSubmissionsPerPartition,
             ?ingesterStatsInterval = ingesterStatsInterval)

--- a/src/Propulsion.CosmosStore/CosmosStorePruner.fs
+++ b/src/Propulsion.CosmosStore/CosmosStorePruner.fs
@@ -130,7 +130,7 @@ type CosmosStorePruner =
         let statsInterval, stateInterval = defaultArg statsInterval (TimeSpan.FromMinutes 5.), defaultArg stateInterval (TimeSpan.FromMinutes 5.)
         let stats = Pruner.Stats(log.ForContext<Pruner.Stats>(), statsInterval, stateInterval)
         let dispatcher = Propulsion.Streams.Scheduling.ItemDispatcher<_>(maxConcurrentStreams)
-        let dumpStreams (s : Propulsion.Streams.Scheduling.StreamStates<_>, totalPurged) logger =
+        let dumpStreams struct (s : Propulsion.Streams.Scheduling.StreamStates<_>, totalPurged) logger =
             s.Dump(logger, totalPurged, Propulsion.Streams.Buffering.StreamState.eventsSize)
         let pruneUntil stream index = Equinox.CosmosStore.Core.Events.pruneUntil context stream index
         let streamScheduler =

--- a/src/Propulsion.CosmosStore/CosmosStoreSink.fs
+++ b/src/Propulsion.CosmosStore/CosmosStoreSink.fs
@@ -147,9 +147,9 @@ module Internal =
             : Scheduling.StreamSchedulingEngine<_, _, _> =
             let maxEvents, maxBytes = defaultArg maxEvents 16384, defaultArg maxBytes (1024 * 1024 - (*fudge*)4096)
             let writerResultLog = log.ForContext<Writer.Result>()
-            let attemptWrite (stream, span) = async {
+            let attemptWrite (stream, span) ct = task {
                 let met, span' = Buffering.StreamSpan.slice (maxEvents, maxBytes) span
-                try let! res = Writer.write log eventsContext (StreamName.toString stream) span'
+                try let! res = Writer.write log eventsContext (StreamName.toString stream) span' |> fun f -> Async.StartAsTask(f, cancellationToken = ct)
                     return span'.events.Length > 0, Choice1Of2 (met, res)
                 with e -> return false, Choice2Of2 (met, e) }
             let interpretWriteResultProgress (streams: Scheduling.StreamStates<_>) stream res =
@@ -186,18 +186,18 @@ type CosmosStoreSink =
             // Default: 1MB (limited by maximum size of a CosmosDB stored procedure invocation)
             ?maxBytes,
             ?ingesterStatsInterval)
-        : Propulsion.ProjectorPipeline<_> =
+        : ProjectorPipeline<_> =
         let statsInterval, stateInterval = defaultArg statsInterval (TimeSpan.FromMinutes 5.), defaultArg stateInterval (TimeSpan.FromMinutes 5.)
         let stats = Internal.Stats(log.ForContext<Internal.Stats>(), statsInterval, stateInterval)
-        let dispatcher = Propulsion.Streams.Scheduling.ItemDispatcher<_>(maxConcurrentStreams)
-        let dumpStreams (s : Scheduling.StreamStates<_>, totalPurged) logger =
-            s.Dump(logger, totalPurged, Propulsion.Streams.Buffering.StreamState.eventsSize)
+        let dispatcher = Scheduling.ItemDispatcher<_>(maxConcurrentStreams)
+        let dumpStreams struct (s : Scheduling.StreamStates<_>, totalPurged) logger =
+            s.Dump(logger, totalPurged, Buffering.StreamState.eventsSize)
         let streamScheduler =
             Internal.StreamSchedulingEngine.Create(
                 log, eventsContext, dispatcher, stats, dumpStreams,
                 ?maxBatches = maxBatches, ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay,
                 ?maxEvents=maxEvents, ?maxBytes=maxBytes)
-        Propulsion.Streams.Projector.StreamsProjectorPipeline.Start(
+        Projector.StreamsProjectorPipeline.Start(
             log, dispatcher.Pump, streamScheduler.Pump, maxReadAhead, streamScheduler.Submit, statsInterval,
             ?maxSubmissionsPerPartition = maxSubmissionsPerPartition,
             ?ingesterStatsInterval = ingesterStatsInterval)


### PR DESCRIPTION
Via profiling, internal signature changes toward `struct`/`task`
Calved from #167 as it's relatively noisy