### PR TITLE
Scheduler tuning/profiling

### DIFF
--- a/src/Propulsion/Ingestion.fs
+++ b/src/Propulsion/Ingestion.fs
@@ -75,7 +75,7 @@ type private Stats(log : ILogger, partitionId, statsInterval : TimeSpan) =
 
     member _.TryDump(readState) =
         cycles <- cycles + 1
-        let due, remaining = statsInterval ()
+        let struct (due, remaining) = statsInterval ()
         if due then dumpStats readState
         remaining
 

--- a/src/Propulsion/Internal.fs
+++ b/src/Propulsion/Internal.fs
@@ -16,8 +16,8 @@ let timeRemaining (period : TimeSpan) =
     let timer, max = Stopwatch.StartNew(), int64 period.TotalMilliseconds
     fun () ->
         match max - timer.ElapsedMilliseconds |> int with
-        | rem when rem <= 0 -> timer.Restart(); true, max
-        | rem -> false, rem
+        | rem when rem <= 0 -> timer.Restart(); struct (true, max)
+        | rem -> (false, rem)
 
 module Channel =
 


### PR DESCRIPTION
Further optimizations based on both internal apps and https://github.com/jet/dotnet-templates/pull/121
- optimizations for scheduler hot paths with both low load and high load
- make prioritizing by stream payload size optional via `prioritizeLargePayloads`
