### PR TITLE
Add AwaitCompletion support for FeedSources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 
+- `Feed`: `Monitor.AwaitCompletion` enables **quasi** deterministic waiting for the processing of async reactions within integration tests [#170](https://github.com/jet/propulsion/pull/170)
 - `Scheduler`: `purgeInterval` to control memory usage [#97](https://github.com/jet/propulsion/pull/97)
 - `Scheduler`: `wakeForResults` option to maximize throughput (without having to drop sleep interval to zero) [#161](https://github.com/jet/propulsion/pull/161)
 - `Ingester`: Expose optional `ingesterStatsInterval` control [#154](https://github.com/jet/propulsion/pull/154)
@@ -17,7 +18,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - `Propulsion.EventStoreDb`: Ported `EventStore` to target `Equinox.EventStore` >= `4.0.0` (using the gRPC interface)  [#139](https://github.com/jet/propulsion/pull/139)
 - `Propulsion.CosmosStore3`: Special cased version of `Propulsion.CosmosStore` to target `Equinox.CosmosStore` v `[3.0.7`-`3.99.0]` **Deprecated; Please migrate to `Propulsion.CosmosStore` by updating `Equinox.CosmosStore` dependencies to `4.0.0`** [#139](https://github.com/jet/propulsion/pull/139)
 - `Propulsion.DynamoStore`: `Equinox.CosmosStore`-equivalent functionality for `Equinox.DynamoStore`. Combines elements of `CosmosStore`, `SqlStreamStore`, `Feed` [#140](https://github.com/jet/propulsion/pull/140)
-- `Propulsion.MemoryStore`: `MemoryStoreSource` to align with other sources for integration testing [#165](https://github.com/jet/propulsion/pull/165)
+- `Propulsion.MemoryStore`: `MemoryStoreSource` to align with other sources for integration testing. Includes *deterministic* `AwaitCompletion` as per `Propulsion.Feed`-based Sources [#165](https://github.com/jet/propulsion/pull/165)
 - `Propulsion.Tool`: `checkpoint` commandline option; enables viewing or overriding checkpoints [#141](https://github.com/jet/propulsion/pull/141)
 - `Propulsion.Tool`: Add support for [autoscaling throughput](https://docs.microsoft.com/en-us/azure/cosmos-db/provision-throughput-autoscale) of Cosmos containers and databases [#142](https://github.com/jet/propulsion/pull/142) :pray: [@brihadish](https://github.com/brihadish)
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The components within this repository are delivered as a multi-targeted Nuget pa
 - `Propulsion.MemoryStore` [![NuGet](https://img.shields.io/nuget/v/Propulsion.MemoryStore.svg)](https://www.nuget.org/packages/Propulsion.MemoryStore/). Provides bindings to `Equinox.MemoryStore`. [Depends](https://www.fuget.org/packages/Propulsion.MemoryStore) on `Equinox.MemoryStore` v `4.0.0`, `FsCodec.Box`, `Propulsion`
 
     1. `MemoryStoreSource`: Forwarding from an `Equinox.MemoryStore` into a `Propulsion.Sink`, in order to enable maximum speed integration testing.
+    2. `FeedMonitor.AwaitSource`: Enables efficient deterministic waits for Reaction processing within an integration test.
 
 - `Propulsion.CosmosStore` [![NuGet](https://img.shields.io/nuget/v/Propulsion.CosmosStore.svg)](https://www.nuget.org/packages/Propulsion.CosmosStore/) Provides bindings to Azure CosmosDB. [Depends](https://www.fuget.org/packages/Propulsion.CosmosStore) on `Equinox.CosmosStore` v `4.0.0`
 
@@ -31,6 +32,7 @@ The components within this repository are delivered as a multi-targeted Nuget pa
     2. `DynamoStoreIndexer`: writes to `AppendsIndex`/`AppendsEpoch` (used by `Propulsion.DynamoStore.Lambda`)
     3. `DynamoStoreSource`: reads from `AppendsIndex`/`AppendsEpoch` (which is populated by `Propulsion.DynamoStore.Lambda` via `DynamoStoreIndexer`)
     4. `ReaderCheckpoint`: checkpoint storage for `Propulsion.DynamoStore`/`Feed`/`EventStoreDb`/SqlStreamSteamStore` using `Equinox.DynamoStore` v `4.0.0`.
+    5. `FeedMonitor.AwaitSource`: See `Propulsion.Feed`
 
   (Reading and position metrics are exposed via `Propulsion.Feed.Prometheus`)
 
@@ -47,7 +49,8 @@ The components within this repository are delivered as a multi-targeted Nuget pa
 - `Propulsion.EventStoreDb` [![NuGet](https://img.shields.io/nuget/v/Propulsion.EventStoreDb.svg)](https://www.nuget.org/packages/Propulsion.EventStoreDb/). Provides bindings to [EventStore](https://www.eventstore.org), writing via `Propulsion.EventStore.EventStoreSink` [Depends](https://www.fuget.org/packages/Propulsion.EventStoreDb) on `Equinox.EventStoreDb` v `4.0.0`, `Serilog`
     1. `EventStoreSource`: reading from an EventStoreDB >= `20.10` `$all` stream into a `Propulsion.Sink` using the gRPC interface. Provides throughput metrics via `Propulsion.Feed.Prometheus`
     2. `EventStoreSink`: writing to `Equinox.EventStoreDb` v `4.0.0`
-  
+    3. `FeedMonitor.AwaitSource`: See `Propulsion.Feed`
+
     (Reading and position metrics are exposed via `Propulsion.Feed.Prometheus`)
 
 - `Propulsion.Feed` [![NuGet](https://img.shields.io/nuget/v/Propulsion.Feed.svg)](https://www.nuget.org/packages/Propulsion.Feed/) Provides helpers for streamwise consumption of a feed of information with an arbitrary interface (e.g. a third-party Feed API), including the maintenance of checkpoints within such a feed. [Depends](https://www.fuget.org/packages/Propulsion.Feed) on `Propulsion`, a `IFeedCheckpointStore` implementation (from e.g., `Propulsion.Cosmos` or `Propulsion.CosmosStore`)
@@ -55,6 +58,7 @@ The components within this repository are delivered as a multi-targeted Nuget pa
   1. `FeedSource`: Handles continual reading and checkpointing of events from a set of feeds ('tranches' of a 'source') that collectively represent a change data capture source from a custom system (roughly analogous to how a CosmosDB Container presents a changefeed). A `readTranches` function is expected to yield a `TrancheId` list; the Feed Source operates a logical reader thread per such tranche. Each individual Tranche is required to be able to represent its content as an incrementally retrievable change feed with a monotonically increasing `Index` per `FsCodec.ITimelineEvent` read from a given tranche.
   2. `PeriodicSource`: Handles regular crawling of an external datasource (such as a SQL database) where there is no way to isolate the changes since a given checkpoint (based on either the intrinsic properties of the data, or of the store itself). The source is expected to present its content as an `AsyncSeq` of `FsCodec.StreamName * FsCodec.IEventData * context`. Checkpointing occurs only when all events have been completely ingested by the Sink.   
   3. `Prometheus`: Exposes reading statistics to Prometheus (including metrics from `SqlStreamStore.SqlStreamStoreSource` and `EventStoreDb.EventStoreSource`)   
+  4. `FeedMonitor.AwaitSource`: Enables efficient waiting for completion of reaction processing within an integration test
 
 - `Propulsion.Kafka` [![NuGet](https://img.shields.io/nuget/v/Propulsion.Kafka.svg)](https://www.nuget.org/packages/Propulsion.Kafka/) Provides bindings for producing and consuming both streamwise and in parallel. Includes a standard codec for use with streamwise projection and consumption, `Propulsion.Kafka.Codec.NewtonsoftJson.RenderedSpan`. [Depends](https://www.fuget.org/packages/Propulsion.Kafka) on `FsKafka` v `1.7.0`-`1.9.99`, `Serilog`
 
@@ -62,6 +66,7 @@ The components within this repository are delivered as a multi-targeted Nuget pa
 
   1. `SqlStreamStoreSource`: reading from a SqlStreamStore `$all` stream into a `Propulsion.Sink`
   2. `ReaderCheckpoint`: checkpoint storage for `Propulsion.Feed`/`SqlStreamSteamStore`/`EventStoreDb` using `Dapper`, `Microsoft.Data.SqlClient`
+  3. `FeedMonitor.AwaitSource`: See `Propulsion.Feed`
 
   (Reading and position metrics are exposed via `Propulsion.Feed.Prometheus`)
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The components within this repository are delivered as a multi-targeted Nuget pa
 - `Propulsion.MemoryStore` [![NuGet](https://img.shields.io/nuget/v/Propulsion.MemoryStore.svg)](https://www.nuget.org/packages/Propulsion.MemoryStore/). Provides bindings to `Equinox.MemoryStore`. [Depends](https://www.fuget.org/packages/Propulsion.MemoryStore) on `Equinox.MemoryStore` v `4.0.0`, `FsCodec.Box`, `Propulsion`
 
     1. `MemoryStoreSource`: Forwarding from an `Equinox.MemoryStore` into a `Propulsion.Sink`, in order to enable maximum speed integration testing.
-    2. `FeedMonitor.AwaitSource`: Enables efficient deterministic waits for Reaction processing within an integration test.
+    2. `Monitor.AwaitCompletion`: Enables efficient deterministic waits for Reaction processing within an integration test.
 
 - `Propulsion.CosmosStore` [![NuGet](https://img.shields.io/nuget/v/Propulsion.CosmosStore.svg)](https://www.nuget.org/packages/Propulsion.CosmosStore/) Provides bindings to Azure CosmosDB. [Depends](https://www.fuget.org/packages/Propulsion.CosmosStore) on `Equinox.CosmosStore` v `4.0.0`
 
@@ -32,7 +32,7 @@ The components within this repository are delivered as a multi-targeted Nuget pa
     2. `DynamoStoreIndexer`: writes to `AppendsIndex`/`AppendsEpoch` (used by `Propulsion.DynamoStore.Lambda`)
     3. `DynamoStoreSource`: reads from `AppendsIndex`/`AppendsEpoch` (which is populated by `Propulsion.DynamoStore.Lambda` via `DynamoStoreIndexer`)
     4. `ReaderCheckpoint`: checkpoint storage for `Propulsion.DynamoStore`/`Feed`/`EventStoreDb`/SqlStreamSteamStore` using `Equinox.DynamoStore` v `4.0.0`.
-    5. `FeedMonitor.AwaitSource`: See `Propulsion.Feed`
+    5. `Monitor.AwaitCompletion`: See `Propulsion.Feed`
 
   (Reading and position metrics are exposed via `Propulsion.Feed.Prometheus`)
 
@@ -49,7 +49,7 @@ The components within this repository are delivered as a multi-targeted Nuget pa
 - `Propulsion.EventStoreDb` [![NuGet](https://img.shields.io/nuget/v/Propulsion.EventStoreDb.svg)](https://www.nuget.org/packages/Propulsion.EventStoreDb/). Provides bindings to [EventStore](https://www.eventstore.org), writing via `Propulsion.EventStore.EventStoreSink` [Depends](https://www.fuget.org/packages/Propulsion.EventStoreDb) on `Equinox.EventStoreDb` v `4.0.0`, `Serilog`
     1. `EventStoreSource`: reading from an EventStoreDB >= `20.10` `$all` stream into a `Propulsion.Sink` using the gRPC interface. Provides throughput metrics via `Propulsion.Feed.Prometheus`
     2. `EventStoreSink`: writing to `Equinox.EventStoreDb` v `4.0.0`
-    3. `FeedMonitor.AwaitSource`: See `Propulsion.Feed`
+    3. `Monitor.AwaitCompletion`: See `Propulsion.Feed`
 
     (Reading and position metrics are exposed via `Propulsion.Feed.Prometheus`)
 
@@ -58,7 +58,7 @@ The components within this repository are delivered as a multi-targeted Nuget pa
   1. `FeedSource`: Handles continual reading and checkpointing of events from a set of feeds ('tranches' of a 'source') that collectively represent a change data capture source from a custom system (roughly analogous to how a CosmosDB Container presents a changefeed). A `readTranches` function is expected to yield a `TrancheId` list; the Feed Source operates a logical reader thread per such tranche. Each individual Tranche is required to be able to represent its content as an incrementally retrievable change feed with a monotonically increasing `Index` per `FsCodec.ITimelineEvent` read from a given tranche.
   2. `PeriodicSource`: Handles regular crawling of an external datasource (such as a SQL database) where there is no way to isolate the changes since a given checkpoint (based on either the intrinsic properties of the data, or of the store itself). The source is expected to present its content as an `AsyncSeq` of `FsCodec.StreamName * FsCodec.IEventData * context`. Checkpointing occurs only when all events have been completely ingested by the Sink.   
   3. `Prometheus`: Exposes reading statistics to Prometheus (including metrics from `SqlStreamStore.SqlStreamStoreSource` and `EventStoreDb.EventStoreSource`)   
-  4. `FeedMonitor.AwaitSource`: Enables efficient waiting for completion of reaction processing within an integration test
+  4. `Monitor.AwaitCompletion`: Enables efficient waiting for completion of reaction processing within an integration test
 
 - `Propulsion.Kafka` [![NuGet](https://img.shields.io/nuget/v/Propulsion.Kafka.svg)](https://www.nuget.org/packages/Propulsion.Kafka/) Provides bindings for producing and consuming both streamwise and in parallel. Includes a standard codec for use with streamwise projection and consumption, `Propulsion.Kafka.Codec.NewtonsoftJson.RenderedSpan`. [Depends](https://www.fuget.org/packages/Propulsion.Kafka) on `FsKafka` v `1.7.0`-`1.9.99`, `Serilog`
 
@@ -66,7 +66,7 @@ The components within this repository are delivered as a multi-targeted Nuget pa
 
   1. `SqlStreamStoreSource`: reading from a SqlStreamStore `$all` stream into a `Propulsion.Sink`
   2. `ReaderCheckpoint`: checkpoint storage for `Propulsion.Feed`/`SqlStreamSteamStore`/`EventStoreDb` using `Dapper`, `Microsoft.Data.SqlClient`
-  3. `FeedMonitor.AwaitSource`: See `Propulsion.Feed`
+  3. `Monitor.AwaitCompletion`: See `Propulsion.Feed`
 
   (Reading and position metrics are exposed via `Propulsion.Feed.Prometheus`)
 

--- a/src/Propulsion.Feed/FeedSource.fs
+++ b/src/Propulsion.Feed/FeedSource.fs
@@ -5,6 +5,7 @@ open Propulsion
 open Propulsion.Feed
 open Propulsion.Internal
 open System
+open System.Collections.Generic
 open System.Threading.Tasks
 
 /// Drives reading and checkpointing for a set of feeds (tranches) of a custom source feed
@@ -15,11 +16,14 @@ type FeedSourceBase internal
         renderPos : Position -> string,
         ?logCommitFailure) =
     let log = log.ForContext("source", sourceId)
+    let positions = TranchePositions()
+    let feedWaiter = lazy FeedMonitor(log, positions, sink)
 
     let pumpPartition crawl partitionId trancheId = async {
         let log = log.ForContext("tranche", trancheId)
         let ingester : Ingestion.Ingester<_> = sink.StartIngester(log, partitionId)
-        let reader = FeedReader(log, sourceId, trancheId, statsInterval, crawl trancheId, ingester.Ingest, checkpoints.Commit, renderPos, ?logCommitFailure = logCommitFailure)
+        let ingest = positions.Intercept(trancheId) >> ingester.Ingest
+        let reader = FeedReader(log, sourceId, trancheId, statsInterval, crawl trancheId, ingest, checkpoints.Commit, renderPos, ?logCommitFailure = logCommitFailure)
         try let! freq, pos = checkpoints.Start(sourceId, trancheId, ?establishOrigin = (establishOrigin |> Option.map (fun f -> f trancheId)))
             log.Information("Reading {source:l}/{tranche:l} From {pos} Checkpoint Event interval {checkpointFreq:n1}m",
                             sourceId, trancheId, renderPos pos, freq.TotalMinutes)
@@ -41,6 +45,122 @@ type FeedSourceBase internal
         with e ->
             log.Warning(e, "Exception encountered while running source, exiting loop")
             return! Async.Raise e }
+
+    member _.Monitor = feedWaiter.Value
+
+/// Intercepts receipt and completion of batches, recording the read and completion positions
+and internal TranchePositions() =
+    let positions = System.Collections.Concurrent.ConcurrentDictionary<TrancheId, TrancheState>()
+
+    member _.Intercept(trancheId) =
+        positions.GetOrAdd(trancheId, fun _trancheId -> { read = ValueNone; completed = ValueNone }) |> ignore
+        fun (batch : Ingestion.Batch<_>) ->
+            positions[trancheId].read <- ValueSome batch.epoch
+            let onCompletion () =
+                batch.onCompletion()
+                positions[trancheId].completed <- ValueSome batch.epoch
+            { batch with onCompletion = onCompletion }
+    member _.Current() = positions.ToArray()
+
+/// Represents the current state of a tranche of the source's processing
+and internal TrancheState =
+    { mutable read : int64 voption; mutable completed : int64 voption }
+    member x.IsEmpty = x.completed = x.read
+
+and FeedMonitor internal (log : Serilog.ILogger, positions : TranchePositions, sink : Propulsion.Streams.Default.Sink) =
+
+    let choose f (xs : KeyValuePair<_, _> array) = [| for x in xs do match f x.Value with ValueNone -> () | ValueSome v' -> struct (x.Key, v') |]
+    let checkForActivity () =
+        match positions.Current() with
+        | xs when xs |> Array.forall (fun (kv : KeyValuePair<_, TrancheState>)  -> kv.Value.IsEmpty) -> Array.empty
+        | originals -> originals |> choose (fun v -> v.read)
+    let awaitPropagation (propagationDelay : TimeSpan) (delayMs : int) = async {
+        let sw, max = System.Diagnostics.Stopwatch.StartNew(), int64 propagationDelay.TotalMilliseconds
+        let mutable startPositions = checkForActivity ()
+        while Array.isEmpty startPositions && not sink.IsCompleted && sw.ElapsedMilliseconds < max do
+            do! Async.Sleep delayMs
+            startPositions <- checkForActivity ()
+        return startPositions }
+    let awaitCompletion starting (delayMs : int) includeSubsequent logInterval = async {
+        let logInterval = IntervalTimer logInterval
+        let logStatus () =
+            let currentRead, completed =
+                let current = positions.Current()
+                current |> choose (fun v -> v.read), current |> choose (fun v -> v.completed)
+            if includeSubsequent then
+                log.Information("FeedSource Awaiting All. Current {current} Completed {completed} Starting {starting}",
+                                currentRead, completed, starting)
+            else log.Information("FeedSource Awaiting Starting {starting} Completed {completed}", starting, completed)
+        let isComplete () =
+            let current = positions.Current()
+            let completed = current |> choose (fun v -> v.completed)
+            let originalStartedAreAllCompleted () =
+                let forTranche = Dictionary() in for struct (k, v) in completed do forTranche.Add(k, v)
+                let hasPassed origin trancheId =
+                    let mutable v = Unchecked.defaultof<_>
+                    forTranche.TryGetValue(trancheId, &v) && v > origin
+                starting |> Seq.forall (fun struct (t, s) -> hasPassed s t)
+            current |> Array.forall (fun kv -> kv.Value.IsEmpty) // All submitted work (including follow-on work), completed
+            || (not includeSubsequent && originalStartedAreAllCompleted ())
+        while not (isComplete ()) && not sink.IsCompleted do
+            if logInterval.IfDueRestart() then logStatus()
+            do! Async.Sleep delayMs }
+    let defaultLinger (propagationTimeout : TimeSpan) (propagation : TimeSpan) (processing : TimeSpan) =
+        max (propagationTimeout.TotalSeconds / 4.) ((propagation.TotalSeconds + processing.TotalSeconds) / 3.) |> TimeSpan.FromSeconds
+
+    /// Waits (for up to the <c>propagationDelay</c>) for events to be observed
+    /// If at least one event has been observed, waits for the completion of the Sink's processing
+    member _.AwaitCompletion
+        (   // time to wait for arrival of initial events, this should take into account:
+            // - time for indexing of the events to complete based on the environment's configuration (e.g. with DynamoStore, the total Lambda and DynamoDB Streams trigger time)
+            // - an adjustment to account for the polling interval that the Source is using
+            propagationDelay,
+            // sleep interval while awaiting completion. Default 1ms.
+            ?delay,
+            // interval at which to log status of the Await (to assist in analyzing stuck Sinks). Default 5s.
+            ?logInterval,
+            // Also wait for processing of batches that arrived subsequent to the start of the AwaitCompletion call
+            ?ignoreSubsequent,
+            // Time to wait subsequent to processing for trailing events. Default: propagationDelay / 4
+            ?linger) = async {
+        let sw = System.Diagnostics.Stopwatch.StartNew()
+        let delayMs = delay |> Option.map (fun (d : TimeSpan) -> int d.TotalMilliseconds) |> Option.defaultValue 1
+        match! awaitPropagation propagationDelay delayMs with
+        | [||] ->
+            let currentCompleted = seq { for kv in positions.Current() -> struct (kv.Key, kv.Value.completed) }
+            if propagationDelay = TimeSpan.Zero then log.Debug("Feed Wait Skipped; no processing pending. Completed Epochs {completed}", currentCompleted)
+            else log.Information("FeedSource Wait {propagationDelay:n1}s Timeout. Completed {completed}", sw.ElapsedSeconds, currentCompleted)
+        | starting ->
+            let propUsed = sw.Elapsed
+            let includeSubsequent = ignoreSubsequent <> Some true
+            let logInterval = defaultArg logInterval (TimeSpan.FromSeconds 5.)
+            let swProcessing = System.Diagnostics.Stopwatch.StartNew()
+            do! awaitCompletion starting delayMs includeSubsequent logInterval
+            let procUsed = swProcessing.Elapsed
+            let lingerF = defaultArg linger defaultLinger
+            let linger = lingerF propagationDelay propUsed procUsed
+            // let linger = linger |> Option.defaultValue (max (propagationDelay.TotalSeconds / 4.) ((propagationS + processingS) / 3.) |> TimeSpan.FromSeconds)
+            let skipLinger = linger = TimeSpan.Zero
+            let ll = if skipLinger then Serilog.Events.LogEventLevel.Information else Serilog.Events.LogEventLevel.Debug
+            let currentCompleted = seq { for kv in positions.Current() -> struct (kv.Key, kv.Value.completed) }
+            let originalCompleted = currentCompleted |> Seq.cache
+            if log.IsEnabled ll then
+                let completed = positions.Current() |> choose (fun v -> v.completed)
+                log.Write(ll, "FeedSource Wait {totalTime:n1}s Processed Propagate {propagate:n1}s/{propTimeout:n1}s Process {process:n1}s Starting {starting} Completed {completed}",
+                                sw.ElapsedSeconds, propUsed.TotalSeconds, propagationDelay.TotalSeconds, procUsed.TotalSeconds, starting, completed)
+            let swLinger = System.Diagnostics.Stopwatch.StartNew()
+            if not skipLinger then
+                match! awaitPropagation linger delayMs with
+                | [||] ->
+                    log.Information("FeedSource Wait {totalTime:n1}s OK Propagate {propagate:n1}/{propTimeout:n1}s Process {process:n1}s Linger {linger:n1}s. Starting {starting} Completed {completed}",
+                                    sw.ElapsedSeconds, propUsed.TotalSeconds, propagationDelay.TotalSeconds, procUsed.TotalSeconds, swLinger.ElapsedSeconds, starting, originalCompleted)
+                | lingering ->
+                    do! awaitCompletion lingering delayMs includeSubsequent logInterval
+                    log.Information("FeedSource Wait {totalTime:n1}s Lingered Propagate {propagate:n1}/{propTimeout:n1}s Process {process:n1}s Linger {lingered:n1}/{linger:n0}s. Starting {starting} Lingering {lingering} Completed {completed}",
+                                    sw.ElapsedSeconds, propUsed.TotalSeconds, propagationDelay.TotalSeconds, procUsed.TotalSeconds, swLinger.ElapsedSeconds, linger, starting, lingering, currentCompleted)
+            // If the sink Faulted, let the awaiter observe the associated Exception that triggered the shutdown
+            if sink.IsCompleted && not sink.RanToCompletion then
+                return! sink.AwaitShutdown() }
 
 /// Drives reading and checkpointing from a source that contains data from multiple streams. While a TrancheId is always required,
 /// it may have a default value of `"0"` if the underlying source representation does not involve autonomous shards/physical partitions etc

--- a/src/Propulsion.Feed/FeedSource.fs
+++ b/src/Propulsion.Feed/FeedSource.fs
@@ -6,7 +6,6 @@ open Propulsion.Feed
 open Propulsion.Internal
 open System
 open System.Collections.Generic
-open System.Threading.Tasks
 
 /// Drives reading and checkpointing for a set of feeds (tranches) of a custom source feed
 type FeedSourceBase internal
@@ -212,7 +211,7 @@ type TailingFeedSource
 
             try return! tcs.Task // aka base.AwaitShutdown()
             finally log.Information "... source stopped" }
-        new Pipeline(Task.Run<unit>(supervise), stop)
+        new Pipeline(Task.run supervise, stop)
 
 /// Drives reading and checkpointing from a source that aggregates data from multiple streams as a singular source
 /// without shards/physical partitions (tranches), such as the SqlStreamStore, and EventStoreDB $all feeds

--- a/src/Propulsion.MemoryStore/MemoryStoreLogger.fs
+++ b/src/Propulsion.MemoryStore/MemoryStoreLogger.fs
@@ -1,0 +1,37 @@
+module Propulsion.MemoryStore.MemoryStoreLogger
+
+open System
+open System.Threading
+
+let private propEvents name (xs : System.Collections.Generic.KeyValuePair<string,string> seq) (log : Serilog.ILogger) =
+    let items = seq { for kv in xs do yield sprintf "{\"%s\": %s}" kv.Key kv.Value }
+    log.ForContext(name, sprintf "[%s]" (String.concat ",\n\r" items))
+
+let private propEventJsonUtf8 name (events : FsCodec.ITimelineEvent<ReadOnlyMemory<byte>> array) (log : Serilog.ILogger) =
+    log |> propEvents name (seq {
+        for e in events do
+            let d = e.Data
+            if not d.IsEmpty then System.Collections.Generic.KeyValuePair<_,_>(e.EventType, System.Text.Encoding.UTF8.GetString d.Span) })
+
+let renderSubmit (log : Serilog.ILogger) struct (epoch, stream, events : FsCodec.ITimelineEvent<'F> array) =
+    if log.IsEnabled Serilog.Events.LogEventLevel.Verbose then
+        let log =
+            if (not << log.IsEnabled) Serilog.Events.LogEventLevel.Debug then log
+            elif typedefof<'F> <> typeof<ReadOnlyMemory<byte>> then log
+            else log |> propEventJsonUtf8 "Json" (unbox events)
+        let types = events |> Seq.map (fun e -> e.EventType)
+        log.ForContext("types", types).Debug("Submit #{epoch} {stream}x{count}", epoch, stream, events.Length)
+    elif log.IsEnabled Serilog.Events.LogEventLevel.Debug then
+        let types = seq { for e in events -> e.EventType } |> Seq.truncate 5
+        log.Debug("Submit #{epoch} {stream}x{count} {types}", epoch, stream, events.Length, types)
+let renderCompleted (log : Serilog.ILogger) (epoch, stream) =
+    log.Verbose("Done!  #{epoch} {stream}", epoch, stream)
+
+/// Wires specified <c>Observable</c> source (e.g. <c>VolatileStore.Committed</c>) to the Logger
+let subscribe log source =
+    let mutable epoch = -1L
+    let aux (stream, events) =
+        let epoch = Interlocked.Increment &epoch
+        renderSubmit log (epoch, stream, events)
+    if log.IsEnabled Serilog.Events.LogEventLevel.Debug then Observable.subscribe aux source
+    else { new IDisposable with member _.Dispose() = () }

--- a/src/Propulsion.MemoryStore/MemoryStoreSource.fs
+++ b/src/Propulsion.MemoryStore/MemoryStoreSource.fs
@@ -91,8 +91,8 @@ and MemoryStoreMonitor internal (log : Serilog.ILogger, positions : TranchePosit
             // Also wait for processing of batches that arrived subsequent to the start of the AwaitCompletion call
             ?ignoreSubsequent) = async {
         match positions.Prepared with
-        | -1L -> log.Information "No events submitted; completing immediately"
-        | epoch when epoch = positions.Completed -> log.Information("No processing pending. Completed Epoch {epoch}", positions.Completed)
+        | -1L -> log.Information "FeedMonitor Wait No events submitted; completing immediately"
+        | epoch when epoch = positions.Completed -> log.Information("FeedMonitor Wait No processing pending. Completed Epoch {epoch}", positions.Completed)
         | startingEpoch ->
             let includeSubsequent = ignoreSubsequent <> Some true
             let delayMs =
@@ -102,9 +102,9 @@ and MemoryStoreMonitor internal (log : Serilog.ILogger, positions : TranchePosit
             let logStatus () =
                 let completed = match positions.Completed with -1L -> Nullable() | x -> Nullable x
                 if includeSubsequent then
-                    log.Information("Awaiting Completion of all Batches. Starting Epoch {epoch} Current Epoch {current} Completed Epoch {completed}",
+                    log.Information("FeedMonitor Wait Awaiting Completion of all Batches. Starting Epoch {epoch} Current Epoch {current} Completed Epoch {completed}",
                                     startingEpoch, positions.Prepared, completed)
-                else log.Information("Awaiting Completion of Starting Epoch {startingEpoch} Completed Epoch {completed}", startingEpoch, completed)
+                else log.Information("FeedMonitor Wait Awaiting Completion of Starting Epoch {startingEpoch} Completed Epoch {completed}", startingEpoch, completed)
             let isComplete () =
                 let currentCompleted = positions.Completed
                 positions.Prepared = currentCompleted // All submitted work (including follow-on work), completed

--- a/src/Propulsion.MemoryStore/Propulsion.MemoryStore.fsproj
+++ b/src/Propulsion.MemoryStore/Propulsion.MemoryStore.fsproj
@@ -7,6 +7,8 @@
   <ItemGroup>
     <Compile Include="MemoryStoreLogger.fs" />
     <Compile Include="MemoryStoreSource.fs" />
+    <Compile Include="ReactorInternal.fs" />
+    <Compile Include="ReactorMonitor.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Propulsion.MemoryStore/Propulsion.MemoryStore.fsproj
+++ b/src/Propulsion.MemoryStore/Propulsion.MemoryStore.fsproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="MemoryStoreLogger.fs" />
     <Compile Include="MemoryStoreSource.fs" />
   </ItemGroup>
 

--- a/src/Propulsion.MemoryStore/ReactorInternal.fs
+++ b/src/Propulsion.MemoryStore/ReactorInternal.fs
@@ -1,31 +1,35 @@
-module Propulsion.Reactor.Internal.Retry
+module Propulsion.Reactor.Internal
 
-open System
 open Propulsion.Internal
+open System
 
-/// Wraps a computation such that:
-/// - Until the timeout, exceptions trigger backing off for 10 ms and retrying
-/// - After the timeout, any exception triggered by the computation will propagate to the caller
-/// NOTE does not guarantee completion within the timeout, nor does it trigger cancellation (see timeoutAfter)
-let private keepTrying (backoffMs : int) timeout computation = async {
-    let cutoff = IntervalTimer timeout
-    let mutable exceptions, finished = ResizeArray(), false
-    while not finished do
-        try do! computation
-            finished <- true
-        with e when not (cutoff.IfDueRestart()) ->
-            exceptions.Add e
-            do! Async.Sleep backoffMs
-    return exceptions.ToArray() }
+module Async =
 
-/// Wraps a computation, cancelling (and triggering a timeout exception) if it doesn't complete within the specified timeout
-let private timeoutAfter (timeout : TimeSpan) (c : Async<'a>) = async {
-    let! r = Async.StartChild(c, int timeout.TotalMilliseconds)
-    return! r }
+    /// Wraps a computation, cancelling (and triggering a timeout exception) if it doesn't complete within the specified timeout
+    let timeoutAfter (timeout : TimeSpan) (c : Async<'a>) = async {
+        let! r = Async.StartChild(c, int timeout.TotalMilliseconds)
+        return! r }
 
-/// Continually retries a computation within a period, with a specified backoff in the case of failure
-/// If it has not succeeded within that time, we allow one more period before triggering a timeout
-/// This is to give us a reasonable chance of seeing the underlying failure rather than a timeout exception
-let withBackoffAndTimeout (backoff : TimeSpan) period computation =
-    keepTrying (int backoff.TotalMilliseconds) period computation
-    |> timeoutAfter (period+period)
+module Retry =
+
+    /// Wraps a computation such that:
+    /// - Until the timeout, exceptions trigger backing off for 10 ms and retrying
+    /// - After the timeout, any exception triggered by the computation will propagate to the caller
+    /// NOTE does not guarantee completion within the timeout, nor does it trigger cancellation (see timeoutAfter)
+    let private keepTrying (backoffMs : int) timeout computation = async {
+        let cutoff = IntervalTimer timeout
+        let mutable exceptions, finished = ResizeArray(), false
+        while not finished do
+            try do! computation
+                finished <- true
+            with e when not (cutoff.IfDueRestart()) ->
+                exceptions.Add e
+                do! Async.Sleep backoffMs
+        return exceptions.ToArray() }
+
+    /// Continually retries a computation within a period, with a specified backoff in the case of failure
+    /// If it has not succeeded within that time, we allow one more period before triggering a timeout
+    /// This is to give us a reasonable chance of seeing the underlying failure rather than a timeout exception
+    let withBackoffAndTimeout (backoff : TimeSpan) period computation =
+        keepTrying (int backoff.TotalMilliseconds) period computation
+        |> Async.timeoutAfter (period+period)

--- a/src/Propulsion.MemoryStore/ReactorInternal.fs
+++ b/src/Propulsion.MemoryStore/ReactorInternal.fs
@@ -1,0 +1,31 @@
+module Propulsion.Reactor.Internal.Retry
+
+open System
+open Propulsion.Internal
+
+/// Wraps a computation such that:
+/// - Until the timeout, exceptions trigger backing off for 10 ms and retrying
+/// - After the timeout, any exception triggered by the computation will propagate to the caller
+/// NOTE does not guarantee completion within the timeout, nor does it trigger cancellation (see timeoutAfter)
+let private keepTrying (backoffMs : int) timeout computation = async {
+    let cutoff = IntervalTimer timeout
+    let mutable exceptions, finished = ResizeArray(), false
+    while not finished do
+        try do! computation
+            finished <- true
+        with e when not (cutoff.IfDueRestart()) ->
+            exceptions.Add e
+            do! Async.Sleep backoffMs
+    return exceptions.ToArray() }
+
+/// Wraps a computation, cancelling (and triggering a timeout exception) if it doesn't complete within the specified timeout
+let private timeoutAfter (timeout : TimeSpan) (c : Async<'a>) = async {
+    let! r = Async.StartChild(c, int timeout.TotalMilliseconds)
+    return! r }
+
+/// Continually retries a computation within a period, with a specified backoff in the case of failure
+/// If it has not succeeded within that time, we allow one more period before triggering a timeout
+/// This is to give us a reasonable chance of seeing the underlying failure rather than a timeout exception
+let withBackoffAndTimeout (backoff : TimeSpan) period computation =
+    keepTrying (int backoff.TotalMilliseconds) period computation
+    |> timeoutAfter (period+period)

--- a/src/Propulsion.MemoryStore/ReactorMonitor.fs
+++ b/src/Propulsion.MemoryStore/ReactorMonitor.fs
@@ -1,0 +1,21 @@
+module Propulsion.Reactor.Monitor
+
+open Propulsion.Internal
+open Propulsion.Reactor.Internal // Retry
+
+/// Run a phase of processing, repeating to
+/// a) verify correct idempotent handling
+/// b) handle cases where the observed effect is not observable immediately, but is eventually upon retrying
+let check wait backoff timeout warnThreshold label f = async {
+    let mutable wt = System.Diagnostics.Stopwatch()
+    let wait waitArg = async {
+        wt.Start()
+        do! wait waitArg
+        wt.Stop()
+    }
+    let t = System.Diagnostics.Stopwatch.StartNew()
+    let! retried = Retry.withBackoffAndTimeout backoff timeout (f wait)
+    // In general, in the MemoryStore case, we should never have retries; for other stores, it's obviously entirely possible
+    if t.Elapsed > warnThreshold || retried.Length > 0 then
+        Serilog.Log.Information("Check {label} {tot:n3}s waits {wt:n3}s retries {c} {retried}",
+                                label, t.ElapsedSeconds, wt.ElapsedSeconds, retried.Length, seq { for e in retried -> e.GetType().Name }) }

--- a/src/Propulsion/Internal.fs
+++ b/src/Propulsion/Internal.fs
@@ -48,7 +48,8 @@ open System.Threading.Tasks
 
 module Task =
 
-    let inline start create = Task.Run<unit>(Func<Task<unit>> create) |> ignore<Task>
+    let inline run create = Task.Run<unit>(Func<Task<unit>> create)
+    let inline start create = run create |> ignore<Task>
 
 type Sem(max) =
     let inner = new SemaphoreSlim(max)
@@ -145,4 +146,3 @@ module Stats =
             if buffer.Count <> 0 then
                 dumpStats kind buffer log
                 buffer.Clear()
-


### PR DESCRIPTION
Enables awaiting async processing of Reactions within integration tests when used with Sources implemented with FeedBase (i.e. DynamoStore, EventStoreDb but not CosmosStore)

Note the wait is not completely deterministic in the manner that `Propulsion.MemoryStore`'s `AwaitCompletion` is.

Has been extensively tested with a significant [closed source] app and https://github.com/jet/dotnet-templates/pull/121. 

Polishes/extends the MemoryStore impl to align with the final naming

Resoves #64 