### PR TITLE
Target Equinox 4.0.0-rc6 + FSharp.Core 6.0.7

### DIFF
--- a/src/Propulsion.CosmosStore/Propulsion.CosmosStore.fsproj
+++ b/src/Propulsion.CosmosStore/Propulsion.CosmosStore.fsproj
@@ -20,8 +20,9 @@
   <ItemGroup>
     <PackageReference Include="MinVer" Version="4.2.0" PrivateAssets="All" />
 
-    <PackageReference Include="Equinox.CosmosStore" Version="4.0.0-rc.5.2" />
+    <PackageReference Include="Equinox.CosmosStore" Version="4.0.0-rc.6" />
     <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.0-rc.9" />
+    <PackageReference Include="FSharp.Control.AsyncSeq" Version="3.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Propulsion.DynamoStore.Indexer/Propulsion.DynamoStore.Indexer.fsproj
+++ b/src/Propulsion.DynamoStore.Indexer/Propulsion.DynamoStore.Indexer.fsproj
@@ -4,6 +4,9 @@
         
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
         <AWSProjectType>Lambda</AWSProjectType>
+        <!-- Try to end up with one FSharp.Core-->
+        <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
+        
         <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 

--- a/src/Propulsion.DynamoStore/Propulsion.DynamoStore.fsproj
+++ b/src/Propulsion.DynamoStore/Propulsion.DynamoStore.fsproj
@@ -27,7 +27,6 @@
 
       <PackageReference Include="Equinox.DynamoStore" Version="4.0.0-rc.6" />
       <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.0-rc.9" />
-      <PackageReference Include="FSharp.Core" Version="6.0.7" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/Propulsion.DynamoStore/Propulsion.DynamoStore.fsproj
+++ b/src/Propulsion.DynamoStore/Propulsion.DynamoStore.fsproj
@@ -27,7 +27,7 @@
 
       <PackageReference Include="Equinox.DynamoStore" Version="4.0.0-rc.6" />
       <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.0-rc.9" />
-      <PackageReference Include="FSharp.Core" Version="6.0.6" />
+      <PackageReference Include="FSharp.Core" Version="6.0.7" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/Propulsion.DynamoStore/Propulsion.DynamoStore.fsproj
+++ b/src/Propulsion.DynamoStore/Propulsion.DynamoStore.fsproj
@@ -25,8 +25,9 @@
     <ItemGroup>
       <PackageReference Include="MinVer" Version="4.2.0" PrivateAssets="All" />
 
-      <PackageReference Include="Equinox.DynamoStore" Version="4.0.0-rc.5.2" />
+      <PackageReference Include="Equinox.DynamoStore" Version="4.0.0-rc.6" />
       <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.0-rc.9" />
+      <PackageReference Include="FSharp.Core" Version="6.0.6" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/Propulsion.DynamoStore/Types.fs
+++ b/src/Propulsion.DynamoStore/Types.fs
@@ -112,7 +112,7 @@ module internal EventCodec =
 
 module internal Async =
 
-    // NOTE there's a bug in FSharp.Core >= 6.0.6 that can trigger a process exit with StackOverflowException
+    // NOTE there's a bug in FSharp.Core <= 6.0.6 that can trigger a process exit with StackOverflowException
     // if more than ~1200 computations are supplied and abort quickly
     let parallelThrottled dop computations = // https://github.com/dotnet/fsharp/issues/13165
         Async.Parallel(computations, maxDegreeOfParallelism = dop)

--- a/src/Propulsion.DynamoStore/Types.fs
+++ b/src/Propulsion.DynamoStore/Types.fs
@@ -112,28 +112,8 @@ module internal EventCodec =
 
 module internal Async =
 
-    open Propulsion.Infrastructure // AwaitTaskCorrect
-
-    type Async with
-        static member Throttle degreeOfParallelism =
-            let s = new System.Threading.SemaphoreSlim(degreeOfParallelism)
-            fun computation -> async {
-                let! ct = Async.CancellationToken
-                do! s.WaitAsync ct |> Async.AwaitTaskCorrect
-                try return! computation
-                finally s.Release() |> ignore }
-    let private parallelThrottledUnsafe dop computations = // https://github.com/dotnet/fsharp/issues/13165
+    // NOTE there's a bug in FSharp.Core >= 6.0.6 that can trigger a process exit with StackOverflowException
+    // if more than ~1200 computations are supplied and abort quickly
+    let parallelThrottled dop computations = // https://github.com/dotnet/fsharp/issues/13165
         Async.Parallel(computations, maxDegreeOfParallelism = dop)
-    // NOTE as soon as a non-preview Async.Parallel impl in FSharp.Core includes the fix (e.g. 6.0.5 does not, 6.0.5-beta.22329.3 does),
-    // we can remove this shimming and replace it with the body of parallelThrottledUnsafe
-    let parallelThrottled dop computations = async {
-        let throttle = Async.Throttle dop // each batch of 1200 gets the full potential dop - we internally limit what actually gets to run concurrently here
-        let! allResults =
-            computations
-            |> Seq.map throttle
-            |> Seq.chunkBySize 1200
-            |> Seq.map (parallelThrottledUnsafe dop)
-            |> Async.Parallel
-        return Array.concat allResults
-    }
 #endif

--- a/src/Propulsion.EventStore/Propulsion.EventStore.fsproj
+++ b/src/Propulsion.EventStore/Propulsion.EventStore.fsproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="MinVer" Version="4.2.0" PrivateAssets="All" />
 
-    <PackageReference Include="Equinox.EventStore" Version="4.0.0-rc.5.2" />
+    <PackageReference Include="Equinox.EventStore" Version="4.0.0-rc.6" />
     <PackageReference Include="FsCodec.Box" Version="3.0.0-rc.9" />
   </ItemGroup>
 

--- a/src/Propulsion.EventStoreDb/Propulsion.EventStoreDb.fsproj
+++ b/src/Propulsion.EventStoreDb/Propulsion.EventStoreDb.fsproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="MinVer" Version="4.2.0" PrivateAssets="All" />
 
-    <PackageReference Include="Equinox.EventStoreDb" Version="4.0.0-rc.5.2" />
+    <PackageReference Include="Equinox.EventStoreDb" Version="4.0.0-rc.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Propulsion.MemoryStore/Propulsion.MemoryStore.fsproj
+++ b/src/Propulsion.MemoryStore/Propulsion.MemoryStore.fsproj
@@ -19,7 +19,7 @@
     <PackageReference Include="MinVer" Version="4.2.0" PrivateAssets="All" />
 
     <PackageReference Include="FsCodec.Box" Version="3.0.0-rc.9" />
-    <PackageReference Include="Equinox.MemoryStore" Version="4.0.0-rc.5.2" />
+    <PackageReference Include="Equinox.MemoryStore" Version="4.0.0-rc.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Propulsion.Tests/ParallelThrottledValidation.fs
+++ b/tests/Propulsion.Tests/ParallelThrottledValidation.fs
@@ -3,7 +3,7 @@ module Propulsion.Tests.ParallelThrottledValidation
 open Swensen.Unquote
 open Xunit
 
-// Fixed in 6.0.5-beta.22329.3 and 6.0.6 (which we explicitly target in this test suite)
+// Fixed in 6.0.5-beta.22329.3 and 6.0.6 (we explicitly target 6.0.7 in this test suite)
 // 6.0.5 is built from a 6.0.4 tag so does not include the fix (but it would win over the beta version in semver)
 let [<Fact>] ``Async.Parallel blows stack when cancelling many <= in FSharp.Core 6.0.5`` () =
     let gen (i : int) = async {

--- a/tests/Propulsion.Tests/ParallelThrottledValidation.fs
+++ b/tests/Propulsion.Tests/ParallelThrottledValidation.fs
@@ -3,9 +3,8 @@ module Propulsion.Tests.ParallelThrottledValidation
 open Swensen.Unquote
 open Xunit
 
-// Fixed in 6.0.5-beta.22329.3 (which we explicitly target in this test suite)
+// Fixed in 6.0.5-beta.22329.3 and 6.0.6 (which we explicitly target in this test suite)
 // 6.0.5 is built from a 6.0.4 tag so does not include the fix (but it would win over the beta version in semver)
-// => Propulsion.DynamoStore needs to depend on on 6.0.0 for now
 let [<Fact>] ``Async.Parallel blows stack when cancelling many <= in FSharp.Core 6.0.5`` () =
     let gen (i : int) = async {
         if i = 0 then

--- a/tests/Propulsion.Tests/Propulsion.Tests.fsproj
+++ b/tests/Propulsion.Tests/Propulsion.Tests.fsproj
@@ -23,7 +23,8 @@
   <ItemGroup>
     <PackageReference Include="FsCheck.Xunit" Version="2.16.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-	<PackageReference Include="FSharp.Core" Version="6.0.6" />
+    <!-- Pin requirement for at least 6.0.6 in one of the tests by requesting same as Propulsion>DynamoStore will require-->
+	<PackageReference Include="FSharp.Core" Version="6.0.7" />
 	<PackageReference Include="unquote" Version="6.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/tests/Propulsion.Tests/Propulsion.Tests.fsproj
+++ b/tests/Propulsion.Tests/Propulsion.Tests.fsproj
@@ -23,7 +23,7 @@
   <ItemGroup>
     <PackageReference Include="FsCheck.Xunit" Version="2.16.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-	<PackageReference Include="FSharp.Core" Version="6.0.5-beta.22329.3" />
+	<PackageReference Include="FSharp.Core" Version="6.0.6" />
 	<PackageReference Include="unquote" Version="6.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/tools/Propulsion.Tool/Propulsion.Tool.fsproj
+++ b/tools/Propulsion.Tool/Propulsion.Tool.fsproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <DisableImplicitFSharpCoreReference>false</DisableImplicitFSharpCoreReference>
+    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
 
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>propulsion</ToolCommandName>


### PR DESCRIPTION
The fix for https://github.com/dotnet/fsharp/issues/13165 is included in FSharp.Core 6.0.6
(Compile error suggests https://github.com/dotnet/fsharp/issues/12706 is still at large though)