### PR TITLE
Feed: Add SinglePassFeedSource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 - `Feed`: `Monitor.AwaitCompletion` enables **quasi** deterministic waiting for the processing of async reactions within integration tests [#170](https://github.com/jet/propulsion/pull/170)
 - `Feed`: `Checkpoint` enables committing progress (and obtaining the achieved positions) without stopping the Sink [#162](https://github.com/jet/propulsion/pull/162)
+- `Feed.SinglePassFeedSource`: Coordinates reads of a set of tranches until each reaches its Tail [#179](https://github.com/jet/propulsion/pull/179)
 - `Scheduler`: `purgeInterval` to control memory usage [#97](https://github.com/jet/propulsion/pull/97)
 - `Scheduler`: `wakeForResults` option to maximize throughput (without having to drop sleep interval to zero) [#161](https://github.com/jet/propulsion/pull/161)
 - `Ingester`: Expose optional `ingesterStatsInterval` control [#154](https://github.com/jet/propulsion/pull/154)

--- a/src/Propulsion.CosmosStore/ChangeFeedProcessor.fs
+++ b/src/Propulsion.CosmosStore/ChangeFeedProcessor.fs
@@ -30,7 +30,7 @@ type internal SourcePipeline =
 
     static member Start(log : ILogger, start, maybeStartChild, stop, observer : IDisposable) =
         let cts = new CancellationTokenSource()
-        let triggerStop () =
+        let triggerStop _disposing =
             let level = if cts.IsCancellationRequested then Events.LogEventLevel.Debug else Events.LogEventLevel.Information
             log.Write(level, "Source stopping...")
             observer.Dispose()

--- a/src/Propulsion.MemoryStore/MemoryStoreSource.fs
+++ b/src/Propulsion.MemoryStore/MemoryStoreSource.fs
@@ -51,7 +51,7 @@ type MemoryStoreSource<'F>(log, store : Equinox.MemoryStore.VolatileStore<'F>, c
     member x.Start() =
         let ct, stop =
             let cts = new CancellationTokenSource()
-            cts.Token, fun () -> log.Information "Source stopping..."; cts.Cancel()
+            cts.Token, fun _disposing -> log.Information "Source stopping..."; cts.Cancel()
 
         let setSuccess, awaitCompletion =
             let tcs = System.Threading.Tasks.TaskCompletionSource<unit>()

--- a/tests/Propulsion.Tests/SourceTests.fs
+++ b/tests/Propulsion.Tests/SourceTests.fs
@@ -11,23 +11,42 @@ open Xunit
 
 type Scenario(testOutput) =
 
-    let log = TestOutputLogger.forTestOutput(testOutput)
+    let log = TestOutputLogger.forTestOutput testOutput
+
+    let store = Equinox.MemoryStore.VolatileStore()
+    let checkpoints = ReaderCheckpoint.MemoryStore.create log ("consumerGroup", TimeSpan.FromMinutes 1) store
+    let stats = { new Propulsion.Streams.Stats<_>(log, TimeSpan.FromMinutes 1, TimeSpan.FromMinutes 1)
+                  with member _.HandleExn(log, x) = ()
+                       member _.HandleOk x = () }
+    let handle _ = async { return struct (Propulsion.Streams.SpanResult.AllProcessed, ()) }
+    let sink = Propulsion.Streams.Default.Config.Start(log, 2, 2, handle, stats, TimeSpan.FromMinutes 1)
 
     [<Fact>]
-    let ``source AwaitCompletion semantics`` () = async {
-        let store = Equinox.MemoryStore.VolatileStore()
-        let checkpoints = ReaderCheckpoint.MemoryStore.create log ("consumerGroup", TimeSpan.FromMinutes 1) store
+    let ``TailingFeedSource Stop / AwaitCompletion semantics`` () = async {
         let crawl _  = AsyncSeq.singleton <| struct (TimeSpan.FromSeconds 0.1, ({ items = Array.empty; isTail = false; checkpoint = Unchecked.defaultof<_> } : Core.Batch<_>))
-        let stats = { new Propulsion.Streams.Stats<_>(log, TimeSpan.FromMinutes 1, TimeSpan.FromMinutes 1)
-                      with member _.HandleExn(log, x) = ()
-                           member _.HandleOk x = () }
-        let handle _ = async { return struct (Propulsion.Streams.SpanResult.AllProcessed, ()) }
-        let sink = Propulsion.Streams.Default.Config.Start(log, 2, 2, handle, stats, TimeSpan.FromMinutes 1)
         let source = Propulsion.Feed.Core.TailingFeedSource(log, TimeSpan.FromMinutes 1, SourceId.parse "sid", TimeSpan.FromMinutes 1,
                                                             checkpoints, (*establishOrigin*)None, sink, crawl, string)
-        let src = source.Start(source.Pump(fun _ -> async { return [| TrancheId.parse "tid" |] }))
+        use src = source.Start(source.Pump(fun _ -> async { return [| TrancheId.parse "tid" |] }))
         Task.Delay(TimeSpan.FromSeconds 0.5).ContinueWith(fun _ -> src.Stop()) |> ignore
+        // Yields sink exception, if any
         do! src.Monitor.AwaitCompletion(propagationDelay = TimeSpan.FromSeconds 0.5, awaitFullyCaughtUp = true)
+        // Yields source exception, if any
         do! src.AwaitShutdown()
         test <@ src.RanToCompletion @>
     }
+
+    [<Fact>]
+    let SinglePassSource () = async {
+        let crawl _  : AsyncSeq<struct (TimeSpan * Core.Batch<_>)> = asyncSeq {
+            yield struct (TimeSpan.FromSeconds 0.1, { items = Array.empty; isTail = true; checkpoint = Unchecked.defaultof<_> })
+        }
+        let source = Propulsion.Feed.Core.SinglePassFeedSource(log, TimeSpan.FromMinutes 1, SourceId.parse "sid", checkpoints, sink, crawl, string)
+        use src = source.Start(source.Pump(fun _ -> async { return [| TrancheId.parse "tid" |] }))
+        // Yields sink exception, if any
+        do! src.Monitor.AwaitCompletion(propagationDelay = TimeSpan.FromSeconds 1, awaitFullyCaughtUp = true)
+        // Yields source exception, if any
+        do! src.AwaitShutdown()
+        test <@ src.RanToCompletion @>
+    }
+
+    interface IDisposable with member _.Dispose() = sink.Stop(); sink.AwaitShutdown() |> Async.RunSynchronously

--- a/tests/Propulsion.Tests/TestOutputLogger.fs
+++ b/tests/Propulsion.Tests/TestOutputLogger.fs
@@ -5,12 +5,14 @@ open Serilog
 // Derived from https://github.com/damianh/CapturingLogOutputWithXunit2AndParallelTests
 // NB VS does not surface these atm, but other test runners / test reports do
 type TestOutputLogger(testOutput : Xunit.Abstractions.ITestOutputHelper) =
-    let formatter = Serilog.Formatting.Display.MessageTemplateTextFormatter("{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level}] {Message}{NewLine}{Exception}", null);
+    let t = "[{Timestamp:HH:mm:ss} {Level:u1}] {Message:lj} {Properties:j}{NewLine}{Exception}"
+    let formatter = Serilog.Formatting.Display.MessageTemplateTextFormatter(t, null);
     let writeSerilogEvent logEvent =
         use writer = new System.IO.StringWriter()
         formatter.Format(logEvent, writer);
-        writer |> string |> testOutput.WriteLine
-        writer |> string |> System.Diagnostics.Debug.Write
+        let message = writer.ToString().TrimEnd('\n')
+        testOutput.WriteLine message
+        System.Diagnostics.Debug.WriteLine message
     interface Serilog.Core.ILogEventSink with member x.Emit logEvent = writeSerilogEvent logEvent
 
 module TestOutputLogger =


### PR DESCRIPTION
See tests - executes a single pass (parallel) ingestion of all tranches of a Source until they've all been Handled by a Sink.