### PR TITLE
Streams: Fix handling of purge under compaction

### DIFF
--- a/src/Propulsion.Feed/FeedReader.fs
+++ b/src/Propulsion.Feed/FeedReader.fs
@@ -58,7 +58,7 @@ module private Impl =
             let readS, postS = readLatency.TotalSeconds, ingestLatency.TotalSeconds
             let inline r pos = match pos with p when p = Position.parse -1L -> null | x -> renderPos x
             (Log.withMetric m log).ForContext("tail", batchCaughtUp).Information(
-                "Reader {partition} {state} Position {readPosition} Committed {lastCommittedPosition} Pages {pagesRead} Empty {pagesEmpty} Events {events} | Recent {l:f1}s Pages {recentPagesRead} Empty {recentPagesEmpty} Events {recentEvents} | Wait {pausedS:f1}s Ahead {cur}/{max}",
+                "Reader {partition} {state} @ {readPosition} Committed {lastCommittedPosition} Pages {pagesRead} Empty {pagesEmpty} Events {events} | Recent {l:f1}s Pages {recentPagesRead} Empty {recentPagesEmpty} Events {recentEvents} | Wait {pausedS:f1}s Ahead {cur}/{max}",
                 partition, (if batchCaughtUp then "Tail" else "Busy"), r batchLastPosition, r lastCommittedPosition, pagesRead, pagesEmpty, events, readS, recentPagesRead, recentPagesEmpty, recentEvents, postS, currentBatches, maxBatches)
             readLatency <- TimeSpan.Zero; ingestLatency <- TimeSpan.Zero;
             recentPagesRead <- 0; recentEvents <- 0; recentPagesEmpty <- 0


### PR DESCRIPTION
Fixes an issue introduced in the original implementation of purging in #97 

Issue was that processing can stop (Scheduler reports Holding 0 batches and no active work) when
- compaction takes effect (Ingester has sufficient read ahead margin to trigger compaction)
- purge removes a stream from the buffer at the point where work has been completed that has yet to enter the pending batches list

This fix causes stream requirements in a batch to immediately be declared complete on ingestion where the underlying stream queue entry has been removed; previously this prevented the batch from being declared complete