### PR TITLE
Scheduler: Fix state logging, extend stats

### DIFF
--- a/src/Propulsion.Cosmos/CosmosPruner.fs
+++ b/src/Propulsion.Cosmos/CosmosPruner.fs
@@ -56,7 +56,7 @@ module Pruner =
             let inline adds x (set:HashSet<_>) = set.Add x |> ignore
             base.Handle message
             match message with
-            | Scheduling.InternalMessage.Result (_duration, stream, _progressed, Choice2Of2 (_, exn)) ->
+            | { stream = stream; result = Choice2Of2 (_, exn) } ->
                 match classify exn with
                 | ExceptionKind.RateLimited ->
                     adds stream rlStreams; rateLimited <- rateLimited + 1
@@ -106,8 +106,9 @@ module Pruner =
                 struct (metrics, struct (stream, span))
             let dispatcher = Scheduling.Dispatcher.MultiDispatcher<_, _, _, _>.Create(itemDispatcher, handle pruneUntil, interpret, (fun _ -> id), stats, dumpStreams)
             Scheduling.StreamSchedulingEngine(
-                dispatcher, maxHolding = 5,
+                dispatcher, maxIngest = 5,
                 ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay)
+
 /// DANGER: <c>CosmosPruner</c> DELETES events - use with care
 type CosmosPruner =
 

--- a/src/Propulsion.Cosmos/CosmosPruner.fs
+++ b/src/Propulsion.Cosmos/CosmosPruner.fs
@@ -107,9 +107,7 @@ module Pruner =
             let dispatcher = Scheduling.Dispatcher.MultiDispatcher<_, _, _, _>.Create(itemDispatcher, handle pruneUntil, interpret, (fun _ -> id), stats, dumpStreams)
             Scheduling.StreamSchedulingEngine(
                 dispatcher, maxHolding = 5,
-                ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay,
-                enableSlipstreaming = false)
-
+                ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay)
 /// DANGER: <c>CosmosPruner</c> DELETES events - use with care
 type CosmosPruner =
 

--- a/src/Propulsion.Cosmos/CosmosPruner.fs
+++ b/src/Propulsion.Cosmos/CosmosPruner.fs
@@ -106,7 +106,7 @@ module Pruner =
                 struct (metrics, struct (stream, span))
             let dispatcher = Scheduling.Dispatcher.MultiDispatcher<_, _, _, _>.Create(itemDispatcher, handle pruneUntil, interpret, (fun _ -> id), stats, dumpStreams)
             Scheduling.StreamSchedulingEngine(
-                dispatcher,
+                dispatcher, maxHolding = 5,
                 ?maxBatches = maxBatches, ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay,
                 enableSlipstreaming = false)
 
@@ -121,7 +121,6 @@ type CosmosPruner =
             ?statsInterval,
             // Default 5m
             ?stateInterval,
-            ?maxSubmissionsPerPartition,
             ?maxBatches, ?purgeInterval, ?wakeForResults, ?idleDelay,
             // Defaults to statsInterval
             ?ingesterStatsInterval)
@@ -135,7 +134,4 @@ type CosmosPruner =
             Pruner.StreamSchedulingEngine.Create(
                 pruneUntil, dispatcher, stats, dumpStreams,
                 ?maxBatches = maxBatches, ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay)
-        Projector.Pipeline.Start(
-            log, dispatcher.Pump, (fun _abend -> streamScheduler.Pump), maxReadAhead, streamScheduler.Submit, statsInterval,
-            ?maxSubmissionsPerPartition = maxSubmissionsPerPartition,
-            ?ingesterStatsInterval = ingesterStatsInterval)
+        Projector.Pipeline.Start(log, dispatcher.Pump, (fun _abend -> streamScheduler.Pump), maxReadAhead, streamScheduler, statsInterval, ?ingesterStatsInterval = ingesterStatsInterval)

--- a/src/Propulsion.Cosmos/CosmosPruner.fs
+++ b/src/Propulsion.Cosmos/CosmosPruner.fs
@@ -99,7 +99,7 @@ module Pruner =
 
     type StreamSchedulingEngine =
 
-        static member Create(pruneUntil, itemDispatcher, stats : Stats, dumpStreams, ?maxBatches, ?purgeInterval, ?wakeForResults, ?idleDelay)
+        static member Create(pruneUntil, itemDispatcher, stats : Stats, dumpStreams, ?purgeInterval, ?wakeForResults, ?idleDelay)
             : Scheduling.StreamSchedulingEngine<_, _, _, _> =
             let interpret struct (stream, span) =
                 let metrics = StreamSpan.metrics Default.eventSize span
@@ -107,7 +107,7 @@ module Pruner =
             let dispatcher = Scheduling.Dispatcher.MultiDispatcher<_, _, _, _>.Create(itemDispatcher, handle pruneUntil, interpret, (fun _ -> id), stats, dumpStreams)
             Scheduling.StreamSchedulingEngine(
                 dispatcher, maxHolding = 5,
-                ?maxBatches = maxBatches, ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay,
+                ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay,
                 enableSlipstreaming = false)
 
 /// DANGER: <c>CosmosPruner</c> DELETES events - use with care
@@ -121,7 +121,7 @@ type CosmosPruner =
             ?statsInterval,
             // Default 5m
             ?stateInterval,
-            ?maxBatches, ?purgeInterval, ?wakeForResults, ?idleDelay,
+            ?purgeInterval, ?wakeForResults, ?idleDelay,
             // Defaults to statsInterval
             ?ingesterStatsInterval)
         : Default.Sink =
@@ -133,5 +133,5 @@ type CosmosPruner =
         let streamScheduler =
             Pruner.StreamSchedulingEngine.Create(
                 pruneUntil, dispatcher, stats, dumpStreams,
-                ?maxBatches = maxBatches, ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay)
+                ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay)
         Projector.Pipeline.Start(log, dispatcher.Pump, (fun _abend -> streamScheduler.Pump), maxReadAhead, streamScheduler, statsInterval, ?ingesterStatsInterval = ingesterStatsInterval)

--- a/src/Propulsion.Cosmos/CosmosSink.fs
+++ b/src/Propulsion.Cosmos/CosmosSink.fs
@@ -135,7 +135,7 @@ module Internal =
 
         static member Create(
                 log : ILogger, cosmosContexts : _ [], itemDispatcher, stats : Stats, dumpStreams,
-                ?maxBatches, ?purgeInterval, ?wakeForResults, ?idleDelay, ?maxEvents, ?maxBytes)
+                ?purgeInterval, ?wakeForResults, ?idleDelay, ?maxEvents, ?maxBytes)
             : Scheduling.StreamSchedulingEngine<_, _, _, _> =
             let maxEvents, maxBytes = defaultArg maxEvents 16384, defaultArg maxBytes (1024 * 1024 - (*fudge*)4096)
             let writerResultLog = log.ForContext<Writer.Result>()
@@ -164,7 +164,7 @@ module Internal =
                     .Create(itemDispatcher, attemptWrite, interpretWriteResultProgress, stats, dumpStreams)
             Scheduling.StreamSchedulingEngine(
                 dispatcher, maxHolding = 5,
-                ?maxBatches = maxBatches, ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay,
+                ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay,
                 enableSlipstreaming = true, prioritizeStreamsBy = Default.eventSize)
 
 type CosmosSink =
@@ -176,7 +176,7 @@ type CosmosSink =
             ?statsInterval,
             // Default 5m
             ?stateInterval,
-            ?maxBatches, ?purgeInterval, ?wakeForResults, ?idleDelay,
+            ?purgeInterval, ?wakeForResults, ?idleDelay,
             // Default: 16384
             ?maxEvents,
             // Default: 1MB (limited by maximum size of a CosmosDB stored procedure invocation)
@@ -190,6 +190,6 @@ type CosmosSink =
         let streamScheduler =
             Internal.StreamSchedulingEngine.Create(
                 log, cosmosContexts, dispatcher, stats, dumpStreams,
-                ?maxBatches = maxBatches, ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay,
+                ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay,
                 ?maxEvents=maxEvents, ?maxBytes = maxBytes)
         Projector.Pipeline.Start(log, dispatcher.Pump, (fun _abend -> streamScheduler.Pump), maxReadAhead, streamScheduler, statsInterval, ?ingesterStatsInterval = ingesterStatsInterval)

--- a/src/Propulsion.Cosmos/CosmosSink.fs
+++ b/src/Propulsion.Cosmos/CosmosSink.fs
@@ -165,7 +165,7 @@ module Internal =
             Scheduling.StreamSchedulingEngine(
                 dispatcher, maxHolding = 5,
                 ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay,
-                enableSlipstreaming = true, prioritizeStreamsBy = Default.eventSize)
+                prioritizeStreamsBy = Default.eventSize)
 
 type CosmosSink =
 

--- a/src/Propulsion.Cosmos/CosmosSink.fs
+++ b/src/Propulsion.Cosmos/CosmosSink.fs
@@ -163,7 +163,7 @@ module Internal =
                 Scheduling.Dispatcher.MultiDispatcher<_, _, _, _>
                     .Create(itemDispatcher, attemptWrite, interpretWriteResultProgress, stats, dumpStreams)
             Scheduling.StreamSchedulingEngine(
-                dispatcher,
+                dispatcher, maxHolding = 5,
                 ?maxBatches = maxBatches, ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay,
                 enableSlipstreaming = true, prioritizeStreamsBy = Default.eventSize)
 
@@ -176,7 +176,6 @@ type CosmosSink =
             ?statsInterval,
             // Default 5m
             ?stateInterval,
-            ?maxSubmissionsPerPartition,
             ?maxBatches, ?purgeInterval, ?wakeForResults, ?idleDelay,
             // Default: 16384
             ?maxEvents,
@@ -193,7 +192,4 @@ type CosmosSink =
                 log, cosmosContexts, dispatcher, stats, dumpStreams,
                 ?maxBatches = maxBatches, ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay,
                 ?maxEvents=maxEvents, ?maxBytes = maxBytes)
-        Projector.Pipeline.Start(
-            log, dispatcher.Pump, (fun _abend -> streamScheduler.Pump), maxReadAhead, streamScheduler.Submit, statsInterval,
-            ?maxSubmissionsPerPartition = maxSubmissionsPerPartition,
-            ?ingesterStatsInterval = ingesterStatsInterval)
+        Projector.Pipeline.Start(log, dispatcher.Pump, (fun _abend -> streamScheduler.Pump), maxReadAhead, streamScheduler, statsInterval, ?ingesterStatsInterval = ingesterStatsInterval)

--- a/src/Propulsion.Cosmos/CosmosSink.fs
+++ b/src/Propulsion.Cosmos/CosmosSink.fs
@@ -104,8 +104,7 @@ module Internal =
             let inline bads x (set:HashSet<_>) = badCats.Ingest(StreamName.categorize x); adds x set
             base.Handle message
             match message with
-            | Scheduling.InternalMessage.Added _ -> () // Processed by standard logging already; we have nothing to add
-            | Scheduling.InternalMessage.Result (_duration, stream, _progressed, Choice1Of2 ((es, bs), res)) ->
+            | { stream = stream; result = Choice1Of2 ((es, bs), res) } ->
                 adds stream okStreams
                 okEvents <- okEvents + es
                 okBytes <- okBytes + int64 bs
@@ -115,7 +114,7 @@ module Internal =
                 | Writer.Result.PartialDuplicate _ -> resultPartialDup <- resultPartialDup + 1
                 | Writer.Result.PrefixMissing _ -> resultPrefix <- resultPrefix + 1
                 this.HandleOk res
-            | Scheduling.InternalMessage.Result (_duration, stream, _progressed, Choice2Of2 ((es, bs), exn)) ->
+            | { stream = stream; result = Choice2Of2 ((es, bs), exn) } ->
                 adds stream failStreams
                 exnEvents <- exnEvents + es
                 exnBytes <- exnBytes + int64 bs
@@ -163,7 +162,7 @@ module Internal =
                 Scheduling.Dispatcher.MultiDispatcher<_, _, _, _>
                     .Create(itemDispatcher, attemptWrite, interpretWriteResultProgress, stats, dumpStreams)
             Scheduling.StreamSchedulingEngine(
-                dispatcher, maxHolding = 5,
+                dispatcher, maxIngest = 5,
                 ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay,
                 prioritizeStreamsBy = Default.eventSize)
 

--- a/src/Propulsion.CosmosStore/CosmosStorePruner.fs
+++ b/src/Propulsion.CosmosStore/CosmosStorePruner.fs
@@ -55,7 +55,7 @@ module Pruner =
             let inline adds x (set:HashSet<_>) = set.Add x |> ignore
             base.Handle message
             match message with
-            | Scheduling.InternalMessage.Result (_duration, stream, _progressed, Choice2Of2 (_, exn)) ->
+            | { stream = stream; result = Choice2Of2 (_, exn) } ->
                 match classify exn with
                 | ExceptionKind.RateLimited ->
                     adds stream rlStreams; rateLimited <- rateLimited + 1
@@ -107,7 +107,7 @@ module Pruner =
                 Scheduling.Dispatcher.MultiDispatcher<_, _, _, _>
                     .Create(itemDispatcher, handle pruneUntil, interpret, (fun _ -> id), stats, dumpStreams)
             Scheduling.StreamSchedulingEngine(
-                dispatcher, maxHolding = 5,
+                dispatcher, maxIngest = 5,
                 ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay)
 
 /// DANGER: <c>CosmosPruner</c> DELETES events - use with care

--- a/src/Propulsion.CosmosStore/CosmosStorePruner.fs
+++ b/src/Propulsion.CosmosStore/CosmosStorePruner.fs
@@ -108,8 +108,7 @@ module Pruner =
                     .Create(itemDispatcher, handle pruneUntil, interpret, (fun _ -> id), stats, dumpStreams)
             Scheduling.StreamSchedulingEngine(
                 dispatcher, maxHolding = 5,
-                ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay,
-                enableSlipstreaming = false)
+                ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay)
 
 /// DANGER: <c>CosmosPruner</c> DELETES events - use with care
 type CosmosStorePruner =

--- a/src/Propulsion.CosmosStore/CosmosStorePruner.fs
+++ b/src/Propulsion.CosmosStore/CosmosStorePruner.fs
@@ -107,7 +107,7 @@ module Pruner =
                 Scheduling.Dispatcher.MultiDispatcher<_, _, _, _>
                     .Create(itemDispatcher, handle pruneUntil, interpret, (fun _ -> id), stats, dumpStreams)
             Scheduling.StreamSchedulingEngine(
-                dispatcher,
+                dispatcher, maxHolding = 5,
                 ?maxBatches = maxBatches, ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay,
                 enableSlipstreaming = false)
 
@@ -122,7 +122,6 @@ type CosmosStorePruner =
             ?statsInterval,
             // Default 5m
             ?stateInterval,
-            ?maxSubmissionsPerPartition,
             ?maxBatches, ?purgeInterval, ?wakeForResults, ?idleDelay,
             // Defaults to statsInterval
             ?ingesterStatsInterval)
@@ -136,7 +135,4 @@ type CosmosStorePruner =
             Pruner.StreamSchedulingEngine.Create(
                 pruneUntil, dispatcher, stats, dumpStreams,
                 ?maxBatches = maxBatches, ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay)
-        Projector.Pipeline.Start(
-            log, dispatcher.Pump, (fun _abend -> streamScheduler.Pump), maxReadAhead, streamScheduler.Submit, statsInterval,
-            ?maxSubmissionsPerPartition = maxSubmissionsPerPartition,
-            ?ingesterStatsInterval = ingesterStatsInterval)
+        Projector.Pipeline.Start(log, dispatcher.Pump, (fun _abend -> streamScheduler.Pump), maxReadAhead, streamScheduler, statsInterval, ?ingesterStatsInterval = ingesterStatsInterval)

--- a/src/Propulsion.CosmosStore/CosmosStorePruner.fs
+++ b/src/Propulsion.CosmosStore/CosmosStorePruner.fs
@@ -98,7 +98,7 @@ module Pruner =
 
     type StreamSchedulingEngine =
 
-        static member Create(pruneUntil, itemDispatcher, stats : Stats, dumpStreams, ?maxBatches, ?purgeInterval, ?wakeForResults, ?idleDelay)
+        static member Create(pruneUntil, itemDispatcher, stats : Stats, dumpStreams, ?purgeInterval, ?wakeForResults, ?idleDelay)
             : Scheduling.StreamSchedulingEngine<_, _, _, _> =
             let interpret struct (stream, span) =
                 let metrics = StreamSpan.metrics Default.eventSize span
@@ -108,7 +108,7 @@ module Pruner =
                     .Create(itemDispatcher, handle pruneUntil, interpret, (fun _ -> id), stats, dumpStreams)
             Scheduling.StreamSchedulingEngine(
                 dispatcher, maxHolding = 5,
-                ?maxBatches = maxBatches, ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay,
+                ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay,
                 enableSlipstreaming = false)
 
 /// DANGER: <c>CosmosPruner</c> DELETES events - use with care
@@ -122,7 +122,7 @@ type CosmosStorePruner =
             ?statsInterval,
             // Default 5m
             ?stateInterval,
-            ?maxBatches, ?purgeInterval, ?wakeForResults, ?idleDelay,
+            ?purgeInterval, ?wakeForResults, ?idleDelay,
             // Defaults to statsInterval
             ?ingesterStatsInterval)
         : Default.Sink =
@@ -134,5 +134,5 @@ type CosmosStorePruner =
         let streamScheduler =
             Pruner.StreamSchedulingEngine.Create(
                 pruneUntil, dispatcher, stats, dumpStreams,
-                ?maxBatches = maxBatches, ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay)
+                ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay)
         Projector.Pipeline.Start(log, dispatcher.Pump, (fun _abend -> streamScheduler.Pump), maxReadAhead, streamScheduler, statsInterval, ?ingesterStatsInterval = ingesterStatsInterval)

--- a/src/Propulsion.CosmosStore/CosmosStoreSink.fs
+++ b/src/Propulsion.CosmosStore/CosmosStoreSink.fs
@@ -172,7 +172,7 @@ module Internal =
             Scheduling.StreamSchedulingEngine(
                  dispatcher, maxHolding = 5,
                  ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay,
-                 enableSlipstreaming = true, ?prioritizeStreamsBy = prioritizeStreamsBy)
+                 ?prioritizeStreamsBy = prioritizeStreamsBy)
 
 type CosmosStoreSink =
 

--- a/src/Propulsion.CosmosStore/CosmosStoreSink.fs
+++ b/src/Propulsion.CosmosStore/CosmosStoreSink.fs
@@ -147,7 +147,7 @@ module Internal =
 
         static member Create(
                 log : ILogger, eventsContext, itemDispatcher, stats : Stats, dumpStreams,
-                ?maxBatches, ?purgeInterval, ?wakeForResults, ?idleDelay, ?maxEvents, ?maxBytes, ?prioritizeStreamsBy)
+                ?purgeInterval, ?wakeForResults, ?idleDelay, ?maxEvents, ?maxBytes, ?prioritizeStreamsBy)
             : Scheduling.StreamSchedulingEngine<_, _, _, _> =
             let maxEvents, maxBytes = defaultArg maxEvents 16384, defaultArg maxBytes (1024 * 1024 - (*fudge*)4096)
             let writerResultLog = log.ForContext<Writer.Result>()
@@ -171,7 +171,7 @@ module Internal =
             let dispatcher = Scheduling.Dispatcher.MultiDispatcher<_, _, _, _>.Create(itemDispatcher, attemptWrite, interpretWriteResultProgress, stats, dumpStreams)
             Scheduling.StreamSchedulingEngine(
                  dispatcher, maxHolding = 5,
-                 ?maxBatches = maxBatches, ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay,
+                 ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay,
                  enableSlipstreaming = true, ?prioritizeStreamsBy = prioritizeStreamsBy)
 
 type CosmosStoreSink =
@@ -183,7 +183,7 @@ type CosmosStoreSink =
             ?statsInterval,
             // Default 5m
             ?stateInterval,
-            ?maxBatches, ?purgeInterval, ?wakeForResults, ?idleDelay,
+            ?purgeInterval, ?wakeForResults, ?idleDelay,
             // Default: 16384
             ?maxEvents,
             // Default: 1MB (limited by maximum size of a CosmosDB stored procedure invocation)
@@ -197,7 +197,7 @@ type CosmosStoreSink =
         let streamScheduler =
             Internal.StreamSchedulingEngine.Create(
                 log, eventsContext, dispatcher, stats, dumpStreams,
-                ?maxBatches = maxBatches, ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay,
+                ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay,
                 ?maxEvents = maxEvents, ?maxBytes = maxBytes, prioritizeStreamsBy = Default.eventSize)
         Projector.Pipeline.Start(
             log, dispatcher.Pump, (fun _abend -> streamScheduler.Pump), maxReadAhead, streamScheduler, statsInterval,

--- a/src/Propulsion.CosmosStore/CosmosStoreSink.fs
+++ b/src/Propulsion.CosmosStore/CosmosStoreSink.fs
@@ -170,7 +170,7 @@ module Internal =
                 struct (ss.WritePos, res)
             let dispatcher = Scheduling.Dispatcher.MultiDispatcher<_, _, _, _>.Create(itemDispatcher, attemptWrite, interpretWriteResultProgress, stats, dumpStreams)
             Scheduling.StreamSchedulingEngine(
-                 dispatcher,
+                 dispatcher, maxHolding = 5,
                  ?maxBatches = maxBatches, ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay,
                  enableSlipstreaming = true, ?prioritizeStreamsBy = prioritizeStreamsBy)
 
@@ -183,7 +183,6 @@ type CosmosStoreSink =
             ?statsInterval,
             // Default 5m
             ?stateInterval,
-            ?maxSubmissionsPerPartition,
             ?maxBatches, ?purgeInterval, ?wakeForResults, ?idleDelay,
             // Default: 16384
             ?maxEvents,
@@ -201,6 +200,5 @@ type CosmosStoreSink =
                 ?maxBatches = maxBatches, ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay,
                 ?maxEvents = maxEvents, ?maxBytes = maxBytes, prioritizeStreamsBy = Default.eventSize)
         Projector.Pipeline.Start(
-            log, dispatcher.Pump, (fun _abend -> streamScheduler.Pump), maxReadAhead, streamScheduler.Submit, statsInterval,
-            ?maxSubmissionsPerPartition = maxSubmissionsPerPartition,
+            log, dispatcher.Pump, (fun _abend -> streamScheduler.Pump), maxReadAhead, streamScheduler, statsInterval,
             ?ingesterStatsInterval = ingesterStatsInterval)

--- a/src/Propulsion.EventStore/EventStoreSink.fs
+++ b/src/Propulsion.EventStore/EventStoreSink.fs
@@ -141,7 +141,7 @@ module Internal =
                 struct (ss.WritePos, res)
 
             let dispatcher = Scheduling.Dispatcher.MultiDispatcher<_, _, _, _>.Create(itemDispatcher, attemptWrite, interpretWriteResultProgress, stats, dumpStreams)
-            Scheduling.StreamSchedulingEngine(dispatcher, maxHolding = 5, enableSlipstreaming = true, ?idleDelay = idleDelay, ?purgeInterval = purgeInterval)
+            Scheduling.StreamSchedulingEngine(dispatcher, maxHolding = 5, ?idleDelay = idleDelay, ?purgeInterval = purgeInterval)
 
 type EventStoreSink =
 

--- a/src/Propulsion.EventStore/EventStoreSink.fs
+++ b/src/Propulsion.EventStore/EventStoreSink.fs
@@ -114,7 +114,7 @@ module Internal =
         default _.HandleExn(_, _) : unit = ()
 
     type EventStoreSchedulingEngine =
-        static member Create(log : ILogger, storeLog, connections : _ [], itemDispatcher, stats : Stats, dumpStreams, ?maxBatches, ?idleDelay, ?purgeInterval)
+        static member Create(log : ILogger, storeLog, connections : _ [], itemDispatcher, stats : Stats, dumpStreams, ?idleDelay, ?purgeInterval)
             : Scheduling.StreamSchedulingEngine<_, _, _, _> =
             let writerResultLog = log.ForContext<Writer.Result>()
             let mutable robin = 0
@@ -141,7 +141,7 @@ module Internal =
                 struct (ss.WritePos, res)
 
             let dispatcher = Scheduling.Dispatcher.MultiDispatcher<_, _, _, _>.Create(itemDispatcher, attemptWrite, interpretWriteResultProgress, stats, dumpStreams)
-            Scheduling.StreamSchedulingEngine(dispatcher, maxHolding = 5, enableSlipstreaming = true, ?maxBatches = maxBatches, ?idleDelay = idleDelay, ?purgeInterval = purgeInterval)
+            Scheduling.StreamSchedulingEngine(dispatcher, maxHolding = 5, enableSlipstreaming = true, ?idleDelay = idleDelay, ?purgeInterval = purgeInterval)
 
 type EventStoreSink =
 

--- a/src/Propulsion.Feed/FeedSource.fs
+++ b/src/Propulsion.Feed/FeedSource.fs
@@ -92,7 +92,7 @@ type FeedSourceBase internal
             Async.Start(supervise pump, cancellationToken = ct)
 
             try return! outcomeTask
-            finally log.Information "... source stopped" }
+            finally log.Information "... source completed" }
 
         let monitor = lazy FeedMonitor(log, positions, sink, fun () -> Task.isCompleted outcomeTask)
         new SourcePipeline<_>(Task.run supervise, stop, monitor)

--- a/src/Propulsion.Kafka/Consumers.fs
+++ b/src/Propulsion.Kafka/Consumers.fs
@@ -191,7 +191,7 @@ module Core =
                 logStreamStates Default.eventSize
             let streamsScheduler =
                 Scheduling.StreamSchedulingEngine.Create<_, _, _, _>(
-                    dispatcher, stats, prepare, handle, SpanResult.toIndex, dumpStreams,
+                    dispatcher, stats, prepare, handle, SpanResult.toIndex, dumpStreams, maxIngest = 5,
                     ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay)
             let mapConsumedMessagesToStreamsBatch onCompletion (x : Submission.Batch<TopicPartition, 'Info>) : struct (_ * Buffer.Batch) =
                 let onCompletion () = x.onCompletion(); onCompletion()
@@ -425,8 +425,7 @@ type BatchesConsumer =
                         ae, x.stream, false, Choice2Of2 struct (metrics, e) |] }
         let dispatcher = Scheduling.Dispatcher.BatchedDispatcher(select, handle, stats, dumpStreams)
         let streamsScheduler = Scheduling.StreamSchedulingEngine.Create(
-            dispatcher,
-            ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay)
+            dispatcher, maxIngest = 5, ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay)
         let mapConsumedMessagesToStreamsBatch onCompletion (x : Submission.Batch<TopicPartition, 'Info>) =
             let onCompletion () = x.onCompletion(); onCompletion()
             Buffer.Batch.Create(onCompletion, Seq.collect infoToStreamEvents x.messages)

--- a/src/Propulsion.Kafka/ProducerSinks.fs
+++ b/src/Propulsion.Kafka/ProducerSinks.fs
@@ -31,8 +31,6 @@ type StreamsProducerSink =
             ?maxBytes,
             // Default 16384
             ?maxEvents,
-            // Max scheduling readahead. Default 128.
-            ?maxBatches,
             // Max inner cycles per loop. Default 128.
             ?maxCycles)
         : Default.Sink =
@@ -52,7 +50,7 @@ type StreamsProducerSink =
                 (    log, maxReadAhead, maxConcurrentStreams, handle,
                      stats, statsInterval, Default.jsonSize, Default.eventSize,
                      maxBytes = maxBytes, ?idleDelay = idleDelay,?purgeInterval = purgeInterval,
-                     ?maxEvents=maxEvents, ?maxBatches = maxBatches, ?maxCycles = maxCycles, dumpExternalStats = producer.DumpStats)
+                     ?maxEvents=maxEvents, ?maxCycles = maxCycles, dumpExternalStats = producer.DumpStats)
 
    static member Start
         (   log : ILogger, maxReadAhead, maxConcurrentStreams,
@@ -68,8 +66,6 @@ type StreamsProducerSink =
             ?maxBytes,
             // Default 16384
             ?maxEvents,
-            // Max scheduling readahead. Default 128.
-            ?maxBatches,
             // Max inner cycles per loop. Default 128.
             ?maxCycles)
         : Default.Sink =
@@ -81,4 +77,4 @@ type StreamsProducerSink =
                 (    log, maxReadAhead, maxConcurrentStreams, prepare, producer,
                      stats, statsInterval,
                      ?idleDelay = idleDelay, ?purgeInterval = purgeInterval, ?maxBytes = maxBytes,
-                     ?maxEvents = maxEvents, ?maxBatches = maxBatches, ?maxCycles = maxCycles)
+                     ?maxEvents = maxEvents, ?maxCycles = maxCycles)

--- a/src/Propulsion.Kafka/ProducerSinks.fs
+++ b/src/Propulsion.Kafka/ProducerSinks.fs
@@ -30,9 +30,7 @@ type StreamsProducerSink =
             // Default 1 MiB
             ?maxBytes,
             // Default 16384
-            ?maxEvents,
-            // Max inner cycles per loop. Default 128.
-            ?maxCycles)
+            ?maxEvents)
         : Default.Sink =
             let maxBytes = defaultArg maxBytes (1024*1024 - (*fudge*)4096)
             let handle struct (stream : StreamName, span) = async {
@@ -50,7 +48,7 @@ type StreamsProducerSink =
                 (    log, maxReadAhead, maxConcurrentStreams, handle,
                      stats, statsInterval, Default.jsonSize, Default.eventSize,
                      maxBytes = maxBytes, ?idleDelay = idleDelay,?purgeInterval = purgeInterval,
-                     ?maxEvents=maxEvents, ?maxCycles = maxCycles, dumpExternalStats = producer.DumpStats)
+                     ?maxEvents = maxEvents, dumpExternalStats = producer.DumpStats)
 
    static member Start
         (   log : ILogger, maxReadAhead, maxConcurrentStreams,
@@ -65,9 +63,7 @@ type StreamsProducerSink =
             // Default 1 MiB
             ?maxBytes,
             // Default 16384
-            ?maxEvents,
-            // Max inner cycles per loop. Default 128.
-            ?maxCycles)
+            ?maxEvents)
         : Default.Sink =
             let prepare struct (stream, span) = async {
                 let! kv = prepare (stream, span)
@@ -77,4 +73,4 @@ type StreamsProducerSink =
                 (    log, maxReadAhead, maxConcurrentStreams, prepare, producer,
                      stats, statsInterval,
                      ?idleDelay = idleDelay, ?purgeInterval = purgeInterval, ?maxBytes = maxBytes,
-                     ?maxEvents = maxEvents, ?maxCycles = maxCycles)
+                     ?maxEvents = maxEvents)

--- a/src/Propulsion.MemoryStore/MemoryStoreSource.fs
+++ b/src/Propulsion.MemoryStore/MemoryStoreSource.fs
@@ -58,7 +58,7 @@ type MemoryStoreSource<'F>(log, store : Equinox.MemoryStore.VolatileStore<'F>, c
             (fun () -> tcs.TrySetResult () |> ignore),
             fun () -> task {
                 try return! tcs.Task // aka base.AwaitShutdown()
-                finally log.Information "... source stopped" }
+                finally log.Information "... source completed" }
 
         let supervise () = task {
             // external cancellation (via Stop()) should yield a success result

--- a/src/Propulsion.MessageDb/MessageDbSource.fs
+++ b/src/Propulsion.MessageDb/MessageDbSource.fs
@@ -1,11 +1,8 @@
 namespace Propulsion.MessageDb
 
-open FsCodec
 open FSharp.Control
-open NpgsqlTypes
 open Propulsion.Internal
 open System
-open System.Data.Common
 
 module internal Npgsql =
 
@@ -16,10 +13,14 @@ module internal Npgsql =
 
 module Internal =
 
+    open NpgsqlTypes
     open Propulsion.Feed
+    open Propulsion.Infrastructure // AwaitTaskCorrect
+    open System.Data.Common
     open System.Threading.Tasks
     open System.Text.Json
-    open Propulsion.Infrastructure // AwaitTaskCorrect
+
+    type Batch<'F> = Propulsion.Feed.Core.Batch<'F>
 
     module private Json =
         let private jsonNull = ReadOnlyMemory(JsonSerializer.SerializeToUtf8Bytes(null))
@@ -32,20 +33,20 @@ module Internal =
         let connect = Npgsql.connect connectionString
         let parseRow (reader: DbDataReader) =
             let readNullableString idx = if reader.IsDBNull(idx) then None else Some (reader.GetString idx)
-            let streamName = reader.GetString(8)
+            let sn = reader.GetString(8) |> FsCodec.StreamName.parse
+            let readUtf8String idx = ReadOnlyMemory(Text.Encoding.UTF8.GetBytes(reader.GetString idx))
+            let c, d, m = reader.GetString(1), readUtf8String 2, readUtf8String 3
+            let sz = d.Length + m.Length + c.Length
             let event = FsCodec.Core.TimelineEvent.Create(
-                index = reader.GetInt64(0),
-                eventType = reader.GetString(1),
-                data = (reader |> Json.fromReader 2),
-                meta = (reader |> Json.fromReader 3),
-                eventId = reader.GetGuid(4),
-                ?correlationId = readNullableString 5,
-                ?causationId = readNullableString 6,
-                context = reader.GetInt64(9),
-                timestamp = DateTimeOffset(DateTime.SpecifyKind(reader.GetDateTime(7), DateTimeKind.Utc)))
-            struct(StreamName.parse streamName, event)
+                index = reader.GetInt64(0), // index within the stream, 0 based
+                eventType = c, data = d, meta = m, eventId = reader.GetGuid(4),
+                ?correlationId = readNullableString 5, ?causationId = readNullableString 6,
+                context = reader.GetInt64(9), // global_position is passed through the Context for checkpointing purposes
+                timestamp = DateTimeOffset(DateTime.SpecifyKind(reader.GetDateTime(7), DateTimeKind.Utc)),
+                size = sz) // precomputed Size is required for stats purposes when fed to a StreamsSink
+            struct (sn, event)
 
-        member _.ReadCategoryMessages(category: TrancheId, fromPositionInclusive: int64, batchSize: int, ct) : Task<Propulsion.Feed.Core.Batch<_>> = task {
+        member _.ReadCategoryMessages(category: TrancheId, fromPositionInclusive: int64, batchSize: int, ct) : Task<Batch<_>> = task {
             use! conn = connect ct
             let command = conn.CreateCommand(CommandText = "select position, type, data, metadata, id::uuid,
                                                                    (metadata::jsonb->>'$correlationId')::text,
@@ -56,14 +57,11 @@ module Internal =
             command.Parameters.AddWithValue("Position", NpgsqlDbType.Bigint, fromPositionInclusive) |> ignore
             command.Parameters.AddWithValue("BatchSize", NpgsqlDbType.Bigint, int64 batchSize) |> ignore
 
-            let mutable checkpoint = fromPositionInclusive
-
             use! reader = command.ExecuteReaderAsync(ct)
             let events = [| while reader.Read() do parseRow reader |]
 
-            checkpoint <- match Array.tryLast events with Some (_, ev) -> unbox<int64> ev.Context | None -> checkpoint
-
-            return ({ checkpoint = Position.parse checkpoint; items = events; isTail = events.Length = 0 } : Propulsion.Feed.Core.Batch<_>) }
+            let checkpoint = match Array.tryLast events with Some (_, ev) -> unbox<int64> ev.Context | None -> fromPositionInclusive
+            return ({ checkpoint = Position.parse checkpoint; items = events; isTail = events.Length = 0 } : Batch<_>) }
 
         member _.ReadCategoryLastVersion(category: TrancheId, ct) : Task<int64> = task {
             use! conn = connect ct
@@ -73,12 +71,12 @@ module Internal =
             use! reader = command.ExecuteReaderAsync(ct)
             return if reader.Read() then reader.GetInt64(0) else 0L }
 
-    let internal readBatch batchSize (store : MessageDbCategoryClient) (category, pos) : Async<Propulsion.Feed.Core.Batch<_>> = async {
+    let internal readBatch batchSize (store : MessageDbCategoryClient) (category, pos) : Async<Batch<_>> = async {
         let! ct = Async.CancellationToken
         let positionInclusive = Position.toInt64 pos
         return! store.ReadCategoryMessages(category, positionInclusive, batchSize, ct) |> Async.AwaitTaskCorrect }
 
-    let internal readTailPositionForTranche (store : MessageDbCategoryClient) trancheId : Async<Propulsion.Feed.Position> = async {
+    let internal readTailPositionForTranche (store : MessageDbCategoryClient) trancheId : Async<Position> = async {
         let! ct = Async.CancellationToken
         let! lastEventPos = store.ReadCategoryLastVersion(trancheId, ct) |> Async.AwaitTaskCorrect
         return Position.parse lastEventPos }

--- a/src/Propulsion/Internal.fs
+++ b/src/Propulsion/Internal.fs
@@ -77,7 +77,7 @@ module Channel =
             worked <- true
             f msg
         worked
-    let inline readAll (r : ChannelReader<_>) = seq {
+    let inline readAll (r : ChannelReader<_>) () = seq {
         let mutable msg = Unchecked.defaultof<_>
         while r.TryRead(&msg) do
             yield msg }

--- a/src/Propulsion/Internal.fs
+++ b/src/Propulsion/Internal.fs
@@ -53,7 +53,7 @@ type IntervalTimer(period : TimeSpan) =
         // The processing loops run on 1s timers, so we busy-wait until they wake
         let timeout = IntervalTimer(defaultArg timeout (TimeSpan.FromSeconds 2))
         while x.IsTriggered && not timeout.IsDue do
-            System.Threading.Thread.Sleep (defaultArg sleepMs 1)
+            System.Threading.Thread.Sleep(defaultArg sleepMs 1)
 
 module Channel =
 

--- a/src/Propulsion/Internal.fs
+++ b/src/Propulsion/Internal.fs
@@ -62,6 +62,9 @@ module Channel =
     let unboundedSr<'t> = Channel.CreateUnbounded<'t>(UnboundedChannelOptions(SingleReader = true))
     let unboundedSw<'t> = Channel.CreateUnbounded<'t>(UnboundedChannelOptions(SingleWriter = true))
     let unboundedSwSr<'t> = Channel.CreateUnbounded<'t>(UnboundedChannelOptions(SingleWriter = true, SingleReader = true))
+    let boundedSw<'t> c = Channel.CreateBounded<'t>(BoundedChannelOptions(c, SingleWriter = true))
+    let waitToWrite (w : ChannelWriter<_>)= w.WaitToWriteAsync
+    let tryWrite (w : ChannelWriter<_>) = w.TryWrite
     let write (w : ChannelWriter<_>) = w.TryWrite >> ignore
     let inline awaitRead (r : ChannelReader<_>) ct = let vt = r.WaitToReadAsync(ct) in vt.AsTask()
     let inline tryRead (r : ChannelReader<_>) () =

--- a/src/Propulsion/Internal.fs
+++ b/src/Propulsion/Internal.fs
@@ -77,6 +77,10 @@ module Channel =
             worked <- true
             f msg
         worked
+    let inline readAll (r : ChannelReader<_>) = seq {
+        let mutable msg = Unchecked.defaultof<_>
+        while r.TryRead(&msg) do
+            yield msg }
 
 open System.Threading
 open System.Threading.Tasks

--- a/src/Propulsion/Streams.fs
+++ b/src/Propulsion/Streams.fs
@@ -339,8 +339,9 @@ module Scheduling =
                     yield { writePos = ss.WritePos; stream = s; span = ss.HeadSpan }
                 | _ -> ()
             if trySlipstreamed then
-                // [lazily] slipstream in further events that are not yet referenced by in-scope batches
+                // [lazily] slipstream in further streams that are not yet referenced by in-scope batches
                 for KeyValue(s, ss) in states do
+                    // We don't exclude gapped streams - the write function is expected to efficiently reject those
                     if ss.HasValid && not (busy.Contains s) && proposed.Add s then
                         yield { writePos = ss.WritePos; stream = s; span = ss.HeadSpan } }
         let markBusy stream = busy.Add stream |> ignore

--- a/tests/Propulsion.Kafka.Integration/ConsumersIntegration.fs
+++ b/tests/Propulsion.Kafka.Integration/ConsumersIntegration.fs
@@ -173,8 +173,7 @@ module Helpers =
             let consumer =
                  StreamsConsumer.Start<unit>
                     (   log, config, messageIndexes.ConsumeResultToStreamEvent(mapStreamConsumeResultToDataAndContext),
-                        handle, 256, stats, TimeSpan.FromSeconds 10.,
-                        maxBatches=50)
+                        handle, 256, stats, TimeSpan.FromSeconds 10)
 
             consumerCell := Some consumer
 

--- a/tests/Propulsion.Tests/ProgressTests.fs
+++ b/tests/Propulsion.Tests/ProgressTests.fs
@@ -10,21 +10,21 @@ let sn x = StreamName.create x x
 let mkDictionary xs = Dictionary<StreamName,int64>(dict xs)
 
 let [<Fact>] ``Empty has zero streams pending or progress to write`` () =
-    let sut = ProgressState<_>()
-    let queue = sut.InScheduledOrder(None)
+    let sut = StreamsPrioritizer(None)
+    let queue = sut.CollectStreams(Seq.empty)
     test <@ Seq.isEmpty queue @>
 
 let [<Fact>] ``Can add multiple batches with overlapping streams`` () =
     let sut = ProgressState<_>()
     let noBatchesComplete () = failwith "No bathes should complete"
-    sut.AppendBatch(noBatchesComplete, mkDictionary [sn "a",1L; sn "b",2L])
-    sut.AppendBatch(noBatchesComplete, mkDictionary [sn "b",2L; sn "c",3L])
+    sut.AppendBatch(noBatchesComplete, mkDictionary [sn "a",1L; sn "b",2L]) |> ignore
+    sut.AppendBatch(noBatchesComplete, mkDictionary [sn "b",2L; sn "c",3L]) |> ignore
 
 let [<Fact>] ``Marking Progress removes batches and triggers the callbacks`` () =
     let sut = ProgressState<_>()
     let mutable callbacks = 0
     let complete () = callbacks <- callbacks + 1
-    sut.AppendBatch(complete, mkDictionary [sn "a",1L; sn "b",2L])
+    sut.AppendBatch(complete, mkDictionary [sn "a",1L; sn "b",2L]) |> ignore
     sut.MarkStreamProgress(sn "a",1L)
     sut.MarkStreamProgress(sn "b",3L)
     1 =! callbacks
@@ -33,17 +33,17 @@ let [<Fact>] ``Empty batches get removed immediately`` () =
     let sut = ProgressState<_>()
     let mutable callbacks = 0
     let complete () = callbacks <- callbacks + 1
-    sut.AppendBatch(complete, mkDictionary [||])
-    sut.AppendBatch(complete, mkDictionary [||])
+    sut.AppendBatch(complete, mkDictionary [||]) |> ignore
+    sut.AppendBatch(complete, mkDictionary [||]) |> ignore
     2 =! callbacks
 
 let [<Fact>] ``Marking progress is not persistent`` () =
     let sut = ProgressState<_>()
     let mutable callbacks = 0
     let complete () = callbacks <- callbacks + 1
-    sut.AppendBatch(complete, mkDictionary [sn "a",1L])
+    sut.AppendBatch(complete, mkDictionary [sn "a",1L]) |> ignore
     sut.MarkStreamProgress(sn "a",2L)
-    sut.AppendBatch(complete, mkDictionary [sn "a",1L; sn "b",2L])
+    sut.AppendBatch(complete, mkDictionary [sn "a",1L; sn "b",2L]) |> ignore
     1 =! callbacks
 
 // TODO: lots more coverage of newer functionality - the above were written very early into the exercise

--- a/tests/Propulsion.Tests/ProgressTests.fs
+++ b/tests/Propulsion.Tests/ProgressTests.fs
@@ -20,7 +20,7 @@ let [<Fact>] ``Can add multiple batches with overlapping streams`` () =
     sut.AppendBatch(noBatchesComplete, mkDictionary [sn "a",1L; sn "b",2L]) |> ignore
     sut.AppendBatch(noBatchesComplete, mkDictionary [sn "b",2L; sn "c",3L]) |> ignore
 
-let [<Fact>] ``Marking Progress removes batches and triggers the callbacks`` () =
+let [<Fact>] ``Marking Progress removes streams from batches; EnumPending triggers the callbacks`` () =
     let sut = ProgressState<_>()
     let mutable callbacks = 0
     let complete () = callbacks <- callbacks + 1
@@ -36,7 +36,6 @@ let [<Fact>] ``Empty batches get removed immediately`` () =
     let complete () = callbacks <- callbacks + 1
     sut.AppendBatch(complete, mkDictionary [||]) |> ignore
     sut.AppendBatch(complete, mkDictionary [||]) |> ignore
-    sut.EnumPending() |> ignore
     2 =! callbacks
 
 let [<Fact>] ``Marking progress is not persistent`` () =
@@ -46,7 +45,6 @@ let [<Fact>] ``Marking progress is not persistent`` () =
     sut.AppendBatch(complete, mkDictionary [sn "a",1L]) |> ignore
     sut.MarkStreamProgress(sn "a",2L)
     sut.AppendBatch(complete, mkDictionary [sn "a",1L; sn "b",2L]) |> ignore
-    sut.EnumPending() |> ignore
     1 =! callbacks
 
 // TODO: lots more coverage of newer functionality - the above were written very early into the exercise

--- a/tests/Propulsion.Tests/ProgressTests.fs
+++ b/tests/Propulsion.Tests/ProgressTests.fs
@@ -27,6 +27,7 @@ let [<Fact>] ``Marking Progress removes batches and triggers the callbacks`` () 
     sut.AppendBatch(complete, mkDictionary [sn "a",1L; sn "b",2L]) |> ignore
     sut.MarkStreamProgress(sn "a",1L)
     sut.MarkStreamProgress(sn "b",3L)
+    sut.EnumPending() |> ignore
     1 =! callbacks
 
 let [<Fact>] ``Empty batches get removed immediately`` () =
@@ -35,6 +36,7 @@ let [<Fact>] ``Empty batches get removed immediately`` () =
     let complete () = callbacks <- callbacks + 1
     sut.AppendBatch(complete, mkDictionary [||]) |> ignore
     sut.AppendBatch(complete, mkDictionary [||]) |> ignore
+    sut.EnumPending() |> ignore
     2 =! callbacks
 
 let [<Fact>] ``Marking progress is not persistent`` () =
@@ -44,6 +46,7 @@ let [<Fact>] ``Marking progress is not persistent`` () =
     sut.AppendBatch(complete, mkDictionary [sn "a",1L]) |> ignore
     sut.MarkStreamProgress(sn "a",2L)
     sut.AppendBatch(complete, mkDictionary [sn "a",1L; sn "b",2L]) |> ignore
+    sut.EnumPending() |> ignore
     1 =! callbacks
 
 // TODO: lots more coverage of newer functionality - the above were written very early into the exercise

--- a/tests/Propulsion.Tests/SourceTests.fs
+++ b/tests/Propulsion.Tests/SourceTests.fs
@@ -26,13 +26,14 @@ type Scenario(testOutput) =
 
     [<Fact>]
     let ``TailingFeedSource Stop / AwaitCompletion semantics`` () = async {
-        let crawl _  = AsyncSeq.singleton <| struct (TimeSpan.FromSeconds 0.1, ({ items = Array.empty; isTail = false; checkpoint = Unchecked.defaultof<_> } : Core.Batch<_>))
+        let crawl _  = AsyncSeq.singleton <| struct (TimeSpan.FromSeconds 0.1, ({ items = Array.empty; isTail = true; checkpoint = Unchecked.defaultof<_> } : Core.Batch<_>))
         let source = Propulsion.Feed.Core.TailingFeedSource(log, TimeSpan.FromMinutes 1, SourceId.parse "sid", TimeSpan.FromMinutes 1,
                                                             checkpoints, (*establishOrigin*)None, sink, crawl, string)
         use src = source.Start(source.Pump(fun _ -> async { return [| TrancheId.parse "tid" |] }))
-        Task.Delay(TimeSpan.FromSeconds 0.5).ContinueWith(fun _ -> src.Stop()) |> ignore
         // Yields sink exception, if any
-        do! src.Monitor.AwaitCompletion(propagationDelay = TimeSpan.FromSeconds 0.5, awaitFullyCaughtUp = true)
+        do! src.Monitor.AwaitCompletion(propagationDelay = TimeSpan.FromSeconds 1, awaitFullyCaughtUp = true)
+        // source runs until someone explicitly stops it, or it throws
+        src.Stop()
         // Yields source exception, if any
         do! src.AwaitShutdown()
         test <@ src.RanToCompletion @>
@@ -46,6 +47,8 @@ type Scenario(testOutput) =
         use src = source.Start(fun () -> async { return [| TrancheId.parse "tid" |] })
         // Yields sink exception, if any
         do! src.Monitor.AwaitCompletion(propagationDelay = TimeSpan.FromSeconds 1, awaitFullyCaughtUp = true)
+        // NB it does not presently stop itself until requested, even though it is a single PassFeedSource
+        src.Stop()
         // Yields source exception, if any
         do! src.AwaitShutdown()
         test <@ src.RanToCompletion @>


### PR DESCRIPTION
- [x] Fix bug causing malformed or gapped streams with all events of `Size = 0` to not be classified correctly in State logging
- DynamoStore already correctly implements the ITimelineEvent.Size
- Skipping CosmosStore for now
- [x] Implemented Size calculations for MessageDb, SqlStreamStore
- [x] implemented for EventStoreDb as a separate commit in Equinox.EventStoreDb https://github.com/jet/equinox/pull/357
- [x] Replaced `Batches Holding {waiting}` with `Batches pending  {waiting} active {active}` in Scheduler stats
- [x] Simplification of Submitter, removing Semaphores and `maxSubmissionsPerPartition` (replaced with round robin submission)
- [x] simplification of Scheduler, removing cycles and slipstreaming
- [x] Add restricted mode that prevents skipping gaps
- [x] Polish shutdown logging for Sources and Sinks
- [x] Fixed/polished/completed `SinglePassFeedSource`