### PR TITLE
Scheduler: Simplification & fixes

### DIFF
--- a/src/Propulsion.Cosmos/ChangeFeedProcessor.fs
+++ b/src/Propulsion.Cosmos/ChangeFeedProcessor.fs
@@ -5,6 +5,7 @@ open Microsoft.Azure.Documents
 open Microsoft.Azure.Documents.Client
 open Microsoft.Azure.Documents.ChangeFeedProcessor
 open Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing
+open Propulsion.Internal
 open Propulsion.Infrastructure // AwaitTaskCorrect
 open Serilog
 open System
@@ -63,7 +64,7 @@ type ChangeFeedObserver =
             | None -> log.Information("Reader {partition} Revoked {reason}", ctx.PartitionKeyRangeId, reason) }
         { new IChangeFeedObserver with
             member _.OpenAsync ctx = Async.StartAsTask(_open ctx) :> _
-            member _.ProcessChangesAsync(ctx, docs, ct) = Async.StartAsTask(_process(ctx, docs), cancellationToken=ct) :> _
+            member _.ProcessChangesAsync(ctx, docs, ct) = _process(ctx, docs) |> Async.startImmediateAsTask ct :> _
             member _.CloseAsync (ctx, reason) = Async.StartAsTask(_close (ctx, reason)) :> _
           interface IDisposable with
             member _.Dispose() =

--- a/src/Propulsion.Cosmos/CosmosPruner.fs
+++ b/src/Propulsion.Cosmos/CosmosPruner.fs
@@ -94,20 +94,7 @@ module Pruner =
         let res = if deleted = 0 && deferred = 0 then Nop span.Length else Ok (deleted, deferred)
         // For case where we discover events have already been deleted beyond our requested position, signal to reader to drop events
         let writePos = max trimmedPos (untilIndex + 1L)
-        return struct (writePos, res)
-    }
-
-    type StreamSchedulingEngine =
-
-        static member Create(pruneUntil, maxDop, stats : Stats, dumpStreams, ?purgeInterval, ?wakeForResults, ?idleDelay)
-            : Scheduling.Engine<_, _, _, _> =
-            let interpret struct (stream, span) =
-                let metrics = StreamSpan.metrics Default.eventSize span
-                struct (metrics, struct (stream, span))
-            let dispatcher = Dispatcher.Concurrent<_, _, _, _>.Create(maxDop, interpret, handle pruneUntil, (fun _ -> id))
-            Scheduling.Engine(
-                dispatcher, stats, dumpStreams, maxIngest = 5,
-                ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay)
+        return struct (writePos, res) }
 
 /// DANGER: <c>CosmosPruner</c> DELETES events - use with care
 type CosmosPruner =
@@ -124,12 +111,15 @@ type CosmosPruner =
             // Defaults to statsInterval
             ?ingesterStatsInterval)
         : Default.Sink =
+        let dispatcher =
+            let pruneUntil stream index = Equinox.Cosmos.Core.Events.pruneUntil context stream index
+            let interpret struct (stream, span) =
+                let metrics = StreamSpan.metrics Default.eventSize span
+                struct (metrics, struct (stream, span))
+            Dispatcher.Concurrent<_, _, _, _>.Create(maxConcurrentStreams, interpret, Pruner.handle pruneUntil, (fun _ -> id))
         let statsInterval, stateInterval = defaultArg statsInterval (TimeSpan.FromMinutes 5.), defaultArg stateInterval (TimeSpan.FromMinutes 5.)
         let stats = Pruner.Stats(log.ForContext<Pruner.Stats>(), statsInterval, stateInterval)
         let dumpStreams logStreamStates _log = logStreamStates Default.eventSize
-        let pruneUntil stream index = Equinox.Cosmos.Core.Events.pruneUntil context stream index
-        let streamScheduler =
-            Pruner.StreamSchedulingEngine.Create(
-                pruneUntil, maxConcurrentStreams, stats, dumpStreams,
-                ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay)
-        Projector.Pipeline.Start(log, streamScheduler.Pump, maxReadAhead, streamScheduler, statsInterval, ?ingesterStatsInterval = ingesterStatsInterval)
+        let scheduler = Scheduling.Engine(dispatcher, stats, dumpStreams, maxIngest = 5,
+                                          ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay)
+        Projector.Pipeline.Start(log, scheduler.Pump, maxReadAhead, scheduler, ingesterStatsInterval = defaultArg ingesterStatsInterval statsInterval)

--- a/src/Propulsion.Cosmos/CosmosPruner.fs
+++ b/src/Propulsion.Cosmos/CosmosPruner.fs
@@ -99,13 +99,13 @@ module Pruner =
 
     type StreamSchedulingEngine =
 
-        static member Create(pruneUntil, itemDispatcher, stats : Stats, dumpStreams, ?purgeInterval, ?wakeForResults, ?idleDelay)
-            : Scheduling.StreamSchedulingEngine<_, _, _, _> =
+        static member Create(pruneUntil, maxDop, stats : Stats, dumpStreams, ?purgeInterval, ?wakeForResults, ?idleDelay)
+            : Scheduling.Engine<_, _, _, _> =
             let interpret struct (stream, span) =
                 let metrics = StreamSpan.metrics Default.eventSize span
                 struct (metrics, struct (stream, span))
-            let dispatcher = Scheduling.Dispatcher.MultiDispatcher<_, _, _, _>.Create(itemDispatcher, handle pruneUntil, interpret, (fun _ -> id))
-            Scheduling.StreamSchedulingEngine(
+            let dispatcher = Dispatcher.Concurrent<_, _, _, _>.Create(maxDop, interpret, handle pruneUntil, (fun _ -> id))
+            Scheduling.Engine(
                 dispatcher, stats, dumpStreams, maxIngest = 5,
                 ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay)
 
@@ -126,11 +126,10 @@ type CosmosPruner =
         : Default.Sink =
         let statsInterval, stateInterval = defaultArg statsInterval (TimeSpan.FromMinutes 5.), defaultArg stateInterval (TimeSpan.FromMinutes 5.)
         let stats = Pruner.Stats(log.ForContext<Pruner.Stats>(), statsInterval, stateInterval)
-        let dispatcher = Dispatch.ItemDispatcher<_, _>(maxConcurrentStreams)
         let dumpStreams logStreamStates _log = logStreamStates Default.eventSize
         let pruneUntil stream index = Equinox.Cosmos.Core.Events.pruneUntil context stream index
         let streamScheduler =
             Pruner.StreamSchedulingEngine.Create(
-                pruneUntil, dispatcher, stats, dumpStreams,
+                pruneUntil, maxConcurrentStreams, stats, dumpStreams,
                 ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay)
-        Projector.Pipeline.Start(log, dispatcher.Pump, (fun _abend -> streamScheduler.Pump), maxReadAhead, streamScheduler, statsInterval, ?ingesterStatsInterval = ingesterStatsInterval)
+        Projector.Pipeline.Start(log, streamScheduler.Pump, maxReadAhead, streamScheduler, statsInterval, ?ingesterStatsInterval = ingesterStatsInterval)

--- a/src/Propulsion.Cosmos/CosmosPruner.fs
+++ b/src/Propulsion.Cosmos/CosmosPruner.fs
@@ -104,9 +104,9 @@ module Pruner =
             let interpret struct (stream, span) =
                 let metrics = StreamSpan.metrics Default.eventSize span
                 struct (metrics, struct (stream, span))
-            let dispatcher = Scheduling.Dispatcher.MultiDispatcher<_, _, _, _>.Create(itemDispatcher, handle pruneUntil, interpret, (fun _ -> id), stats, dumpStreams)
+            let dispatcher = Scheduling.Dispatcher.MultiDispatcher<_, _, _, _>.Create(itemDispatcher, handle pruneUntil, interpret, (fun _ -> id))
             Scheduling.StreamSchedulingEngine(
-                dispatcher, maxIngest = 5,
+                dispatcher, stats, dumpStreams, maxIngest = 5,
                 ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay)
 
 /// DANGER: <c>CosmosPruner</c> DELETES events - use with care

--- a/src/Propulsion.Cosmos/CosmosSink.fs
+++ b/src/Propulsion.Cosmos/CosmosSink.fs
@@ -140,7 +140,7 @@ module Internal =
                 let index = Interlocked.Increment(&robin) % cosmosContexts.Length
                 let selectedConnection = cosmosContexts[index]
                 let struct (met, span') = StreamSpan.slice Default.jsonSize (maxEvents, maxBytes) span
-                try let! res = Writer.write log selectedConnection (StreamName.toString stream) span' |> fun f -> Async.StartAsTask(f, cancellationToken = ct)
+                try let! res = Writer.write log selectedConnection (StreamName.toString stream) span' |> Async.startImmediateAsTask ct
                     return struct (span'.Length > 0, Choice1Of2 struct (met, res))
                 with e -> return false, Choice2Of2 struct (met, e) }
             let interpretWriteResultProgress (streams: Scheduling.StreamStates<_>) stream res =

--- a/src/Propulsion.Cosmos/CosmosSink.fs
+++ b/src/Propulsion.Cosmos/CosmosSink.fs
@@ -158,11 +158,9 @@ module Internal =
                 let struct (ss, malformed) = applyResultToStreamState res
                 Writer.logTo writerResultLog malformed (stream, res)
                 struct (ss.WritePos, res)
-            let dispatcher =
-                Scheduling.Dispatcher.MultiDispatcher<_, _, _, _>
-                    .Create(itemDispatcher, attemptWrite, interpretWriteResultProgress, stats, dumpStreams)
+            let dispatcher = Scheduling.Dispatcher.MultiDispatcher<_, _, _, _>.Create(itemDispatcher, attemptWrite, interpretWriteResultProgress)
             Scheduling.StreamSchedulingEngine(
-                dispatcher, maxIngest = 5,
+                dispatcher, stats, dumpStreams, maxIngest = 5,
                 ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay,
                 prioritizeStreamsBy = Default.eventSize)
 

--- a/src/Propulsion.CosmosStore/CosmosStorePruner.fs
+++ b/src/Propulsion.CosmosStore/CosmosStorePruner.fs
@@ -103,11 +103,9 @@ module Pruner =
             let interpret struct (stream, span) =
                 let metrics = StreamSpan.metrics Default.eventSize span
                 struct (metrics, struct (stream, span))
-            let dispatcher =
-                Scheduling.Dispatcher.MultiDispatcher<_, _, _, _>
-                    .Create(itemDispatcher, handle pruneUntil, interpret, (fun _ -> id), stats, dumpStreams)
+            let dispatcher = Scheduling.Dispatcher.MultiDispatcher<_, _, _, _>.Create(itemDispatcher, handle pruneUntil, interpret, (fun _ -> id))
             Scheduling.StreamSchedulingEngine(
-                dispatcher, maxIngest = 5,
+                dispatcher, stats, dumpStreams, maxIngest = 5,
                 ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay)
 
 /// DANGER: <c>CosmosPruner</c> DELETES events - use with care

--- a/src/Propulsion.CosmosStore/CosmosStoreSink.fs
+++ b/src/Propulsion.CosmosStore/CosmosStoreSink.fs
@@ -167,9 +167,9 @@ module Internal =
                 let struct (ss, malformed) = applyResultToStreamState res
                 Writer.logTo writerResultLog malformed (stream, res)
                 struct (ss.WritePos, res)
-            let dispatcher = Scheduling.Dispatcher.MultiDispatcher<_, _, _, _>.Create(itemDispatcher, attemptWrite, interpretWriteResultProgress, stats, dumpStreams)
+            let dispatcher = Scheduling.Dispatcher.MultiDispatcher<_, _, _, _>.Create(itemDispatcher, attemptWrite, interpretWriteResultProgress)
             Scheduling.StreamSchedulingEngine(
-                 dispatcher, maxIngest = 5,
+                 dispatcher, stats, dumpStreams, maxIngest = 5,
                  ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay,
                  ?prioritizeStreamsBy = prioritizeStreamsBy)
 

--- a/src/Propulsion.CosmosStore/CosmosStoreSink.fs
+++ b/src/Propulsion.CosmosStore/CosmosStoreSink.fs
@@ -149,7 +149,7 @@ module Internal =
             let writerResultLog = log.ForContext<Writer.Result>()
             let attemptWrite struct (stream, span) ct = task {
                 let struct (met, span') = StreamSpan.slice Default.jsonSize (maxEvents, maxBytes) span
-                try let! res = Writer.write log eventsContext (StreamName.toString stream) span' |> fun f -> Async.StartAsTask(f, cancellationToken = ct)
+                try let! res = Writer.write log eventsContext (StreamName.toString stream) span' |> Async.startImmediateAsTask ct
                     return struct (span'.Length > 0, Choice1Of2 struct (met, res))
                 with e -> return struct (false, Choice2Of2 struct (met, e)) }
             let interpretWriteResultProgress (streams: Scheduling.StreamStates<_>) stream res =

--- a/src/Propulsion.CosmosStore/CosmosStoreSink.fs
+++ b/src/Propulsion.CosmosStore/CosmosStoreSink.fs
@@ -142,12 +142,9 @@ module Internal =
         abstract member HandleExn : log : ILogger * exn : exn -> unit
         default _.HandleExn(_, _) : unit = ()
 
-    type StreamSchedulingEngine =
+    type Dispatcher =
 
-        static member Create(
-                log : ILogger, eventsContext, itemDispatcher, stats : Stats, dumpStreams,
-                ?purgeInterval, ?wakeForResults, ?idleDelay, ?maxEvents, ?maxBytes, ?prioritizeStreamsBy)
-            : Scheduling.Engine<_, _, _, _> =
+        static member Create(log : ILogger, eventsContext, itemDispatcher, ?maxEvents, ?maxBytes) =
             let maxEvents, maxBytes = defaultArg maxEvents 16384, defaultArg maxBytes (1024 * 1024 - (*fudge*)4096)
             let writerResultLog = log.ForContext<Writer.Result>()
             let attemptWrite struct (stream, span) ct = task {
@@ -167,11 +164,7 @@ module Internal =
                 let struct (ss, malformed) = applyResultToStreamState res
                 Writer.logTo writerResultLog malformed (stream, res)
                 struct (ss.WritePos, res)
-            let dispatcher = Dispatcher.Concurrent<_, _, _, _>.Create(itemDispatcher, attemptWrite, interpretWriteResultProgress)
-            Scheduling.Engine(
-                 dispatcher, stats, dumpStreams, maxIngest = 5,
-                 ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay,
-                 ?prioritizeStreamsBy = prioritizeStreamsBy)
+            Dispatcher.Concurrent<_, _, _, _>.Create(itemDispatcher, attemptWrite, interpretWriteResultProgress)
 
 type CosmosStoreSink =
 
@@ -190,13 +183,10 @@ type CosmosStoreSink =
             ?ingesterStatsInterval)
         : Default.Sink =
         let statsInterval, stateInterval = defaultArg statsInterval (TimeSpan.FromMinutes 5.), defaultArg stateInterval (TimeSpan.FromMinutes 5.)
-        let stats = Internal.Stats(log.ForContext<Internal.Stats>(), statsInterval, stateInterval)
-        let dumpStreams logStreamStates _log = logStreamStates Default.eventSize
-        let streamScheduler =
-            Internal.StreamSchedulingEngine.Create(
-                log, eventsContext, maxConcurrentStreams, stats, dumpStreams,
-                ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay,
-                ?maxEvents = maxEvents, ?maxBytes = maxBytes, prioritizeStreamsBy = Default.eventSize)
-        Projector.Pipeline.Start(
-            log, streamScheduler.Pump, maxReadAhead, streamScheduler, statsInterval,
-            ?ingesterStatsInterval = ingesterStatsInterval)
+        let dispatcher = Internal.Dispatcher.Create(log, eventsContext, maxConcurrentStreams, ?maxEvents = maxEvents, ?maxBytes = maxBytes)
+        let scheduler =
+            let stats = Internal.Stats(log.ForContext<Internal.Stats>(), statsInterval, stateInterval)
+            let dumpStreams logStreamStates _log = logStreamStates Default.eventSize
+            Scheduling.Engine(dispatcher, stats, dumpStreams, maxIngest = 5, prioritizeStreamsBy = Default.eventSize,
+                              ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay)
+        Projector.Pipeline.Start(log, scheduler.Pump, maxReadAhead, scheduler, ingesterStatsInterval = defaultArg ingesterStatsInterval statsInterval)

--- a/src/Propulsion.EventStore/EventStoreSink.fs
+++ b/src/Propulsion.EventStore/EventStoreSink.fs
@@ -112,9 +112,8 @@ module Internal =
         abstract member HandleExn : log : ILogger * exn : exn -> unit
         default _.HandleExn(_, _) : unit = ()
 
-    type EventStoreSchedulingEngine =
-        static member Create(log : ILogger, storeLog, connections : _ [], itemDispatcher, stats : Stats, dumpStreams, ?idleDelay, ?purgeInterval)
-            : Scheduling.Engine<_, _, _, _> =
+    type Dispatcher =
+        static member Create(log : ILogger, storeLog, connections : _ [], maxDop) =
             let writerResultLog = log.ForContext<Writer.Result>()
             let mutable robin = 0
 
@@ -127,7 +126,6 @@ module Internal =
                                |> fun f -> Async.StartAsTask(f, cancellationToken = ct)
                     return struct (span'.Length > 0, Choice1Of2 struct (met, res))
                 with e -> return false, Choice2Of2 struct (met, e) }
-
             let interpretWriteResultProgress (streams : Scheduling.StreamStates<_>) stream res =
                 let applyResultToStreamState = function
                     | Choice1Of2 struct (_stats, Writer.Ok pos) ->                streams.RecordWriteProgress(stream, pos, null)
@@ -138,9 +136,7 @@ module Internal =
                 let ss = applyResultToStreamState res
                 Writer.logTo writerResultLog (stream, res)
                 struct (ss.WritePos, res)
-
-            let dispatcher = Dispatcher.Concurrent<_, _, _, _>.Create(itemDispatcher, attemptWrite, interpretWriteResultProgress)
-            Scheduling.Engine(dispatcher, stats, dumpStreams, maxIngest = 5, ?idleDelay = idleDelay, ?purgeInterval = purgeInterval)
+            Dispatcher.Concurrent<_, _, _, _>.Create(maxDop, attemptWrite, interpretWriteResultProgress)
 
 type EventStoreSink =
 
@@ -151,17 +147,17 @@ type EventStoreSink =
             ?statsInterval,
             // Default 5m
             ?stateInterval,
-            // Tune the sleep time when there are no items to schedule or responses to process. Default 1ms.
-            ?idleDelay,
             // Frequency with which to jettison Write Position information for inactive streams in order to limit memory consumption
             // NOTE: Can impair performance and/or increase costs of writes as it inhibits the ability of the ingester to discard redundant inputs
             ?purgeInterval,
+            // Tune the sleep time when there are no items to schedule or responses to process. Default 1ms.
+            ?idleDelay,
             ?ingesterStatsInterval)
         : Default.Sink =
+        let dispatcher = Internal.Dispatcher.Create(log, storeLog, connections, maxConcurrentStreams)
         let statsInterval, stateInterval = defaultArg statsInterval (TimeSpan.FromMinutes 5.), defaultArg stateInterval (TimeSpan.FromMinutes 5.)
-        let stats = Internal.Stats(log.ForContext<Internal.Stats>(), statsInterval, stateInterval)
-        let dumpStreams logStreamStates _log = logStreamStates Default.eventSize
-        let streamScheduler = Internal.EventStoreSchedulingEngine.Create(log, storeLog, connections, maxConcurrentStreams, stats, dumpStreams, ?idleDelay = idleDelay, ?purgeInterval = purgeInterval)
-        Projector.Pipeline.Start(
-            log, streamScheduler.Pump, maxReadAhead, streamScheduler, statsInterval,
-            ?ingesterStatsInterval = ingesterStatsInterval)
+        let scheduler =
+            let stats = Internal.Stats(log.ForContext<Internal.Stats>(), statsInterval, stateInterval)
+            let dumpStreams logStreamStates _log = logStreamStates Default.eventSize
+            Scheduling.Engine(dispatcher, stats, dumpStreams, maxIngest = 5, ?purgeInterval = purgeInterval, ?idleDelay = idleDelay)
+        Projector.Pipeline.Start( log, scheduler.Pump, maxReadAhead, scheduler, ingesterStatsInterval = defaultArg ingesterStatsInterval statsInterval)

--- a/src/Propulsion.EventStore/EventStoreSink.fs
+++ b/src/Propulsion.EventStore/EventStoreSink.fs
@@ -139,8 +139,8 @@ module Internal =
                 Writer.logTo writerResultLog (stream, res)
                 struct (ss.WritePos, res)
 
-            let dispatcher = Scheduling.Dispatcher.MultiDispatcher<_, _, _, _>.Create(itemDispatcher, attemptWrite, interpretWriteResultProgress, stats, dumpStreams)
-            Scheduling.StreamSchedulingEngine(dispatcher, maxIngest = 5, ?idleDelay = idleDelay, ?purgeInterval = purgeInterval)
+            let dispatcher = Scheduling.Dispatcher.MultiDispatcher<_, _, _, _>.Create(itemDispatcher, attemptWrite, interpretWriteResultProgress)
+            Scheduling.StreamSchedulingEngine(dispatcher, stats, dumpStreams, maxIngest = 5, ?idleDelay = idleDelay, ?purgeInterval = purgeInterval)
 
 type EventStoreSink =
 

--- a/src/Propulsion.EventStoreDb/EventStoreSource.fs
+++ b/src/Propulsion.EventStoreDb/EventStoreSource.fs
@@ -13,12 +13,12 @@ module private Impl =
     let private checkpointPos (xs : EventRecord array) =
         match Array.tryLast xs with Some e -> int64 e.Position.CommitPosition | None -> -1L
         |> Propulsion.Feed.Position.parse
-    let readBatch hydrateBodies batchSize categoryFilter (store : EventStoreClient) pos : Async<Propulsion.Feed.Core.Batch<_>> = async {
+    let readBatch hydrateBodies batchSize categoryFilter (store : EventStoreClient) pos = async {
         let! ct = Async.CancellationToken
         let pos = let p = pos |> Propulsion.Feed.Position.toInt64 |> uint64 in Position(p, p)
         let res = store.ReadAllAsync(Direction.Forwards, pos, batchSize, hydrateBodies, cancellationToken = ct)
         let! batch = AsyncSeq.ofAsyncEnum res |> AsyncSeq.map (fun e -> e.Event) |> AsyncSeq.toArrayAsync
-        return { checkpoint = checkpointPos batch; items = toItems categoryFilter batch; isTail = batch.LongLength <> batchSize } }
+        return ({ checkpoint = checkpointPos batch; items = toItems categoryFilter batch; isTail = batch.LongLength <> batchSize } : Propulsion.Feed.Core.Batch<_>) }
 
     // @scarvel8: event_global_position = 256 x 1024 x 1024 x chunk_number + chunk_header_size (128) + event_position_offset_in_chunk
     let private chunk (pos : Position) = uint64 pos.CommitPosition >>> 28

--- a/src/Propulsion.Feed/FeedReader.fs
+++ b/src/Propulsion.Feed/FeedReader.fs
@@ -34,63 +34,60 @@ module Log =
         logEvent.Properties.TryGetValue(PropertyTag, &p) |> ignore
         match p with Log.ScalarValue (:? Metric as e) -> ValueSome e | _ -> ValueNone
 
-[<AutoOpen>]
-module private Impl =
+type internal Stats(partition : int, source : SourceId, tranche : TrancheId, renderPos : Position -> string) =
 
-    type Stats(partition : int, source : SourceId, tranche : TrancheId, renderPos : Position -> string) =
+    let mutable batchLastPosition = Position.parse -1L
+    let mutable closed, lastWasTail, finishedReading = false, false, false
 
-        let mutable batchLastPosition = Position.parse -1L
-        let mutable closed, lastWasTail, finishedReading = false, false, false
+    let mutable pagesRead, pagesEmpty, events = 0, 0, 0L
+    let mutable readLatency, recentPagesRead, recentEvents, recentPagesEmpty = TimeSpan.Zero, 0, 0, 0
 
-        let mutable pagesRead, pagesEmpty, events = 0, 0, 0L
-        let mutable readLatency, recentPagesRead, recentEvents, recentPagesEmpty = TimeSpan.Zero, 0, 0, 0
+    let mutable ingestLatency, currentBatches, maxReadAhead = TimeSpan.Zero, 0, 0
 
-        let mutable ingestLatency, currentBatches, maxReadAhead = TimeSpan.Zero, 0, 0
+    let mutable lastCommittedPosition = Position.parse -1L
 
-        let mutable lastCommittedPosition = Position.parse -1L
+    member _.Dump(log : ILogger) =
+        if closed then () else
 
-        member _.Dump(log : ILogger) =
-            if closed then () else
+        let p pos = match pos with p when p = Position.parse -1L -> Nullable() | x -> Nullable x
+        let m = Log.Metric.Read {
+            source = source; tranche = tranche
+            token = p batchLastPosition; latency = readLatency; pages = recentPagesRead; items = recentEvents
+            ingestLatency = ingestLatency; ingestQueued = currentBatches }
+        let readS, postS = readLatency.TotalSeconds, ingestLatency.TotalSeconds
+        let inline r pos = match pos with p when p = Position.parse -1L -> null | x -> renderPos x
+        let state = if not lastWasTail then "Busy"
+                    elif lastCommittedPosition = batchLastPosition then "COMPLETE"
+                    else if finishedReading then "End" else "Tail"
+        (Log.withMetric m log).ForContext("tail", lastWasTail).Information(
+            "Reader {partition} {state} @ {lastCommittedPosition}/{readPosition} Pages {pagesRead} empty {pagesEmpty} events {events} | Recent {l:f1}s Pages {recentPagesRead} empty {recentPagesEmpty} events {recentEvents} | Wait {pausedS:f1}s Ahead {cur}/{max}",
+            partition, state, r lastCommittedPosition, r batchLastPosition, pagesRead, pagesEmpty, events, readS, recentPagesRead, recentPagesEmpty, recentEvents, postS, currentBatches, maxReadAhead)
+        readLatency <- TimeSpan.Zero; ingestLatency <- TimeSpan.Zero
+        recentPagesRead <- 0; recentEvents <- 0; recentPagesEmpty <- 0
+        closed <- finishedReading
 
-            let p pos = match pos with p when p = Position.parse -1L -> Nullable() | x -> Nullable x
-            let m = Log.Metric.Read {
-                source = source; tranche = tranche
-                token = p batchLastPosition; latency = readLatency; pages = recentPagesRead; items = recentEvents
-                ingestLatency = ingestLatency; ingestQueued = currentBatches }
-            let readS, postS = readLatency.TotalSeconds, ingestLatency.TotalSeconds
-            let inline r pos = match pos with p when p = Position.parse -1L -> null | x -> renderPos x
-            let state = if not lastWasTail then "Busy"
-                        elif lastCommittedPosition = batchLastPosition then "COMPLETE"
-                        else if finishedReading then "End" else "Tail"
-            (Log.withMetric m log).ForContext("tail", lastWasTail).Information(
-                "Reader {partition} {state} @ {lastCommittedPosition}/{readPosition} Pages {pagesRead} empty {pagesEmpty} events {events} | Recent {l:f1}s Pages {recentPagesRead} empty {recentPagesEmpty} events {recentEvents} | Wait {pausedS:f1}s Ahead {cur}/{max}",
-                partition, state, r lastCommittedPosition, r batchLastPosition, pagesRead, pagesEmpty, events, readS, recentPagesRead, recentPagesEmpty, recentEvents, postS, currentBatches, maxReadAhead)
-            readLatency <- TimeSpan.Zero; ingestLatency <- TimeSpan.Zero
-            recentPagesRead <- 0; recentEvents <- 0; recentPagesEmpty <- 0
-            closed <- finishedReading
+    member _.RecordBatch(readTime, batch: Batch<_>) =
+        readLatency <- readLatency + readTime
+        batchLastPosition <- batch.checkpoint
+        lastWasTail <- batch.isTail
+        match Array.length batch.items with
+        | 0 ->  pagesEmpty <- pagesEmpty + 1
+                recentPagesEmpty <- recentPagesEmpty + 1
+        | c ->  pagesRead <- pagesRead + 1
+                events <- events + int64 c
+                recentEvents <- recentEvents + c
+                recentPagesRead <- recentPagesRead + 1
 
-        member _.RecordBatch(readTime, batch: Batch<_>) =
-            readLatency <- readLatency + readTime
-            batchLastPosition <- batch.checkpoint
-            lastWasTail <- batch.isTail
-            match Array.length batch.items with
-            | 0 ->  pagesEmpty <- pagesEmpty + 1
-                    recentPagesEmpty <- recentPagesEmpty + 1
-            | c ->  pagesRead <- pagesRead + 1
-                    events <- events + int64 c
-                    recentEvents <- recentEvents + c
-                    recentPagesRead <- recentPagesRead + 1
+    member _.UpdateCommittedPosition(pos) =
+        lastCommittedPosition <- pos
+        closed <- false // Any updates trigger logging
 
-        member _.UpdateCommittedPosition(pos) =
-            lastCommittedPosition <- pos
-            closed <- false // Any updates trigger logging
-
-        member _.UpdateIngesterState(latency, cur, max, ?finished) =
-            ingestLatency <- ingestLatency + latency
-            currentBatches <- cur
-            maxReadAhead <- max
-            finishedReading <- defaultArg finished false
-            closed <- false // Any straggler reads (and/or bugs!) trigger logging
+    member _.UpdateIngesterState(latency, cur, max, ?finished) =
+        ingestLatency <- ingestLatency + latency
+        currentBatches <- cur
+        maxReadAhead <- max
+        finishedReading <- defaultArg finished false
+        closed <- false // Any straggler reads (and/or bugs!) trigger logging
 
 type FeedReader
     (   log : ILogger, partition, source, tranche,

--- a/src/Propulsion.Feed/FeedSource.fs
+++ b/src/Propulsion.Feed/FeedSource.fs
@@ -259,7 +259,7 @@ type TailingFeedSource
         checkpoints : IFeedCheckpointStore, establishOrigin : (TrancheId -> Async<Position>) option, sink : Propulsion.Streams.Default.Sink,
         crawl : TrancheId * Position -> AsyncSeq<struct (TimeSpan * Batch<_>)>,
         renderPos,
-        ?logReadFailure, ?readFailureSleepInterval, ?logCommitFailure, ?readersStopAtTail) =
+        ?logReadFailure, ?readFailureSleepInterval : TimeSpan, ?logCommitFailure, ?readersStopAtTail) =
     inherit FeedSourceBase(log, statsInterval, sourceId, checkpoints, establishOrigin, sink, renderPos, ?logCommitFailure = logCommitFailure, ?readersStopAtTail = readersStopAtTail)
 
     let crawl trancheId (wasLast, startPos) = asyncSeq {
@@ -293,7 +293,7 @@ type AllFeedSource
             (fun (_trancheId, pos) -> asyncSeq {
                   let sw = Stopwatch.start ()
                   let! b = readBatch pos
-                  yield sw.Elapsed, b } ),
+                  yield struct (sw.Elapsed, b) } ),
             renderPos = defaultArg renderPos string)
 
     member internal _.Pump =

--- a/src/Propulsion.Feed/FeedSource.fs
+++ b/src/Propulsion.Feed/FeedSource.fs
@@ -29,8 +29,7 @@ type FeedSourceBase internal
     let dumpStats () = for _i, r in partitions do r.DumpStats()
     let rec pumpStats () = async {
         try do! Async.Sleep statsInterval
-        // Note we want to dump the stats on exit if we are cancelled - if we don't do that in a finally, the Async workflow will already have stopped
-        finally dumpStats ()
+        finally dumpStats () // finally is so we do a final write after we are cancelled, which would otherwise stop us after the Async.Sleep
         return! pumpStats () }
 
     member val internal Positions = positions
@@ -39,11 +38,11 @@ type FeedSourceBase internal
     /// Yields current Tranche Positions
     member _.Checkpoint() : Async<IReadOnlyDictionary<TrancheId, Position>> = async {
         let! ct = Async.CancellationToken
-        do! Async.Parallel(seq { for i, _r in partitions -> Async.AwaitTask(i.FlushProgress ct) }) |> Async.Ignore<unit array>
+        do! Async.Parallel(seq { for i, _r in partitions -> i.FlushProgress ct |> Async.AwaitTaskCorrect }) |> Async.Ignore<unit array>
         return positions.Completed() }
 
     /// Propagates exceptions raised by <c>readTranches</c> or <c>crawl</c>,
-    member internal _.Pump
+    member internal x.Pump
         (   readTranches : unit -> Async<TrancheId[]>,
             // Responsible for managing retries and back offs; yielding an exception will result in abend of the read loop
             crawl : TrancheId -> bool * Position -> AsyncSeq<struct (TimeSpan * Batch<_>)>) = async {
@@ -62,7 +61,8 @@ type FeedSourceBase internal
         // This will get cancelled as we exit in the case where everything is drained (or, in the exception case)
         let! _stats = pumpStats () |> Async.StartChild
         let trancheWorkflows = (tranches, partitions) ||> Seq.mapi2 pumpPartition
-        return! Async.Parallel(trancheWorkflows) |> Async.Ignore<unit[]> }
+        do! Async.Parallel(trancheWorkflows) |> Async.Ignore<unit[]>
+        do! x.Checkpoint() |> Async.Ignore }
 
     member x.Start(pump) =
         let ct, stop =
@@ -97,7 +97,7 @@ type FeedSourceBase internal
             try return! outcomeTask
             finally log.Information "... source completed" }
 
-        let monitor = lazy FeedMonitor(log, positions, sink, fun () -> Task.isCompleted outcomeTask)
+        let monitor = lazy FeedMonitor(log, positions, sink, fun () -> outcomeTask.IsCompleted)
         new SourcePipeline<_>(Task.run supervise, stop, monitor)
 
 /// Intercepts receipt and completion of batches, recording the read and completion positions
@@ -125,9 +125,9 @@ and internal TrancheState =
     member x.IsEmpty = x.completed = x.read
 
 and [<Struct; NoComparison; NoEquality>] private WaitMode = OriginalWorkOnly | IncludeSubsequent | AwaitFullyCaughtUp
-and FeedMonitor internal (log : Serilog.ILogger, positions : TranchePositions, sink : Propulsion.Streams.Default.Sink, completed) =
+and FeedMonitor internal (log : Serilog.ILogger, positions : TranchePositions, sink : Propulsion.Streams.Default.Sink, sourceIsCompleted) =
 
-    let notEol () = not sink.IsCompleted && not (completed ())
+    let notEol () = not sink.IsCompleted && not (sourceIsCompleted ())
     let choose f (xs : KeyValuePair<_, _> array) = [| for x in xs do match f x.Value with ValueNone -> () | ValueSome v' -> struct (x.Key, v') |]
     // Waits for up to propagationDelay, returning the opening tranche positions observed (or empty if the wait has timed out)
     let awaitPropagation (sleepMs : int) (propagationDelay : TimeSpan) positions = async {
@@ -149,7 +149,8 @@ and FeedMonitor internal (log : Serilog.ILogger, positions : TranchePositions, s
             if not worked && Array.any current then startPositions <- current; worked <- true // Starting: Record start position (for if we exit due to timeout)
             elif worked && Array.isEmpty current then startPositions <- current // Finished now: clear starting position record, triggering normal exit of loop
         return startPositions }
-    let isDrained : KeyValuePair<_, TrancheState> array -> bool = Array.forall (fun (KeyValue (_t, s)) -> s.isTail && s.IsEmpty)
+    let isTrancheDrained (s : TrancheState) = s.isTail && s.IsEmpty
+    let isDrained : KeyValuePair<_, TrancheState> array -> bool = Array.forall (fun (KeyValue (_t, s)) -> isTrancheDrained s)
     let awaitCompletion (sleepMs : int, logInterval) (sw : System.Diagnostics.Stopwatch) startReadPositions waitMode = async {
         let logInterval = IntervalTimer logInterval
         let logWaitStatusUpdateNow () =
@@ -160,9 +161,9 @@ and FeedMonitor internal (log : Serilog.ILogger, positions : TranchePositions, s
                                                     sw.ElapsedSeconds, startReadPositions, completed)
             | IncludeSubsequent ->  log.Information("FeedMonitor {totalTime:n1}s Awaiting Running. Current {current} Completed {completed} Starting {starting}",
                                                     sw.ElapsedSeconds, currentRead, completed, startReadPositions)
-            | AwaitFullyCaughtUp -> let catchingUp = current |> choose (fun v -> if not v.isTail then ValueSome () else ValueNone) |> Array.map ValueTuple.fst
+            | AwaitFullyCaughtUp -> let draining = current |> choose (fun v -> if isTrancheDrained v then ValueNone else ValueSome ()) |> Array.map ValueTuple.fst
                                     log.Information("FeedMonitor {totalTime:n1}s Awaiting Tails {tranches}. Current {current} Completed {completed} Starting {starting}",
-                                                    sw.ElapsedSeconds, catchingUp, currentRead, completed, startReadPositions)
+                                                    sw.ElapsedSeconds, draining, currentRead, completed, startReadPositions)
         let busy () =
             let current = positions.Current()
             match waitMode with
@@ -189,7 +190,7 @@ and FeedMonitor internal (log : Serilog.ILogger, positions : TranchePositions, s
             // - an adjustment to account for the polling interval that the Source is using
             propagationDelay,
             // sleep interval while awaiting completion. Default 1ms.
-            ?delay,
+            ?sleep,
             // interval at which to log status of the Await (to assist in analyzing stuck Sinks). Default 5s.
             ?logInterval,
             // Inhibit waiting for the handling of follow-on events that arrived after the wait commenced.
@@ -205,7 +206,7 @@ and FeedMonitor internal (log : Serilog.ILogger, positions : TranchePositions, s
             //      max (propagationTimeout.TotalSeconds / 4.) ((propagation.TotalSeconds + processing.TotalSeconds) / 3.) |> TimeSpan.FromSeconds
             ?lingerTime : bool -> TimeSpan -> TimeSpan -> TimeSpan -> TimeSpan) = async {
         let sw = Stopwatch.start ()
-        let delayMs = delay |> Option.map (fun (d : TimeSpan) -> int d.TotalMilliseconds) |> Option.defaultValue 1
+        let sleepMs = sleep |> Option.map (fun (d : TimeSpan) -> int d.TotalMilliseconds) |> Option.defaultValue 1
         let currentCompleted = seq { for kv in positions.Current() -> struct (kv.Key, ValueOption.toNullable kv.Value.completed) }
         let waitMode =
             match ignoreSubsequent, awaitFullyCaughtUp with
@@ -218,7 +219,7 @@ and FeedMonitor internal (log : Serilog.ILogger, positions : TranchePositions, s
             match positions.Current() with
             | xs when xs |> Array.forall (fun (kv : KeyValuePair<_, TrancheState>) -> kv.Value.IsEmpty && (not requireTail || kv.Value.isTail)) -> Array.empty
             | originals -> originals |> choose (fun v -> v.read)
-        match! awaitPropagation delayMs propagationDelay activeTranches with
+        match! awaitPropagation sleepMs propagationDelay activeTranches with
         | [||] ->
             if propagationDelay = TimeSpan.Zero then log.Debug("FeedSource Wait Skipped; no processing pending. Completed {completed}", currentCompleted)
             else log.Information("FeedMonitor Wait {propagationDelay:n1}s Timeout. Completed {completed}", sw.ElapsedSeconds, currentCompleted)
@@ -226,7 +227,7 @@ and FeedMonitor internal (log : Serilog.ILogger, positions : TranchePositions, s
             let propUsed = sw.Elapsed
             let logInterval = defaultArg logInterval (TimeSpan.FromSeconds 5.)
             let swProcessing = Stopwatch.start ()
-            do! awaitCompletion (delayMs, logInterval) swProcessing starting waitMode
+            do! awaitCompletion (sleepMs, logInterval) swProcessing starting waitMode
             let procUsed = swProcessing.Elapsed
             let isDrainedNow () = positions.Current() |> isDrained
             let linger = match lingerTime with None -> TimeSpan.Zero | Some lingerF -> lingerF (isDrainedNow ()) propagationDelay propUsed procUsed
@@ -239,12 +240,12 @@ and FeedMonitor internal (log : Serilog.ILogger, positions : TranchePositions, s
                           sw.ElapsedSeconds, propUsed.TotalSeconds, propagationDelay.TotalSeconds, procUsed.TotalSeconds, isDrainedNow (), starting, completed)
             if not skipLinger then
                 let swLinger = Stopwatch.start ()
-                match! awaitLinger delayMs linger activeTranches with
+                match! awaitLinger sleepMs linger activeTranches with
                 | [||] ->
                     log.Information("FeedMonitor Wait {totalTime:n1}s OK Propagate {propagate:n1}/{propTimeout:n1}s Process {process:n1}s Linger {lingered:n1}/{linger:n1}s Tail {allAtTail}. Starting {starting} Completed {completed}",
                                     sw.ElapsedSeconds, propUsed.TotalSeconds, propagationDelay.TotalSeconds, procUsed.TotalSeconds, swLinger.ElapsedSeconds, linger.TotalSeconds, isDrainedNow (), starting, originalCompleted)
                 | lingering ->
-                    do! awaitCompletion (delayMs, logInterval) swProcessing lingering waitMode
+                    do! awaitCompletion (sleepMs, logInterval) swProcessing lingering waitMode
                     log.Information("FeedMonitor Wait {totalTime:n1}s Lingered Propagate {propagate:n1}/{propTimeout:n1}s Process {process:n1}s Linger {lingered:n1}/{linger:n1}s Tail {allAtTail}. Starting {starting} Lingering {lingering} Completed {completed}",
                                     sw.ElapsedSeconds, propUsed.TotalSeconds, propagationDelay.TotalSeconds, procUsed.TotalSeconds, swLinger.ElapsedSeconds, linger, isDrainedNow (), starting, lingering, currentCompleted)
             // If the sink Faulted, let the awaiter observe the associated Exception that triggered the shutdown

--- a/src/Propulsion.Kafka/Consumers.fs
+++ b/src/Propulsion.Kafka/Consumers.fs
@@ -423,9 +423,9 @@ type BatchesConsumer =
                     [| for x in items ->
                         let metrics = StreamSpan.metrics Default.jsonSize x.span
                         ae, x.stream, false, Choice2Of2 struct (metrics, e) |] }
-        let dispatcher = Scheduling.Dispatcher.BatchedDispatcher(select, handle, stats, dumpStreams)
+        let dispatcher = Scheduling.Dispatcher.BatchedDispatcher(select, handle)
         let streamsScheduler = Scheduling.StreamSchedulingEngine.Create(
-            dispatcher, maxIngest = 5, ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay)
+            dispatcher, stats, dumpStreams, maxIngest = 5, ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay)
         let mapConsumedMessagesToStreamsBatch onCompletion (x : Submission.Batch<TopicPartition, 'Info>) =
             let onCompletion () = x.onCompletion(); onCompletion()
             Buffer.Batch.Create(onCompletion, Seq.collect infoToStreamEvents x.messages)

--- a/src/Propulsion.Kafka/Consumers.fs
+++ b/src/Propulsion.Kafka/Consumers.fs
@@ -401,7 +401,7 @@ type BatchesConsumer =
             let avgElapsed () =
                 let tot = float sw.ElapsedMilliseconds
                 TimeSpan.FromMilliseconds(tot / float items.Length)
-            try let! results = handle items |> fun f -> Async.StartAsTask(f, cancellationToken = ct)
+            try let! results = handle items |> Async.startAsTask ct
                 let ae = avgElapsed ()
                 return
                     [| for x in Seq.zip items results ->

--- a/src/Propulsion.Kafka/Consumers.fs
+++ b/src/Propulsion.Kafka/Consumers.fs
@@ -390,12 +390,12 @@ type BatchesConsumer =
             // - Choice1Of2: Index at which next processing will proceed (which can trigger discarding of earlier items on that stream)
             // - Choice2Of2: Records the processing of the stream in question as having faulted (the stream's pending events and/or
             //   new ones that arrived while the handler was processing are then eligible for retry purposes in the next dispatch cycle)
-            handle : Dispatch.Item<_>[] -> Async<seq<Choice<int64, exn>>>,
+            handle : Scheduling.Item<_>[] -> Async<seq<Choice<int64, exn>>>,
             // The responses from each <c>handle</c> invocation are passed to <c>stats</c> for periodic emission
             stats : Scheduling.Stats<struct (StreamSpan.Metrics * unit), struct (StreamSpan.Metrics * exn)>, statsInterval,
             ?purgeInterval, ?wakeForResults, ?idleDelay,
             ?logExternalState) =
-        let handle (items : Dispatch.Item<Default.EventBody>[]) ct
+        let handle (items : Scheduling.Item<Default.EventBody>[]) ct
             : Task<struct (TimeSpan * StreamName * bool * Choice<struct (int64 * struct (StreamSpan.Metrics * unit)), struct (StreamSpan.Metrics * exn)>)[]> = task {
             let sw = Stopwatch.start ()
             let avgElapsed () =

--- a/src/Propulsion.Kafka/ProducerSinks.fs
+++ b/src/Propulsion.Kafka/ProducerSinks.fs
@@ -22,11 +22,11 @@ type StreamsProducerSink =
             prepare : struct (StreamName * Default.StreamSpan) -> Async<struct ((struct (string * string)) voption * 'Outcome)>,
             producer : Producer,
             stats : Sync.Stats<'Outcome>, statsInterval,
-            // Default 1 ms
-            ?idleDelay,
             // Frequency with which to jettison Write Position information for inactive streams in order to limit memory consumption
             // NOTE: Can impair performance and/or increase costs of writes as it inhibits the ability of the ingester to discard redundant inputs
             ?purgeInterval,
+            // Default 1 ms
+            ?idleDelay,
             // Default 1 MiB
             ?maxBytes,
             // Default 16384
@@ -55,11 +55,11 @@ type StreamsProducerSink =
             prepare : struct (StreamName * Default.StreamSpan) -> Async<struct (string * string)>,
             producer : Producer,
             stats : Sync.Stats<unit>, statsInterval,
-            // Default 1 ms
-            ?idleDelay,
             // Frequency with which to jettison Write Position information for inactive streams in order to limit memory consumption
             // NOTE: Can impair performance and/or increase costs of writes as it inhibits the ability of the ingester to discard redundant inputs
             ?purgeInterval,
+            // Default 1 ms
+            ?idleDelay,
             // Default 1 MiB
             ?maxBytes,
             // Default 16384

--- a/src/Propulsion/Ingestion.fs
+++ b/src/Propulsion/Ingestion.fs
@@ -14,6 +14,8 @@ type ProgressWriter<'Res when 'Res : equality>() =
     let mutable validatedPos = None
     let result = Event<Choice<'Res, exn>>()
 
+    [<CLIEvent>] member _.Result = result.Publish
+
     member _.IsDirty =
         match Volatile.Read &validatedPos with
         | Some (v, _) when Volatile.Read(&committedEpoch) <> Some v -> true
@@ -23,17 +25,13 @@ type ProgressWriter<'Res when 'Res : equality>() =
         match Volatile.Read &validatedPos with
         | Some (v, f) when Volatile.Read(&committedEpoch) <> Some v ->
             try do! Async.StartImmediateAsTask(f, cancellationToken = ct)
-                Volatile.Write(&committedEpoch, Some v)
                 result.Trigger(Choice1Of2 v)
+                Volatile.Write(&committedEpoch, Some v)
             with e -> result.Trigger(Choice2Of2 e)
         | _ -> () }
 
-    [<CLIEvent>] member _.Result = result.Publish
-
     member _.Post(version, f) =
         Volatile.Write(&validatedPos, Some (version, f))
-
-    member _.CommittedEpoch = Volatile.Read(&committedEpoch)
 
 [<NoComparison; NoEquality>]
 type private InternalMessage =
@@ -42,20 +40,20 @@ type private InternalMessage =
     /// Result from updating of Progress to backing store - processed up to nominated `epoch` or threw `exn`
     | ProgressResult of Choice<int64, exn>
     /// Internal message for stats purposes
-    | Added of streams : int * events : int
+    | Added of epoch : int64 * streams : int * events : int
 
 [<Struct; NoComparison; NoEquality>]
 type Batch<'Items> = { epoch : int64; items : 'Items; onCompletion : unit -> unit; checkpoint : Async<unit>; isTail : bool }
 
 type private Stats(log : ILogger, partitionId, statsInterval : TimeSpan) =
-    let mutable validatedEpoch, committedEpoch : int64 option * int64 option = None, None
+    let mutable readEpoch, validatedEpoch, committedEpoch = None, None, None
     let mutable commitFails, commits = 0, 0
     let mutable cycles, batchesPended, streamsPended, eventsPended = 0, 0, 0, 0
     member val Interval = IntervalTimer statsInterval
 
     member _.DumpStats(activeReads, maxReads) =
-        log.Information("Ingester {partition} Ahead {activeReads}/{maxReads} @ {validated} Committed {committed} ok {commits} failed {fails} Ingested {batches} ({streams:n0}s {events:n0}e) Cycles {cycles}",
-                        partitionId, activeReads, maxReads, Option.toNullable validatedEpoch, Option.toNullable committedEpoch, commits, commitFails, batchesPended, streamsPended, eventsPended, cycles)
+        log.Information("Ingester {partition} Ahead {activeReads}/{maxReads} Committed {committed} @ {validated}/{pos} ok {commits} failed {fails} Ingested {batches} ({streams:n0}s {events:n0}e) Cycles {cycles}",
+                        partitionId, activeReads, maxReads, Option.toNullable committedEpoch, Option.toNullable validatedEpoch, Option.toNullable readEpoch, commits, commitFails, batchesPended, streamsPended, eventsPended, cycles)
         cycles <- 0; batchesPended <- 0; streamsPended <- 0; eventsPended <- 0
         if commitFails <> 0 && commits = 0 then log.Error("Ingester {partition} Commits failing: {failures} failures", partitionId, commitFails)
         commits <- 0; commitFails <- 0
@@ -68,7 +66,8 @@ type private Stats(log : ILogger, partitionId, statsInterval : TimeSpan) =
             committedEpoch <- Some epoch
         | ProgressResult (Choice2Of2 (_exn : exn)) ->
             commitFails <- commitFails + 1
-        | Added (streams, events) ->
+        | Added (epoch, streams, events) ->
+            readEpoch <- Some epoch
             batchesPended <- batchesPended + 1
             streamsPended <- streamsPended + streams
             eventsPended <- eventsPended + events
@@ -87,7 +86,7 @@ type Ingester<'Items> private
 
     let maxRead = Sem maxReadAhead
     let awaitIncoming, applyIncoming, enqueueIncoming =
-        let c = Channel.unboundedSwSr<Batch<'Items>> in let r, w = c.Reader, c.Writer
+        let c = Channel.unboundedSr<Batch<'Items>> in let r, w = c.Reader, c.Writer
         Channel.awaitRead r, Channel.apply r, Channel.write w
     let awaitMessage, applyMessages, enqueueMessage =
         let c = Channel.unboundedSr in let r, w = c.Reader, c.Writer
@@ -98,12 +97,13 @@ type Ingester<'Items> private
 
     let handleIncoming (batch : Batch<'Items>) =
         let markCompleted () =
-            maxRead.Release()
-            batch.onCompletion () // we guarantee this happens before checkpoint can be called
             enqueueMessage <| Validated batch.epoch
+            // Need to report progress before the Release or batch.OnCompletion, in order for AwaitCheckpointed to be correct
             progressWriter.Post(batch.epoch, batch.checkpoint)
+            batch.onCompletion ()
+            maxRead.Release()
         let struct (streamCount, itemCount) = submitBatch (batch.items, markCompleted)
-        enqueueMessage <| Added (streamCount, itemCount)
+        enqueueMessage <| Added (batch.epoch, streamCount, itemCount)
 
     member _.FlushProgress ct =
         progressWriter.CommitIfDirty ct
@@ -128,17 +128,14 @@ type Ingester<'Items> private
             stats.RecordCycle()
             if stats.Interval.IfDueRestart() then let struct (active, max) = maxRead.State in stats.DumpStats(active, max)
             do! Task.WhenAny(awaitIncoming ct, awaitMessage ct, Task.Delay(stats.Interval.RemainingMs)) :> Task }
-            // arguably the impl should be submitting while unpacking but
-            // - maintaining consistency between incoming order and submit order is required
-            // - in general maxRead will be double maxSubmit so this will only be relevant in catchup situations
 
     /// Starts an independent Task that handles
     /// a) `unpack`ing of `incoming` items
-    /// b) `submit`ting them onward (assuming there is capacity within the `readLimit`)
-    static member Start<'Items>(log, partitionId, maxRead, submitBatch, statsInterval, ?commitInterval) =
+    /// b) `submit`ting them onward (assuming there is capacity within the `maxReadAhead`)
+    static member Start<'Items>(log, partitionId, maxReadAhead, submitBatch, statsInterval, ?commitInterval) =
         let cts = new CancellationTokenSource()
         let stats = Stats(log, partitionId, statsInterval)
-        let instance = Ingester<'Items>(stats, maxRead, submitBatch, cts, ?commitInterval = commitInterval)
+        let instance = Ingester<'Items>(stats, maxReadAhead, submitBatch, cts, ?commitInterval = commitInterval)
         let startPump () = task {
             try do! instance.Pump cts.Token
             finally log.Information("... ingester stopped") }
@@ -158,6 +155,6 @@ type Ingester<'Items> private
     member _.Stop() = cts.Cancel()
 
     member x.Await(ct) = task {
-        let! r = maxRead.WaitForEmpty ct
+        let! r = maxRead.WaitForCompleted ct
         do! x.AwaitCheckpointed ct
         return r }

--- a/src/Propulsion/Parallel.fs
+++ b/src/Propulsion/Parallel.fs
@@ -212,4 +212,4 @@ type ParallelSink =
 
         let submitter = Submission.SubmissionEngine<_, _, _, _>(log, statsInterval, mapBatch, ignore, alwaysReady, submitBatch)
         let startIngester (rangeLog, partitionId) = ParallelIngester<'Item>.Start(rangeLog, partitionId, maxReadAhead, submitter.Ingest, ingesterStatsInterval)
-        Sink.Start(log, dispatcher.Pump, (fun abend ct -> scheduler.Pump(abend, ct)), submitter.Pump, startIngester)
+        Sink.Start(log, scheduler.Pump, submitter.Pump, startIngester, pumpDispatcher = dispatcher.Pump)

--- a/src/Propulsion/Pipeline.fs
+++ b/src/Propulsion/Pipeline.fs
@@ -15,8 +15,8 @@ type Pipeline(task : Task<unit>, triggerStop) =
     /// Inspects current status of task representing the Pipeline's overall state
     member _.Status = task.Status
 
-    /// Determines whether processing has completed, be that due to an intentional Stop(), or due to a Fault (see also RanToCompletion)
-    member _.IsCompleted = Task.isCompleted task
+    /// Determines whether processing has completed, be that due to an intentional Stop(), due to a Fault, or successful completion (see also RanToCompletion)
+    member _.IsCompleted = task.IsCompleted
 
     /// After AwaitShutdown (or IsCompleted returns true), can be used to infer whether exit was clean (via Stop) or due to a Pipeline Fault (which ca be observed via AwaitShutdown)
     member _.RanToCompletion = task.Status = TaskStatus.RanToCompletion

--- a/src/Propulsion/Pipeline.fs
+++ b/src/Propulsion/Pipeline.fs
@@ -34,7 +34,7 @@ type Pipeline(task : Task<unit>, triggerStop) =
         use _ = ct.Register(fun () -> x.Stop())
         return! x.AwaitShutdown() }
 
-    static member Prepare(log : ILogger, pumpDispatcher, pumpScheduler, pumpSubmitter, ?pumpIngester) =
+    static member Prepare(log : ILogger, pumpScheduler, pumpSubmitter, ?pumpIngester, ?pumpDispatcher) =
         let cts = new CancellationTokenSource()
         let triggerStop disposing =
             let level = if disposing || cts.IsCancellationRequested then Events.LogEventLevel.Debug else Events.LogEventLevel.Information
@@ -65,9 +65,9 @@ type Pipeline(task : Task<unit>, triggerStop) =
             use _ = ct.Register(fun _ -> tcs.TrySetResult () |> ignore)
 
             pumpIngester |> Option.iter (start "ingester")
-            start "dispatcher" pumpDispatcher
+            pumpDispatcher |> Option.iter (start "dispatcher")
             // ... fault results from dispatched tasks result in the `machine` concluding with an exception
-            let scheduler = run "scheduler" (pumpScheduler abend)
+            let scheduler = run "scheduler" (fun ct -> pumpScheduler (abend, ct))
             start "submitter" pumpSubmitter
 
             // await for either handler-driven abend or external cancellation via Stop()
@@ -92,6 +92,6 @@ type Sink<'Ingester> private (task : Task<unit>, triggerStop, startIngester) =
 
     member _.StartIngester(rangeLog : ILogger, partitionId : int) : 'Ingester = startIngester (rangeLog, partitionId)
 
-    static member Start(log : ILogger, pumpDispatcher, pumpScheduler, pumpSubmitter, startIngester) =
-        let task, triggerStop = Pipeline.Prepare(log, pumpDispatcher, pumpScheduler, pumpSubmitter, ?pumpIngester = None)
+    static member Start(log : ILogger, pumpScheduler, pumpSubmitter, startIngester, ?pumpDispatcher) =
+        let task, triggerStop = Pipeline.Prepare(log, pumpScheduler, pumpSubmitter, ?pumpIngester = None, ?pumpDispatcher = pumpDispatcher)
         new Sink<'Ingester>(task, triggerStop, startIngester)

--- a/src/Propulsion/Streams.fs
+++ b/src/Propulsion/Streams.fs
@@ -966,7 +966,6 @@ module Projector =
 
         static member Start(log : ILogger, pumpScheduler, maxReadAhead, streamsScheduler, ingesterStatsInterval) =
             let mapBatch onCompletion (x : Submission.Batch<_, StreamEvent<'F>>) : struct (Buffer.Streams<'F> * Buffer.Batch) =
-                let onCompletion () = x.onCompletion (); onCompletion ()
                 Buffer.Batch.Create(onCompletion, x.messages)
             let submitter = StreamsSubmitter.Create(log, mapBatch, streamsScheduler, ingesterStatsInterval)
             let startIngester (rangeLog, partitionId : int) = StreamsIngester.Start(rangeLog, partitionId, maxReadAhead, submitter.Ingest, ingesterStatsInterval)

--- a/src/Propulsion/Streams.fs
+++ b/src/Propulsion/Streams.fs
@@ -962,8 +962,7 @@ module Projector =
 
     type Pipeline =
 
-        static member Start(log : ILogger, pumpScheduler, maxReadAhead, streamsScheduler, statsInterval, ?ingesterStatsInterval) =
-            let ingesterStatsInterval = defaultArg ingesterStatsInterval statsInterval
+        static member Start(log : ILogger, pumpScheduler, maxReadAhead, streamsScheduler, ingesterStatsInterval) =
             let mapBatch onCompletion (x : Submission.Batch<_, StreamEvent<'F>>) : struct (Buffer.Streams<'F> * Buffer.Batch) =
                 let onCompletion () = x.onCompletion (); onCompletion ()
                 Buffer.Batch.Create(onCompletion, x.messages)
@@ -1026,9 +1025,7 @@ type StreamsSink =
                     (fun logStreamStates _log -> logStreamStates eventSize),
                     defaultArg maxIngest maxReadAhead, ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay,
                     ?requireCompleteStreams = requireCompleteStreams)
-        Projector.Pipeline.Start(
-            log, streamScheduler.Pump, maxReadAhead, streamScheduler, statsInterval,
-            ?ingesterStatsInterval = ingesterStatsInterval)
+        Projector.Pipeline.Start(log, streamScheduler.Pump, maxReadAhead, streamScheduler, ingesterStatsInterval = defaultArg ingesterStatsInterval statsInterval)
 
     /// Project StreamSpans using a <code>handle</code> function that yields a Write Position representing the next event that's to be handled on this Stream
     static member Start<'Outcome, 'F>

--- a/src/Propulsion/Streams.fs
+++ b/src/Propulsion/Streams.fs
@@ -263,7 +263,7 @@ module Scheduling =
         let markBusy stream = busy.Add stream |> ignore
         let markNotBusy stream = busy.Remove stream |> ignore
 
-        member _.ChooseDispatchable(s : FsCodec.StreamName, allowGaps) : 'item voption =
+        member _.ChooseDispatchable(s : FsCodec.StreamName, allowGaps) : _ voption =
             match tryGetItem s with
             | ValueSome ss when ss.IsReady(allowGaps) && not (busy.Contains s) -> ValueSome ss
             | _ -> ValueNone

--- a/tests/Propulsion.Kafka.Integration/ConsumersIntegration.fs
+++ b/tests/Propulsion.Kafka.Integration/ConsumersIntegration.fs
@@ -121,7 +121,7 @@ module Helpers =
             // When offered, take whatever is pending
             let select = Array.ofSeq
             // when processing, declare all items processed each time we're invoked
-            let handle (streams : Propulsion.Streams.Dispatch.Item<Propulsion.Streams.Default.EventBody>[]) = async {
+            let handle (streams : Propulsion.Streams.Scheduling.Item<Propulsion.Streams.Default.EventBody>[]) = async {
                 let mutable c = 0
                 for stream in streams do
                   for event in stream.span do

--- a/tests/Propulsion.Tests/SourceTests.fs
+++ b/tests/Propulsion.Tests/SourceTests.fs
@@ -34,16 +34,20 @@ type Scenario(testOutput) =
         do! src.Monitor.AwaitCompletion(propagationDelay = TimeSpan.FromSeconds 1, awaitFullyCaughtUp = true)
         // source runs until someone explicitly stops it, or it throws
         src.Stop()
+        // TailingFeedSource does not implicitly wait for completion or flush
+        do! source.Checkpoint() |> Async.Ignore
         // Yields source exception, if any
         do! src.AwaitShutdown()
         test <@ src.RanToCompletion @> }
 
     [<Theory; InlineData true; InlineData false>]
-    let SinglePassSource withWait = async {
+    let SinglePassFeedSource withWait = async {
         let crawl _ : AsyncSeq<struct (TimeSpan * Core.Batch<_>)> =
             AsyncSeq.singleton (TimeSpan.FromSeconds 0.1, { items = Array.empty; isTail = true; checkpoint = Unchecked.defaultof<_> })
         let source = Propulsion.Feed.Core.SinglePassFeedSource(log, TimeSpan.FromMinutes 1, SourceId.parse "sid", crawl, checkpoints, sink, string)
         use src = source.Start(fun () -> async { return [| TrancheId.parse "tid" |] })
+        // SinglePassFeedSource completion includes Waiting for Completion of all Batches on all Tranches and Flushing of Checkpoints
+        // Hence waiting with the Monitor is not actually necessary (though it provides progress logging which otherwise would be less thorough)
         if withWait then
             // Yields sink exception, if any
             do! src.Monitor.AwaitCompletion(propagationDelay = TimeSpan.FromSeconds 1, awaitFullyCaughtUp = true)

--- a/tests/Propulsion.Tests/SourceTests.fs
+++ b/tests/Propulsion.Tests/SourceTests.fs
@@ -36,8 +36,7 @@ type Scenario(testOutput) =
         src.Stop()
         // Yields source exception, if any
         do! src.AwaitShutdown()
-        test <@ src.RanToCompletion @>
-    }
+        test <@ src.RanToCompletion @> }
 
     [<Theory; InlineData true; InlineData false>]
     let SinglePassSource withWait = async {
@@ -50,7 +49,6 @@ type Scenario(testOutput) =
             do! src.Monitor.AwaitCompletion(propagationDelay = TimeSpan.FromSeconds 1, awaitFullyCaughtUp = true)
         // Yields source exception, if any
         do! src.AwaitShutdown()
-        test <@ src.RanToCompletion @>
-    }
+        test <@ src.RanToCompletion @> }
 
     interface IDisposable with member _.Dispose() = dispose ()

--- a/tests/Propulsion.Tests/SourceTests.fs
+++ b/tests/Propulsion.Tests/SourceTests.fs
@@ -6,7 +6,6 @@ open Propulsion.Internal
 open Serilog
 open Swensen.Unquote
 open System
-open System.Threading.Tasks
 open Xunit
 
 type Scenario(testOutput) =
@@ -42,8 +41,7 @@ type Scenario(testOutput) =
 
     [<Theory; InlineData true; InlineData false>]
     let SinglePassFeedSource withWait = async {
-        let crawl _ : AsyncSeq<struct (TimeSpan * Core.Batch<_>)> =
-            AsyncSeq.singleton (TimeSpan.FromSeconds 0.1, { items = Array.empty; isTail = true; checkpoint = Unchecked.defaultof<_> })
+        let crawl _ = AsyncSeq.singleton <| struct (TimeSpan.FromSeconds 0.1, ({ items = Array.empty; isTail = true; checkpoint = Unchecked.defaultof<_> } : Core.Batch<_>))
         let source = Propulsion.Feed.Core.SinglePassFeedSource(log, TimeSpan.FromMinutes 1, SourceId.parse "sid", crawl, checkpoints, sink, string)
         use src = source.Start(fun () -> async { return [| TrancheId.parse "tid" |] })
         // SinglePassFeedSource completion includes Waiting for Completion of all Batches on all Tranches and Flushing of Checkpoints

--- a/tools/Propulsion.Tool/Program.fs
+++ b/tools/Propulsion.Tool/Program.fs
@@ -338,7 +338,7 @@ module Project =
         let stats = Stats(TimeSpan.FromMinutes 1., TimeSpan.FromMinutes 5., logExternalStats = dumpStoreStats)
         let sink =
             let maxReadAhead, maxConcurrentStreams = 2, 16
-            let handle (stream : FsCodec.StreamName, span : Propulsion.Streams.Default.StreamSpan) = async {
+            let handle struct (stream : FsCodec.StreamName, span : Propulsion.Streams.Default.StreamSpan) = async {
                 match producer with
                 | None -> ()
                 | Some producer ->


### PR DESCRIPTION
- [x] Tidy Dispatcher abstractions and impls
- [x] Remove multiple factories
- [x] Finesse Reader and Ingester logging
- [x] Log head batch at State interval when streams are gapped
Fixes:
- [x] Removed incorrect dropping of events in `WritePositionIsAlreadyBeyond`
- [x] Fix wait semantics for `SinglePassFeedSource`
- [x] Fix Double release on batch completion