### PR TITLE
Streams: Rename maxIngest  -> pendingBufferSize

### DIFF
--- a/src/Propulsion.Cosmos/CosmosPruner.fs
+++ b/src/Propulsion.Cosmos/CosmosPruner.fs
@@ -120,6 +120,6 @@ type CosmosPruner =
         let statsInterval, stateInterval = defaultArg statsInterval (TimeSpan.FromMinutes 5.), defaultArg stateInterval (TimeSpan.FromMinutes 5.)
         let stats = Pruner.Stats(log.ForContext<Pruner.Stats>(), statsInterval, stateInterval)
         let dumpStreams logStreamStates _log = logStreamStates Default.eventSize
-        let scheduler = Scheduling.Engine(dispatcher, stats, dumpStreams, maxIngest = 5,
+        let scheduler = Scheduling.Engine(dispatcher, stats, dumpStreams, pendingBufferSize = 5,
                                           ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay)
         Projector.Pipeline.Start(log, scheduler.Pump, maxReadAhead, scheduler, ingesterStatsInterval = defaultArg ingesterStatsInterval statsInterval)

--- a/src/Propulsion.Cosmos/CosmosSink.fs
+++ b/src/Propulsion.Cosmos/CosmosSink.fs
@@ -178,6 +178,6 @@ type CosmosSink =
         let scheduler =
             let stats = Internal.Stats(log.ForContext<Internal.Stats>(), statsInterval, stateInterval)
             let dumpStreams logStreamStates _log = logStreamStates Default.eventSize
-            Scheduling.Engine(dispatcher, stats, dumpStreams, maxIngest = 5, prioritizeStreamsBy = Default.eventSize,
+            Scheduling.Engine(dispatcher, stats, dumpStreams, pendingBufferSize = 5, prioritizeStreamsBy = Default.eventSize,
                               ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay)
         Projector.Pipeline.Start(log, scheduler.Pump, maxReadAhead, scheduler, ingesterStatsInterval = defaultArg ingesterStatsInterval statsInterval)

--- a/src/Propulsion.CosmosStore/CosmosStorePruner.fs
+++ b/src/Propulsion.CosmosStore/CosmosStorePruner.fs
@@ -119,6 +119,6 @@ type CosmosStorePruner =
         let statsInterval, stateInterval = defaultArg statsInterval (TimeSpan.FromMinutes 5.), defaultArg stateInterval (TimeSpan.FromMinutes 5.)
         let stats = Pruner.Stats(log.ForContext<Pruner.Stats>(), statsInterval, stateInterval)
         let dumpStreams logStreamStates _log = logStreamStates Default.eventSize
-        let scheduler = Scheduling.Engine(dispatcher, stats, dumpStreams, maxIngest = 5,
+        let scheduler = Scheduling.Engine(dispatcher, stats, dumpStreams, pendingBufferSize = 5,
                                           ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay)
         Projector.Pipeline.Start(log, scheduler.Pump, maxReadAhead, scheduler, ingesterStatsInterval = defaultArg ingesterStatsInterval statsInterval)

--- a/src/Propulsion.CosmosStore/CosmosStoreSink.fs
+++ b/src/Propulsion.CosmosStore/CosmosStoreSink.fs
@@ -193,6 +193,6 @@ type CosmosStoreSink =
         let scheduler =
             let stats = Internal.Stats(log.ForContext<Internal.Stats>(), statsInterval, stateInterval)
             let dumpStreams logStreamStates _log = logStreamStates Default.eventSize
-            Scheduling.Engine(dispatcher, stats, dumpStreams, maxIngest = 5, prioritizeStreamsBy = Default.eventSize,
+            Scheduling.Engine(dispatcher, stats, dumpStreams, pendingBufferSize = 5, prioritizeStreamsBy = Default.eventSize,
                               ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay)
         Projector.Pipeline.Start(log, scheduler.Pump, maxReadAhead, scheduler, ingesterStatsInterval = defaultArg ingesterStatsInterval statsInterval)

--- a/src/Propulsion.EventStore/EventStoreSink.fs
+++ b/src/Propulsion.EventStore/EventStoreSink.fs
@@ -164,5 +164,5 @@ type EventStoreSink =
         let scheduler =
             let stats = Internal.Stats(log.ForContext<Internal.Stats>(), statsInterval, stateInterval)
             let dumpStreams logStreamStates _log = logStreamStates Default.eventSize
-            Scheduling.Engine(dispatcher, stats, dumpStreams, maxIngest = 5, ?purgeInterval = purgeInterval, ?idleDelay = idleDelay)
+            Scheduling.Engine(dispatcher, stats, dumpStreams, pendingBufferSize = 5, ?purgeInterval = purgeInterval, ?idleDelay = idleDelay)
         Projector.Pipeline.Start( log, scheduler.Pump, maxReadAhead, scheduler, ingesterStatsInterval = defaultArg ingesterStatsInterval statsInterval)

--- a/src/Propulsion.Kafka/Consumers.fs
+++ b/src/Propulsion.Kafka/Consumers.fs
@@ -190,7 +190,7 @@ module Core =
                 logStreamStates Default.eventSize
             let scheduler =
                 Scheduling.Engine(
-                    Dispatcher.Concurrent<_, _, _, _>.Create(maxDop, prepare, handle, SpanResult.toIndex), stats, dumpStreams, maxIngest = 5,
+                    Dispatcher.Concurrent<_, _, _, _>.Create(maxDop, prepare, handle, SpanResult.toIndex), stats, dumpStreams, pendingBufferSize = 5,
                     ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay)
             let mapConsumedMessagesToStreamsBatch onCompletion (x : Submission.Batch<TopicPartition, 'Info>) : struct (_ * Buffer.Batch) =
                 let onCompletion () = x.onCompletion(); onCompletion()
@@ -423,7 +423,7 @@ type BatchesConsumer =
         let dumpStreams logStreamStates log =
             logExternalState |> Option.iter (fun f -> f log)
             logStreamStates Default.eventSize
-        let scheduler = Scheduling.Engine(dispatcher, stats, dumpStreams, maxIngest = 5,
+        let scheduler = Scheduling.Engine(dispatcher, stats, dumpStreams, pendingBufferSize = 5,
                                           ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay)
         let mapConsumedMessagesToStreamsBatch onCompletion (x : Submission.Batch<TopicPartition, 'Info>) =
             let onCompletion () = x.onCompletion(); onCompletion()


### PR DESCRIPTION
MaxIngest was previously a far more significant parameter for tuning performance under high throughput. This adjustment is intended to convey that this is of less consequence, due to:
- Because the Submitter continually submits events as they arrive from the Ingesters, there is no longer a merging cost per batch that needs to be minimised to the same degree as previously
- The Scheduler Engine was simplified to ingest a single batch at a time (which it then immediately dispatches any work that results from)
- The Submitter now has a deterministic wait for input capacity (previously it was on a 1-5ms timer so buffering was critical to avoid the scheduler falling idle while there are batches in the Submitter)

The bottom line is that this parameter should only ever need tweaking under extreme throughput where handler latency is sub-millisecond level
