### PR TITLE
DynamoStore Index: rename tranche->partition

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ If you're looking for a good discussion forum on these kinds of topics, look no 
 
 - `Propulsion.DynamoStore` [![NuGet](https://img.shields.io/nuget/v/Propulsion.DynamoStore.svg)](https://www.nuget.org/packages/Propulsion.DynamoStore/) Provides bindings to `Equinox.DynamoStore`. [Depends](https://www.fuget.org/packages/Propulsion.DynamoStore) on `Equinox.DynamoStore` v `4.0.0`
 
-    1. `AppendsIndex`/`AppendsEpoch`: `Equinox.DynamoStore` aggregates that together form the Index Event Store 
+    1. `AppendsIndex`/`AppendsEpoch`: `Equinox.DynamoStore` aggregates that together form the DynamoStore Index
     2. `DynamoStoreIndexer`: writes to `AppendsIndex`/`AppendsEpoch` (used by `Propulsion.DynamoStore.Indexer`, `Propulsion.Tool`)
     3. `DynamoStoreSource`: reads from `AppendsIndex`/`AppendsEpoch` (see `DynamoStoreIndexer`)
     4. `ReaderCheckpoint`: checkpoint storage for `Propulsion.DynamoStore`/`EventStoreDb`/`Feed`/`MessageDb`/`SqlStreamSteamStore` using `Equinox.DynamoStore` v `4.0.0`.
@@ -64,7 +64,7 @@ If you're looking for a good discussion forum on these kinds of topics, look no 
 
 - `Propulsion.DynamoStore.Notifier` [![NuGet](https://img.shields.io/nuget/v/Propulsion.DynamoStore.Notifier.svg)](https://www.nuget.org/packages/Propulsion.DynamoStore.Notifier/) AWS Lambda to report new events indexed by the Indexer to an SNS Topic, in order to enable triggering AWS Lambdas to service Reactions without requiring a long-lived host application. [Depends](https://www.fuget.org/packages/Propulsion.DynamoStore.Notifier) on `Amazon.Lambda.Core`, `Amazon.Lambda.DynamoDBEvents`, `Amazon.Lambda.Serialization.SystemTextJson`, `AWSSDK.SimpleNotificationService`
 
-    1. `Handler`: parses Dynamo DB Streams Source Mapping input, generates a message per updated Tranche in the batch
+    1. `Handler`: parses Dynamo DB Streams Source Mapping input, generates a message per updated Partition in the batch
     2. `Function`: AWS Lambda Function that can be fed via a DynamoDB Streams Event Source Mapping; passes to `Handler`
 
   (Diagnostics are exposed via Console to CloudWatch)
@@ -226,7 +226,7 @@ $env:PROPULSION_KAFKA_BROKER="instance.kafka.mysite.com:9092" # or use -b
 propulsion -V project -g projector3 -l 5 kafka temp-topic cosmos
 ```
 
-### 3. Use `propulsion` tool to inspect DynamoStoreSource Index
+### 3. Use `propulsion` tool to inspect DynamoStore Index
 
 Summarize current state of the index being prepared by `Propulsion.DynamoStore.Indexer`
 
@@ -234,15 +234,15 @@ Summarize current state of the index being prepared by `Propulsion.DynamoStore.I
 
 Example output:
 
-    19:15:50 I Current Tranches / Active Epochs [[0, 354], [2, 15], [3, 13], [4, 13], [5, 13], [6, 64], [7, 53], [8, 53], [9, 60]]  
-    19:15:50 I Inspect Index Tranches list events 👉 eqx -C dump '$AppendsIndex-0' dynamo -t equinox-test-index  
-    19:15:50 I Inspect Batches in Epoch 2 of Index Tranche 0 👉 eqx -C dump '$AppendsEpoch-0_2' -B dynamo -t equinox-test-index
+    19:15:50 I Current Partitions / Active Epochs [[0, 354], [2, 15], [3, 13], [4, 13], [5, 13], [6, 64], [7, 53], [8, 53], [9, 60]]  
+    19:15:50 I Inspect Index Partitions list events 👉 eqx -C dump '$AppendsIndex-0' dynamo -t equinox-test-index  
+    19:15:50 I Inspect Batches in Epoch 2 of Index Partition 0 👉 eqx -C dump '$AppendsEpoch-0_2' -B dynamo -t equinox-test-index
 
 ### 4. Use `propulsion` tool to validate DynamoStoreSource Index  
 
 Validate `Propulsion.DynamoStore.Indexer` has not missed any events (normally you guarantee this by having alerting on Lambda failures) 
  
-    propulsion index -t 0 dynamo -t equinox-test
+    propulsion index -p 0 dynamo -t equinox-test
 
 ### 5. Use `propulsion` tool to reindex and/or add missing notifications
 

--- a/src/Propulsion.DynamoStore.Indexer/Handler.fs
+++ b/src/Propulsion.DynamoStore.Indexer/Handler.fs
@@ -48,5 +48,5 @@ let handle log (service : DynamoStoreIndexer) dynamoEvent = task {
     match parse log dynamoEvent with
     | [||] -> ()
     // TOCONSIDER if there are multiple shards, they should map to individual TrancheIds in order to avoid continual concurrency violations from competing writers
-    | spans -> return! service.IngestWithoutConcurrency(AppendsTrancheId.wellKnownId, spans) }
+    | spans -> return! service.IngestWithoutConcurrency(AppendsPartitionId.wellKnownId, spans) }
 

--- a/src/Propulsion.DynamoStore.Lambda/SqsNotificationBatch.fs
+++ b/src/Propulsion.DynamoStore.Lambda/SqsNotificationBatch.fs
@@ -9,12 +9,12 @@ open System.Collections.Generic
 type SqsNotificationBatch(event : SQSEvent) =
     let inputs = [|
         for r in event.Records ->
-            let trancheId = r.MessageAttributes["Tranche"].StringValue |> Propulsion.Feed.TrancheId.parse
+            let trancheId = r.MessageAttributes["Partition"].StringValue |> Propulsion.Feed.TrancheId.parse
             let position = r.MessageAttributes["Position"].StringValue |> int64 |> Propulsion.Feed.Position.parse
             struct (trancheId, position, r.MessageId) |]
 
     member val Count = inputs.Length
-    /// Yields the set of Index Tranches on which we are anticipating there to be work available
+    /// Yields the set of Index Partitions on which we are anticipating there to be work available
     member val Tranches = seq { for trancheId, _, _ in inputs -> trancheId } |> Seq.distinct |> Seq.toArray
     /// Correlates the achieved Tranche Positions with those that triggered the work; requeue any not yet acknowledged as processed
     member _.FailuresForPositionsNotReached(updated : IReadOnlyDictionary<_, _>) =

--- a/src/Propulsion.DynamoStore/AppendsIndex.fs
+++ b/src/Propulsion.DynamoStore/AppendsIndex.fs
@@ -17,7 +17,7 @@ module Events =
     and StartedUpConverter() =
         inherit FsCodec.SystemTextJson.JsonIsomorphism<Started, StartedBackcompatPreRc2>()
         override _.Pickle e = { partition = Some e.partition; tranche = None; epoch = e.epoch }
-        override _.UnPickle e = { partition = e.partition |> Option.orElse e.tranche |> Option.get; epoch = e.epoch }
+        override _.UnPickle e = { partition = (match e.partition with Some p -> p | _ -> e.tranche.Value); epoch = e.epoch }
     and StartedBackcompatPreRc2 = { partition : AppendsPartitionId option; tranche : AppendsPartitionId option; epoch : AppendsEpochId }
 
     type Event =

--- a/src/Propulsion.DynamoStore/Types.fs
+++ b/src/Propulsion.DynamoStore/Types.fs
@@ -2,7 +2,7 @@ namespace Propulsion.DynamoStore
 
 open FSharp.UMX
 
-/// Identifies a batch of coalesced deduplicated sets of commits indexed from DynamoDB Streams for a given tranche
+/// Identifies a batch of coalesced deduplicated sets of commits indexed from DynamoDB Streams for a given partition
 type internal AppendsEpochId = int<appendsEpochId>
 and [<Measure>] appendsEpochId
 module internal AppendsEpochId =
@@ -14,17 +14,16 @@ module internal AppendsEpochId =
     let parse : string -> AppendsEpochId = int >> UMX.tag
 
 /// Identifies a chain of epochs within an index that's to be ingested and/or read in sequence
-/// Multiple tranches within an index are analogous to how the Table's data is split into shards
-type internal AppendsTrancheId = int<appendsTrancheId>
-and [<Measure>] appendsTrancheId
-module AppendsTrancheId =
+type internal AppendsPartitionId = int<appendsPartitionId>
+and [<Measure>] appendsPartitionId
+module AppendsPartitionId =
 
-    // Tranches are not yet fully implemented
-    let wellKnownId : AppendsTrancheId = UMX.tag 0
-    let internal toString : AppendsTrancheId -> string = UMX.untag >> string
-    let internal toTrancheId : AppendsTrancheId -> Propulsion.Feed.TrancheId = toString >> UMX.tag
-    let parse : int -> AppendsTrancheId = int >> UMX.tag
-    let internal (|Parse|) : Propulsion.Feed.TrancheId -> AppendsTrancheId = UMX.untag >> int >> UMX.tag
+    // Partitioning is not yet implemented
+    let wellKnownId : AppendsPartitionId = UMX.tag 0
+    let internal toString : AppendsPartitionId -> string = UMX.untag >> string
+    let internal toTrancheId : AppendsPartitionId -> Propulsion.Feed.TrancheId = toString >> UMX.tag
+    let parse : string -> AppendsPartitionId = int >> UMX.tag
+    let internal (|Parse|) : Propulsion.Feed.TrancheId -> AppendsPartitionId = UMX.untag >> int >> UMX.tag
 
 type [<Measure>] checkpoint
 type Checkpoint = int64<checkpoint>

--- a/tests/Propulsion.Tests/AppendsIndexTests.fs
+++ b/tests/Propulsion.Tests/AppendsIndexTests.fs
@@ -1,0 +1,31 @@
+module Propulsion.Tests.AppendsIndexTests
+
+open FSharp.UMX
+open Propulsion.DynamoStore
+open Propulsion.DynamoStore.AppendsIndex
+open Swensen.Unquote
+open Xunit
+
+let u8 = System.Text.Encoding.UTF8
+
+[<Fact>]
+let ``serializes, writing as expected`` () =
+    let enc = Events.codec.Encode((), Events.Started { partition = AppendsPartitionId.wellKnownId; epoch = % 2 })
+    let struct (_, body) = enc.Data
+    let body = u8.GetString(body.Span)
+    test <@ body = """{"partition":0,"tranche":null,"epoch":2}""" @>
+
+[<Fact>]
+let ``deserializes, with upconversion`` () =
+    let data = struct (0, System.ReadOnlyMemory(u8.GetBytes("""{"tranche":3,"epoch":2}""")))
+    let e = FsCodec.Core.TimelineEvent.Create(0, "Started", data)
+    let dec = Events.codec.TryDecode e
+    let expected = Events.Started { partition = % 3 ; epoch = % 2 }
+    test <@ ValueSome expected = dec @>
+
+[<FsCheck.Xunit.Property>]
+let roundtrips value =
+    let e = Events.codec.Encode((), value)
+    let t = FsCodec.Core.TimelineEvent.Create(-1L, e.EventType, e.Data)
+    let decoded = Events.codec.TryDecode t
+    test <@ ValueSome value = decoded @>

--- a/tests/Propulsion.Tests/Propulsion.Tests.fsproj
+++ b/tests/Propulsion.Tests/Propulsion.Tests.fsproj
@@ -12,6 +12,7 @@
     <Compile Include="ParallelThrottledValidation.fs" />
     <Compile Include="TestOutputLogger.fs" />
     <Compile Include="SourceTests.fs" />
+    <Compile Include="AppendsIndexTests.fs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Arising from discussions around #200, this replaces the term 'tranche' in the DynamoStore Index with the more common term 'partition'

resolves #201