### PR TITLE
Sources: Add missing category filter support

### DIFF
--- a/src/Propulsion.CosmosStore/CosmosStoreParser.fs
+++ b/src/Propulsion.CosmosStore/CosmosStoreParser.fs
@@ -42,6 +42,10 @@ module EquinoxSystemTextJsonParser =
     /// Collects all events with a Document [typically obtained via the CosmosDb ChangeFeed] that potentially represents an Equinox.Cosmos event-batch
     let enumStreamEvents categoryFilter d : Default.StreamEvent seq =
         tryParseEquinoxBatch categoryFilter d |> ValueOption.map enumEquinoxCosmosEvents |> ValueOption.defaultValue Seq.empty
+
+    /// Collects all events with a Document [typically obtained via the CosmosDb ChangeFeed] that potentially represents an Equinox.Cosmos event-batch
+    let enumCategoryEvents categories d : Default.StreamEvent seq =
+        enumStreamEvents (fun c -> Array.contains c categories) d
 #else
 module EquinoxNewtonsoftParser =
 

--- a/src/Propulsion.EventStoreDb/EventStoreSource.fs
+++ b/src/Propulsion.EventStoreDb/EventStoreSource.fs
@@ -34,7 +34,10 @@ type EventStoreSource
     (   log : Serilog.ILogger, statsInterval,
         client : EventStore.Client.EventStoreClient, batchSize, tailSleepInterval,
         checkpoints : Propulsion.Feed.IFeedCheckpointStore, sink : Propulsion.Streams.Default.Sink,
-        categoryFilter : string -> bool,
+        // The whitelist of Categories to use
+        ?categories,
+        // Predicate to filter Categories to use
+        ?categoryFilter : string -> bool,
         // If the Handler does not utilize the Data/Meta of the events, we can avoid shipping them from the Store in the first instance. Default false.
         ?withData,
         // Override default start position to be at the tail of the index. Default: Replay all events.
@@ -42,5 +45,5 @@ type EventStoreSource
         ?sourceId) =
     inherit Propulsion.Feed.Core.AllFeedSource
         (   log, statsInterval, defaultArg sourceId FeedSourceId.wellKnownId, tailSleepInterval,
-            Impl.readBatch (withData = Some true) batchSize categoryFilter client, checkpoints, sink,
+            Impl.readBatch (withData = Some true) batchSize (Propulsion.Feed.Core.Categories.mapFilters categories categoryFilter) client, checkpoints, sink,
             ?establishOrigin = if startFromTail <> Some true then None else Some (Impl.readTailPositionForTranche log client))

--- a/src/Propulsion.Feed/FeedSource.fs
+++ b/src/Propulsion.Feed/FeedSource.fs
@@ -324,6 +324,15 @@ type SinglePassFeedSource
     member x.Start(readTranches) =
         base.Start(fun ct -> x.Pump(readTranches, ct))
 
+module Categories =
+
+    let mapFilters categories categoryFilter =
+        match categories, categoryFilter with
+        | None, None ->                   fun _ -> true
+        | Some categories, None ->        fun x -> Array.contains x categories
+        | None, Some filter ->            filter
+        | Some categories, Some filter -> fun x -> Array.contains x categories && filter x
+
 namespace Propulsion.Feed
 
 open FSharp.Control

--- a/src/Propulsion.Kafka/ProducerSinks.fs
+++ b/src/Propulsion.Kafka/ProducerSinks.fs
@@ -53,6 +53,29 @@ type StreamsProducerSink =
                      stats, statsInterval, Default.jsonSize, Default.eventSize,
                      maxBytes = maxBytes, ?idleDelay = idleDelay,?purgeInterval = purgeInterval,
                      ?maxEvents = maxEvents, dumpExternalStats = producer.DumpStats)
+   static member Start
+        (   log : ILogger, maxReadAhead, maxConcurrentStreams,
+            prepare : StreamName -> Default.StreamSpan -> Async<struct (struct (string * string) voption * 'Outcome)>,
+            producer : Producer,
+            stats : Sync.Stats<'Outcome>, statsInterval,
+            // Frequency with which to jettison Write Position information for inactive streams in order to limit memory consumption
+            // NOTE: Can impair performance and/or increase costs of writes as it inhibits the ability of the ingester to discard redundant inputs
+            ?purgeInterval,
+            // Default 1 ms
+            ?idleDelay,
+            // Default 1 MiB
+            ?maxBytes,
+            // Default 16384
+            ?maxEvents)
+        : Default.Sink =
+        StreamsProducerSink.Start(
+            log, maxReadAhead, maxConcurrentStreams,
+            (fun sn ss ct -> Async.startImmediateAsTask ct (prepare sn ss)),
+            producer, stats, statsInterval,
+            ?purgeInterval = purgeInterval,
+            ?idleDelay = idleDelay,
+            ?maxBytes = maxBytes,
+            ?maxEvents = maxEvents)
 
    static member Start
         (   log : ILogger, maxReadAhead, maxConcurrentStreams,
@@ -78,3 +101,26 @@ type StreamsProducerSink =
                      stats, statsInterval,
                      ?idleDelay = idleDelay, ?purgeInterval = purgeInterval, ?maxBytes = maxBytes,
                      ?maxEvents = maxEvents)
+   static member Start
+        (   log : ILogger, maxReadAhead, maxConcurrentStreams,
+            prepare : StreamName -> Default.StreamSpan -> Async<struct (string * string)>,
+            producer : Producer,
+            stats : Sync.Stats<unit>, statsInterval,
+            // Frequency with which to jettison Write Position information for inactive streams in order to limit memory consumption
+            // NOTE: Can impair performance and/or increase costs of writes as it inhibits the ability of the ingester to discard redundant inputs
+            ?purgeInterval,
+            // Default 1 ms
+            ?idleDelay,
+            // Default 1 MiB
+            ?maxBytes,
+            // Default 16384
+            ?maxEvents)
+        : Default.Sink =
+        StreamsProducerSink.Start(
+            log, maxReadAhead, maxConcurrentStreams,
+            (fun sn ss ct -> Async.startImmediateAsTask ct (prepare sn ss)),
+            producer, stats, statsInterval,
+            ?purgeInterval = purgeInterval,
+            ?idleDelay = idleDelay,
+            ?maxBytes = maxBytes,
+            ?maxEvents = maxEvents)

--- a/src/Propulsion.MemoryStore/MemoryStoreSource.fs
+++ b/src/Propulsion.MemoryStore/MemoryStoreSource.fs
@@ -126,3 +126,5 @@ module TimelineEvent =
 /// Supports awaiting the (asynchronous) handling by the Sink of all Committed events from a given point in time
 type MemoryStoreSource(log, store : Equinox.MemoryStore.VolatileStore<struct (int * ReadOnlyMemory<byte>)>, categoryFilter, sink) =
     inherit MemoryStoreSource<struct (int * ReadOnlyMemory<byte>)>(log, store, categoryFilter, TimelineEvent.mapEncoded, sink)
+    new (log, store, categories, sink) =
+        MemoryStoreSource(log, store, (fun x -> Array.contains x categories), sink)

--- a/src/Propulsion.SqlStreamStore/SqlStreamStoreSource.fs
+++ b/src/Propulsion.SqlStreamStore/SqlStreamStoreSource.fs
@@ -29,12 +29,15 @@ type SqlStreamStoreSource
     (   log : Serilog.ILogger, statsInterval,
         store : SqlStreamStore.IStreamStore, batchSize, tailSleepInterval,
         checkpoints : Propulsion.Feed.IFeedCheckpointStore, sink : Propulsion.Streams.Default.Sink,
-        categoryFilter : string -> bool,
+        // The whitelist of Categories to use
+        ?categories,
+        // Predicate to filter Categories to use
+        ?categoryFilter : string -> bool,
         // If the Handler does not require the Data/Meta of the events, the query to load the events can be much more efficient. Default: false
         ?withData,
         ?startFromTail,
         ?sourceId) =
     inherit Propulsion.Feed.Core.AllFeedSource
         (   log, statsInterval, defaultArg sourceId FeedSourceId.wellKnownId, tailSleepInterval,
-            Impl.readBatch (withData = Some true) batchSize categoryFilter store, checkpoints, sink,
+            Impl.readBatch (withData = Some true) batchSize (Propulsion.Feed.Core.Categories.mapFilters categories categoryFilter) store, checkpoints, sink,
             ?establishOrigin = if startFromTail <> Some true then None else Some (Impl.readTailPositionForTranche store))

--- a/src/Propulsion/Streams.fs
+++ b/src/Propulsion/Streams.fs
@@ -1206,24 +1206,14 @@ module Default =
                 ?pendingBufferSize = pendingBufferSize, ?purgeInterval = purgeInterval,
                 ?wakeForResults = wakeForResults, ?idleDelay = idleDelay, ?ingesterStatsInterval = ingesterStatsInterval,
                 ?requireCompleteStreams = requireCompleteStreams)
-
         static member Start<'Outcome>
             (   log, maxReadAhead, maxConcurrentStreams,
                 handle : FsCodec.StreamName -> StreamSpan -> Async<struct (SpanResult * 'Outcome)>,
                 stats, statsInterval,
-                // Configure max number of batches to buffer within the scheduler; Default: Same as maxReadAhead
-                [<O; D null>] ?pendingBufferSize,
-                [<O; D null>] ?purgeInterval,
-                [<O; D null>] ?wakeForResults,
-                [<O; D null>] ?idleDelay,
-                [<O; D null>] ?ingesterStatsInterval,
-                [<O; D null>] ?requireCompleteStreams) =
+                [<O; D null>] ?pendingBufferSize, [<O; D null>] ?purgeInterval, [<O; D null>] ?wakeForResults, [<O; D null>] ?idleDelay,
+                [<O; D null>] ?ingesterStatsInterval, [<O; D null>] ?requireCompleteStreams) =
             Config.Start(log, maxReadAhead, maxConcurrentStreams,
                 (fun stream span ct -> Async.startImmediateAsTask ct (handle stream span)),
                 stats, statsInterval,
-                ?pendingBufferSize = pendingBufferSize,
-                ?purgeInterval = purgeInterval,
-                ?wakeForResults = wakeForResults,
-                ?idleDelay = idleDelay,
-                ?ingesterStatsInterval = ingesterStatsInterval,
-                ?requireCompleteStreams = requireCompleteStreams)
+                ?pendingBufferSize = pendingBufferSize, ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay,
+                ?ingesterStatsInterval = ingesterStatsInterval, ?requireCompleteStreams = requireCompleteStreams)

--- a/src/Propulsion/Streams.fs
+++ b/src/Propulsion/Streams.fs
@@ -1206,3 +1206,24 @@ module Default =
                 ?pendingBufferSize = pendingBufferSize, ?purgeInterval = purgeInterval,
                 ?wakeForResults = wakeForResults, ?idleDelay = idleDelay, ?ingesterStatsInterval = ingesterStatsInterval,
                 ?requireCompleteStreams = requireCompleteStreams)
+
+        static member Start<'Outcome>
+            (   log, maxReadAhead, maxConcurrentStreams,
+                handle : FsCodec.StreamName -> StreamSpan -> Async<struct (SpanResult * 'Outcome)>,
+                stats, statsInterval,
+                // Configure max number of batches to buffer within the scheduler; Default: Same as maxReadAhead
+                [<O; D null>] ?pendingBufferSize,
+                [<O; D null>] ?purgeInterval,
+                [<O; D null>] ?wakeForResults,
+                [<O; D null>] ?idleDelay,
+                [<O; D null>] ?ingesterStatsInterval,
+                [<O; D null>] ?requireCompleteStreams) =
+            Config.Start(log, maxReadAhead, maxConcurrentStreams,
+                (fun stream span ct -> Async.startImmediateAsTask ct (handle stream span)),
+                stats, statsInterval,
+                ?pendingBufferSize = pendingBufferSize,
+                ?purgeInterval = purgeInterval,
+                ?wakeForResults = wakeForResults,
+                ?idleDelay = idleDelay,
+                ?ingesterStatsInterval = ingesterStatsInterval,
+                ?requireCompleteStreams = requireCompleteStreams)


### PR DESCRIPTION
Stragglers from #204 re MemoryStore, SqlStreamStore, EventStoreDb, Cosmos
Overloads for Async handlers for `Streams.Default.Config.Start` and `Propulsion.Kafka.StreamsProducerSink.Start`