### PR TITLE
fix: MessageDB is off-by-one when reading the category messages

### DIFF
--- a/src/Propulsion.Feed/FeedReader.fs
+++ b/src/Propulsion.Feed/FeedReader.fs
@@ -10,7 +10,13 @@ open System.Threading
 open System.Threading.Tasks
 
 [<NoComparison; NoEquality>]
-type Batch<'F> = { items : Propulsion.Streams.StreamEvent<'F>[]; checkpoint : Position; isTail : bool }
+type Batch<'F> =
+    {   items : Propulsion.Streams.StreamEvent<'F>[]
+        /// Next computed read position (inclusive). Checkpoint stores treat absence of a value as `Position.initial` (= `0`)
+        checkpoint : Position
+        /// Indicates whether the end of a feed has been reached (a batch being empty does not necessarily imply that)
+        /// Implies tail sleep delay. May trigger completion of `Monitor.AwaitCompletion`
+        isTail : bool }
 
 module internal TimelineEvent =
 

--- a/src/Propulsion.MessageDb/MessageDbSource.fs
+++ b/src/Propulsion.MessageDb/MessageDbSource.fs
@@ -38,7 +38,7 @@ module Internal =
                 index = reader.GetInt64(0), // index within the stream, 0 based
                 eventType = et, data = data, meta = meta, eventId = reader.GetGuid(4),
                 ?correlationId = readNullableString 5, ?causationId = readNullableString 6,
-                context = reader.GetInt64(9), // global_position is passed through the Context for checkpointing purposes
+                context = reader.GetInt64(9) + 1L, // global_position is passed through the Context for checkpointing purposes
                 timestamp = DateTimeOffset(DateTime.SpecifyKind(reader.GetDateTime(7), DateTimeKind.Utc)),
                 size = sz) // precomputed Size is required for stats purposes when fed to a StreamsSink
             let sn = reader.GetString(8) |> FsCodec.StreamName.parse
@@ -71,7 +71,7 @@ module Internal =
 
     let internal readBatch batchSize (store : MessageDbCategoryClient) (category, pos, ct) : Task<Core.Batch<_>> =
         let positionInclusive = Position.toInt64 pos
-        store.ReadCategoryMessages(category, positionInclusive + 1L, batchSize, ct)
+        store.ReadCategoryMessages(category, positionInclusive, batchSize, ct)
 
     let internal readTailPositionForTranche (store : MessageDbCategoryClient) trancheId ct : Task<Position> = task {
         let! lastEventPos = store.ReadCategoryLastVersion(trancheId, ct)

--- a/src/Propulsion.MessageDb/MessageDbSource.fs
+++ b/src/Propulsion.MessageDb/MessageDbSource.fs
@@ -71,7 +71,7 @@ module Internal =
 
     let internal readBatch batchSize (store : MessageDbCategoryClient) (category, pos, ct) : Task<Core.Batch<_>> =
         let positionInclusive = Position.toInt64 pos
-        store.ReadCategoryMessages(category, positionInclusive, batchSize, ct)
+        store.ReadCategoryMessages(category, positionInclusive + 1L, batchSize, ct)
 
     let internal readTailPositionForTranche (store : MessageDbCategoryClient) trancheId ct : Task<Position> = task {
         let! lastEventPos = store.ReadCategoryLastVersion(trancheId, ct)

--- a/src/Propulsion.MessageDb/MessageDbSource.fs
+++ b/src/Propulsion.MessageDb/MessageDbSource.fs
@@ -79,7 +79,7 @@ module Internal =
 
 type MessageDbSource internal
     (   log : Serilog.ILogger, statsInterval,
-        client: Internal.MessageDbCategoryClient, batchSize, tailSleepInterval,
+        client : Internal.MessageDbCategoryClient, batchSize, tailSleepInterval,
         checkpoints : Propulsion.Feed.IFeedCheckpointStore, sink : Propulsion.Streams.Default.Sink,
         tranches, ?startFromTail, ?sourceId) =
     inherit Propulsion.Feed.Core.TailingFeedSource
@@ -101,7 +101,7 @@ type MessageDbSource internal
         MessageDbSource(log, statsInterval, Internal.MessageDbCategoryClient(connectionString),
                         batchSize, tailSleepInterval, checkpoints, sink,
                         categories |> Array.map Propulsion.Feed.TrancheId.parse,
-                        ?startFromTail=startFromTail, ?sourceId=sourceId)
+                        ?startFromTail = startFromTail, ?sourceId = sourceId)
 
     abstract member ListTranches : ct : CancellationToken -> Task<Propulsion.Feed.TrancheId array>
     default _.ListTranches(_ct) = task { return tranches }

--- a/tests/Propulsion.MessageDb.Integration/Tests.fs
+++ b/tests/Propulsion.MessageDb.Integration/Tests.fs
@@ -119,20 +119,16 @@ let ``It doesn't read the tail event again`` () = task {
 
     let handle _ _ _ = task {
         return struct (Propulsion.Streams.SpanResult.AllProcessed, ()) }
-    use sink = Propulsion.Streams.Default.Config.Start(log, 2, 2, handle, stats, TimeSpan.FromMinutes 1)
+    use sink = Propulsion.Streams.Default.Config.Start(log, 10, 1, handle, stats, TimeSpan.FromMinutes 1)
     let source = MessageDbSource(
         log, TimeSpan.FromMilliseconds 10,
         connString, 1000, TimeSpan.FromMilliseconds 10,
         checkpoints, sink, [| category |])
     use src = source.Start()
 
-    let awaiter = src.Await() |> Async.StartAsTask
-
     // Fetch 3 page
     while logSink.CallCount < 3 do ()
     src.Stop()
-
-    do! awaiter
 
     test <@ logSink.Events = 20 @> }
 

--- a/tests/Propulsion.MessageDb.Integration/Tests.fs
+++ b/tests/Propulsion.MessageDb.Integration/Tests.fs
@@ -14,121 +14,215 @@ open System.Threading.Tasks
 open Xunit
 
 module Simple =
-    type Hello = { name : string}
+    type Hello = { name: string }
+
     type Event =
         | Hello of Hello
+
         interface TypeShape.UnionContract.IUnionContract
+
     let codec = FsCodec.SystemTextJson.Codec.Create<Event>()
 
 let createStreamMessage streamName =
     let cmd = NpgsqlBatchCommand()
     cmd.CommandText <- "select 1 from write_message(@Id::text, @StreamName, @EventType, @Data, null, null)"
     cmd.Parameters.AddWithValue("Id", NpgsqlDbType.Uuid, Guid.NewGuid()) |> ignore
-    cmd.Parameters.AddWithValue("StreamName", NpgsqlDbType.Text, streamName) |> ignore
+
+    cmd.Parameters.AddWithValue("StreamName", NpgsqlDbType.Text, streamName)
+    |> ignore
+
     cmd.Parameters.AddWithValue("EventType", NpgsqlDbType.Text, "Hello") |> ignore
-    cmd.Parameters.AddWithValue("Data", NpgsqlDbType.Jsonb, """{"name": "world"}""") |> ignore
+
+    cmd.Parameters.AddWithValue("Data", NpgsqlDbType.Jsonb, """{"name": "world"}""")
+    |> ignore
+
     cmd
 
-let writeMessagesToStream (conn: NpgsqlConnection) streamName = task {
-    let batch = conn.CreateBatch()
-    for _ in 1..20 do
-        let cmd = createStreamMessage streamName
-        batch.BatchCommands.Add(cmd)
-    do! batch.ExecuteNonQueryAsync() :> Task }
+let writeMessagesToStream (conn: NpgsqlConnection) streamName =
+    task {
+        let batch = conn.CreateBatch()
 
-let writeMessagesToCategory category = task {
-    use conn = new NpgsqlConnection("Host=localhost; Port=5433; Username=message_store; Password=;")
-    do! conn.OpenAsync()
-    for _ in 1..50 do
-        let streamName = $"{category}-{Guid.NewGuid():N}"
-        do! writeMessagesToStream conn streamName }
+        for _ in 1..20 do
+            let cmd = createStreamMessage streamName
+            batch.BatchCommands.Add(cmd)
 
-let stats log = { new Propulsion.Streams.Stats<_>(log, TimeSpan.FromMinutes 1, TimeSpan.FromMinutes 1)
-                  with member _.HandleOk x = ()
-                       member _.HandleExn(log, x) = () }
+        do! batch.ExecuteNonQueryAsync() :> Task
+    }
+
+let writeMessagesToCategory category =
+    task {
+        use conn =
+            new NpgsqlConnection("Host=localhost; Port=5433; Username=message_store; Password=;")
+
+        do! conn.OpenAsync()
+
+        for _ in 1..50 do
+            let streamName = $"{category}-{Guid.NewGuid():N}"
+            do! writeMessagesToStream conn streamName
+
+        do! conn.CloseAsync()
+    }
+
+let stats log =
+    { new Propulsion.Streams.Stats<_>(log, TimeSpan.FromMinutes 1, TimeSpan.FromMinutes 1) with
+        member _.HandleOk x = ()
+        member _.HandleExn(log, x) = () }
+
+let makeCheckpoints consumerGroup =
+    task {
+        let checkpoints =
+            ReaderCheckpoint.CheckpointStore(
+                "Host=localhost; Database=message_store; Port=5433; Username=postgres; Password=postgres",
+                "public",
+                $"TestGroup{consumerGroup}",
+                TimeSpan.FromSeconds 10
+            )
+
+        do! checkpoints.CreateSchemaIfNotExists()
+        return checkpoints
+    }
 
 [<Fact>]
-let ``It processes events for a category`` () = task {
-    let log = Serilog.Log.Logger
-    let consumerGroup = $"{Guid.NewGuid():N}"
-    let category1 = $"{Guid.NewGuid():N}"
-    let category2 = $"{Guid.NewGuid():N}"
-    do! writeMessagesToCategory category1
-    do! writeMessagesToCategory category2
-    let connString = "Host=localhost; Database=message_store; Port=5433; Username=message_store; Password=;"
-    let checkpoints = ReaderCheckpoint.CheckpointStore("Host=localhost; Database=message_store; Port=5433; Username=postgres; Password=postgres", "public", $"TestGroup{consumerGroup}", TimeSpan.FromSeconds 10)
-    do! checkpoints.CreateSchemaIfNotExists()
-    let stats = stats log
-    let mutable stop = ignore
-    let handled = HashSet<_>()
-    let handle stream (events: Propulsion.Streams.Default.StreamSpan) _ct = task {
-        lock handled (fun _ ->
-           for evt in events do
-               handled.Add((stream, evt.Index)) |> ignore)
-        test <@ Array.chooseV Simple.codec.TryDecode events |> Array.forall ((=) (Simple.Hello { name = "world" })) @>
-        if handled.Count >= 2000 then
-            stop ()
-        return struct (Propulsion.Streams.SpanResult.AllProcessed, ()) }
-    use sink = Propulsion.Streams.Default.Config.Start(log, 2, 2, handle, stats, TimeSpan.FromMinutes 1)
-    let source = MessageDbSource(
-        log, TimeSpan.FromMinutes 1,
-        connString, 1000, TimeSpan.FromMilliseconds 100,
-        checkpoints, sink, [| category1; category2 |])
-    use src = source.Start()
-    stop <- src.Stop
+let ``It processes events for a category`` () =
+    task {
+        let log = Serilog.Log.Logger
+        let consumerGroup = $"{Guid.NewGuid():N}"
+        let category1 = $"{Guid.NewGuid():N}"
+        let category2 = $"{Guid.NewGuid():N}"
+        do! writeMessagesToCategory category1
+        do! writeMessagesToCategory category2
 
-    Task.Delay(TimeSpan.FromSeconds 30).ContinueWith(fun _ -> src.Stop()) |> ignore
+        let connString =
+            "Host=localhost; Database=message_store; Port=5433; Username=message_store; Password=;"
 
-    do! src.Await()
+        let! checkpoints = makeCheckpoints consumerGroup
+        let stats = stats log
+        let mutable stop = ignore
+        let handled = HashSet<_>()
 
-    // 2000 total events
-    test <@ handled.Count = 2000 @>
-    // 20 in each stream
-    test <@ handled |> Array.ofSeq |> Array.groupBy fst |> Array.map (snd >> Array.length) |> Array.forall ((=) 20) @>
-    // they were handled in order within streams
-    let ordering = handled |> Seq.groupBy fst |> Seq.map (snd >> Seq.map snd >> Seq.toArray) |> Seq.toArray
-    test <@ ordering |> Array.forall ((=) [| 0L..19L |]) @> }
+        let handle stream (events: Propulsion.Streams.Default.StreamSpan) _ct =
+            task {
+                lock handled (fun _ ->
+                    for evt in events do
+                        handled.Add((stream, evt.Index)) |> ignore)
+
+                test
+                    <@
+                        Array.chooseV Simple.codec.TryDecode events
+                        |> Array.forall ((=) (Simple.Hello { name = "world" }))
+                    @>
+
+                if handled.Count >= 2000 then
+                    stop ()
+
+                return struct (Propulsion.Streams.SpanResult.AllProcessed, ())
+            }
+
+        use sink =
+            Propulsion.Streams.Default.Config.Start(log, 2, 2, handle, stats, TimeSpan.FromMinutes 1)
+
+        let source =
+            MessageDbSource(
+                log,
+                TimeSpan.FromMinutes 1,
+                connString,
+                1000,
+                TimeSpan.FromMilliseconds 100,
+                checkpoints,
+                sink,
+                [| category1; category2 |]
+            )
+
+        use src = source.Start()
+        stop <- src.Stop
+
+        Task.Delay(TimeSpan.FromSeconds 30).ContinueWith(fun _ -> src.Stop()) |> ignore
+
+        do! src.Await()
+
+        // 2000 total events
+        test <@ handled.Count = 2000 @>
+        // 20 in each stream
+        test
+            <@
+                handled
+                |> Array.ofSeq
+                |> Array.groupBy fst
+                |> Array.map (snd >> Array.length)
+                |> Array.forall ((=) 20)
+            @>
+        // they were handled in order within streams
+        let ordering =
+            handled
+            |> Seq.groupBy fst
+            |> Seq.map (snd >> Seq.map snd >> Seq.toArray)
+            |> Seq.toArray
+
+        test <@ ordering |> Array.forall ((=) [| 0L .. 19L |]) @>
+    }
 
 type LogSink() =
     let mutable items = 0
+    let mutable pages = 0
     let mutable calledTimes = 0
     member _.Events = items
     member _.CallCount = calledTimes
+    member _.Pages = pages
+
     interface ILogEventSink with
         member _.Emit(logEvent) =
             match logEvent with
             | Propulsion.Feed.Core.Log.MetricEvent (Propulsion.Feed.Core.Log.Metric.Read r) ->
                 calledTimes <- calledTimes + 1
                 items <- items + r.items
+                pages <- pages + r.pages
             | _ -> ()
 
 [<Fact>]
-let ``It doesn't read the tail event again`` () = task {
-    let logSink = LogSink()
-    let log = LoggerConfiguration().WriteTo.Sink(logSink).CreateLogger()
-    let consumerGroup = $"{Guid.NewGuid():N}"
-    let category = $"{Guid.NewGuid():N}"
-    let connString = "Host=localhost; Database=message_store; Port=5433; Username=message_store; Password=;"
-    use conn = new NpgsqlConnection(connString)
-    do! conn.OpenAsync()
-    do! writeMessagesToStream conn $"{category}-1"
-    do! conn.CloseAsync()
-    let checkpoints = ReaderCheckpoint.CheckpointStore("Host=localhost; Database=message_store; Port=5433; Username=postgres; Password=postgres", "public", $"TestGroup{consumerGroup}", TimeSpan.FromSeconds 10)
-    do! checkpoints.CreateSchemaIfNotExists()
-    let stats = stats log
+let ``It doesn't read the tail event again`` () =
+    task {
+        let logSink = LogSink()
+        let log = LoggerConfiguration().WriteTo.Sink(logSink).CreateLogger()
+        let consumerGroup = $"{Guid.NewGuid():N}"
+        let category = $"{Guid.NewGuid():N}"
 
-    let handle _ _ _ = task {
-        return struct (Propulsion.Streams.SpanResult.AllProcessed, ()) }
-    use sink = Propulsion.Streams.Default.Config.Start(log, 10, 1, handle, stats, TimeSpan.FromMinutes 1)
-    let source = MessageDbSource(
-        log, TimeSpan.FromMilliseconds 10,
-        connString, 1000, TimeSpan.FromMilliseconds 10,
-        checkpoints, sink, [| category |])
-    use src = source.Start()
+        let connString =
+            "Host=localhost; Database=message_store; Port=5433; Username=message_store; Password=;"
 
-    // Fetch 3 page
-    while logSink.CallCount < 3 do ()
-    src.Stop()
+        use conn = new NpgsqlConnection(connString)
+        do! conn.OpenAsync()
+        do! writeMessagesToStream conn $"{category}-1"
+        do! conn.CloseAsync()
+        let! checkpoints = makeCheckpoints consumerGroup
 
-    test <@ logSink.Events = 20 @> }
+        let stats = stats log
 
+        let handle _ _ _ =
+            task { return struct (Propulsion.Streams.SpanResult.AllProcessed, ()) }
+
+        use sink =
+            Propulsion.Streams.Default.Config.Start(log, 10, 1, handle, stats, TimeSpan.FromMinutes 1)
+
+        let source =
+            MessageDbSource(
+                log,
+                TimeSpan.FromMilliseconds 10,
+                connString,
+                10,
+                TimeSpan.FromMilliseconds 10,
+                checkpoints,
+                sink,
+                [| category |]
+            )
+
+        use src = source.Start()
+
+        // Fetch 3 page
+        while logSink.CallCount < 3 do
+            ()
+
+        src.Stop()
+
+        test <@ logSink.Events = 20 @>
+        test <@ logSink.Pages = 2 @>
+    }

--- a/tests/Propulsion.MessageDb.Integration/Tests.fs
+++ b/tests/Propulsion.MessageDb.Integration/Tests.fs
@@ -14,161 +14,94 @@ open System.Threading.Tasks
 open Xunit
 
 module Simple =
-    type Hello = { name: string }
-
+    type Hello = { name : string}
     type Event =
         | Hello of Hello
-
         interface TypeShape.UnionContract.IUnionContract
-
     let codec = FsCodec.SystemTextJson.Codec.Create<Event>()
 
 let createStreamMessage streamName =
     let cmd = NpgsqlBatchCommand()
     cmd.CommandText <- "select 1 from write_message(@Id::text, @StreamName, @EventType, @Data, null, null)"
     cmd.Parameters.AddWithValue("Id", NpgsqlDbType.Uuid, Guid.NewGuid()) |> ignore
-
-    cmd.Parameters.AddWithValue("StreamName", NpgsqlDbType.Text, streamName)
-    |> ignore
-
+    cmd.Parameters.AddWithValue("StreamName", NpgsqlDbType.Text, streamName) |> ignore
     cmd.Parameters.AddWithValue("EventType", NpgsqlDbType.Text, "Hello") |> ignore
-
-    cmd.Parameters.AddWithValue("Data", NpgsqlDbType.Jsonb, """{"name": "world"}""")
-    |> ignore
-
+    cmd.Parameters.AddWithValue("Data", NpgsqlDbType.Jsonb, """{"name": "world"}""") |> ignore
     cmd
 
-let writeMessagesToStream (conn: NpgsqlConnection) streamName =
-    task {
-        let batch = conn.CreateBatch()
+let writeMessagesToStream (conn: NpgsqlConnection) streamName = task {
+    let batch = conn.CreateBatch()
+    for _ in 1..20 do
+        let cmd = createStreamMessage streamName
+        batch.BatchCommands.Add(cmd)
+    do! batch.ExecuteNonQueryAsync() :> Task }
 
-        for _ in 1..20 do
-            let cmd = createStreamMessage streamName
-            batch.BatchCommands.Add(cmd)
+let writeMessagesToCategory category = task {
+    use conn = new NpgsqlConnection("Host=localhost; Port=5433; Username=message_store; Password=;")
+    do! conn.OpenAsync()
+    for _ in 1..50 do
+        let streamName = $"{category}-{Guid.NewGuid():N}"
+        do! writeMessagesToStream conn streamName
+    do! conn.CloseAsync()
+}
 
-        do! batch.ExecuteNonQueryAsync() :> Task
-    }
+let stats log = { new Propulsion.Streams.Stats<_>(log, TimeSpan.FromMinutes 1, TimeSpan.FromMinutes 1)
+                  with member _.HandleOk x = ()
+                       member _.HandleExn(log, x) = () }
 
-let writeMessagesToCategory category =
-    task {
-        use conn =
-            new NpgsqlConnection("Host=localhost; Port=5433; Username=message_store; Password=;")
-
-        do! conn.OpenAsync()
-
-        for _ in 1..50 do
-            let streamName = $"{category}-{Guid.NewGuid():N}"
-            do! writeMessagesToStream conn streamName
-
-        do! conn.CloseAsync()
-    }
-
-let stats log =
-    { new Propulsion.Streams.Stats<_>(log, TimeSpan.FromMinutes 1, TimeSpan.FromMinutes 1) with
-        member _.HandleOk x = ()
-        member _.HandleExn(log, x) = () }
-
-let makeCheckpoints consumerGroup =
-    task {
-        let checkpoints =
-            ReaderCheckpoint.CheckpointStore(
-                "Host=localhost; Database=message_store; Port=5433; Username=postgres; Password=postgres",
-                "public",
-                $"TestGroup{consumerGroup}",
-                TimeSpan.FromSeconds 10
-            )
-
-        do! checkpoints.CreateSchemaIfNotExists()
-        return checkpoints
-    }
-
+let makeCheckpoints () = task {
+    let checkpoints = ReaderCheckpoint.CheckpointStore("Host=localhost; Database=message_store; Port=5433; Username=postgres; Password=postgres", "public", $"TestGroup{consumerGroup}", TimeSpan.FromSeconds 10)
+    do! checkpoints.CreateSchemaIfNotExists()
+    return checkpoints
+}
 [<Fact>]
-let ``It processes events for a category`` () =
-    task {
-        let log = Serilog.Log.Logger
-        let consumerGroup = $"{Guid.NewGuid():N}"
-        let category1 = $"{Guid.NewGuid():N}"
-        let category2 = $"{Guid.NewGuid():N}"
-        do! writeMessagesToCategory category1
-        do! writeMessagesToCategory category2
+let ``It processes events for a category`` () = task {
+    let log = Serilog.Log.Logger
+    let consumerGroup = $"{Guid.NewGuid():N}"
+    let category1 = $"{Guid.NewGuid():N}"
+    let category2 = $"{Guid.NewGuid():N}"
+    do! writeMessagesToCategory category1
+    do! writeMessagesToCategory category2
+    let connString = "Host=localhost; Database=message_store; Port=5433; Username=message_store; Password=;"
+    let! checkpoints = makeCheckpoints ()
+    let stats = stats log
+    let mutable stop = ignore
+    let handled = HashSet<_>()
+    let handle stream (events: Propulsion.Streams.Default.StreamSpan) _ct = task {
+        lock handled (fun _ ->
+           for evt in events do
+               handled.Add((stream, evt.Index)) |> ignore)
+        test <@ Array.chooseV Simple.codec.TryDecode events |> Array.forall ((=) (Simple.Hello { name = "world" })) @>
+        if handled.Count >= 2000 then
+            stop ()
+        return struct (Propulsion.Streams.SpanResult.AllProcessed, ()) }
+    use sink = Propulsion.Streams.Default.Config.Start(log, 2, 2, handle, stats, TimeSpan.FromMinutes 1)
+    let source = MessageDbSource(
+        log, TimeSpan.FromMinutes 1,
+        connString, 1000, TimeSpan.FromMilliseconds 100,
+        checkpoints, sink, [| category1; category2 |])
+    use src = source.Start()
+    stop <- src.Stop
 
-        let connString =
-            "Host=localhost; Database=message_store; Port=5433; Username=message_store; Password=;"
+    Task.Delay(TimeSpan.FromSeconds 30).ContinueWith(fun _ -> src.Stop()) |> ignore
 
-        let! checkpoints = makeCheckpoints consumerGroup
-        let stats = stats log
-        let mutable stop = ignore
-        let handled = HashSet<_>()
+    do! src.Await()
 
-        let handle stream (events: Propulsion.Streams.Default.StreamSpan) _ct =
-            task {
-                lock handled (fun _ ->
-                    for evt in events do
-                        handled.Add((stream, evt.Index)) |> ignore)
-
-                test
-                    <@
-                        Array.chooseV Simple.codec.TryDecode events
-                        |> Array.forall ((=) (Simple.Hello { name = "world" }))
-                    @>
-
-                if handled.Count >= 2000 then
-                    stop ()
-
-                return struct (Propulsion.Streams.SpanResult.AllProcessed, ())
-            }
-
-        use sink =
-            Propulsion.Streams.Default.Config.Start(log, 2, 2, handle, stats, TimeSpan.FromMinutes 1)
-
-        let source =
-            MessageDbSource(
-                log,
-                TimeSpan.FromMinutes 1,
-                connString,
-                1000,
-                TimeSpan.FromMilliseconds 100,
-                checkpoints,
-                sink,
-                [| category1; category2 |]
-            )
-
-        use src = source.Start()
-        stop <- src.Stop
-
-        Task.Delay(TimeSpan.FromSeconds 30).ContinueWith(fun _ -> src.Stop()) |> ignore
-
-        do! src.Await()
-
-        // 2000 total events
-        test <@ handled.Count = 2000 @>
-        // 20 in each stream
-        test
-            <@
-                handled
-                |> Array.ofSeq
-                |> Array.groupBy fst
-                |> Array.map (snd >> Array.length)
-                |> Array.forall ((=) 20)
-            @>
-        // they were handled in order within streams
-        let ordering =
-            handled
-            |> Seq.groupBy fst
-            |> Seq.map (snd >> Seq.map snd >> Seq.toArray)
-            |> Seq.toArray
-
-        test <@ ordering |> Array.forall ((=) [| 0L .. 19L |]) @>
-    }
+    // 2000 total events
+    test <@ handled.Count = 2000 @>
+    // 20 in each stream
+    test <@ handled |> Array.ofSeq |> Array.groupBy fst |> Array.map (snd >> Array.length) |> Array.forall ((=) 20) @>
+    // they were handled in order within streams
+    let ordering = handled |> Seq.groupBy fst |> Seq.map (snd >> Seq.map snd >> Seq.toArray) |> Seq.toArray
+    test <@ ordering |> Array.forall ((=) [| 0L..19L |]) @> }
 
 type LogSink() =
     let mutable items = 0
     let mutable pages = 0
     let mutable calledTimes = 0
     member _.Events = items
-    member _.CallCount = calledTimes
     member _.Pages = pages
-
+    member _.CallCount = calledTimes
     interface ILogEventSink with
         member _.Emit(logEvent) =
             match logEvent with
@@ -179,50 +112,33 @@ type LogSink() =
             | _ -> ()
 
 [<Fact>]
-let ``It doesn't read the tail event again`` () =
-    task {
-        let logSink = LogSink()
-        let log = LoggerConfiguration().WriteTo.Sink(logSink).CreateLogger()
-        let consumerGroup = $"{Guid.NewGuid():N}"
-        let category = $"{Guid.NewGuid():N}"
+let ``It doesn't read the tail event again`` () = task {
+    let logSink = LogSink()
+    let log = LoggerConfiguration().WriteTo.Sink(logSink).CreateLogger()
+    let consumerGroup = $"{Guid.NewGuid():N}"
+    let category = $"{Guid.NewGuid():N}"
+    let connString = "Host=localhost; Database=message_store; Port=5433; Username=message_store; Password=;"
+    use conn = new NpgsqlConnection(connString)
+    do! conn.OpenAsync()
+    do! writeMessagesToStream conn $"{category}-1"
+    do! conn.CloseAsync()
+    let! checkpoints = makeCheckpoints ()
 
-        let connString =
-            "Host=localhost; Database=message_store; Port=5433; Username=message_store; Password=;"
+    let stats = stats log
 
-        use conn = new NpgsqlConnection(connString)
-        do! conn.OpenAsync()
-        do! writeMessagesToStream conn $"{category}-1"
-        do! conn.CloseAsync()
-        let! checkpoints = makeCheckpoints consumerGroup
+    let handle _ _ _ = task {
+        return struct (Propulsion.Streams.SpanResult.AllProcessed, ()) }
+    use sink = Propulsion.Streams.Default.Config.Start(log, 10, 1, handle, stats, TimeSpan.FromMinutes 1)
+    let source = MessageDbSource(
+        log, TimeSpan.FromMilliseconds 10,
+        connString, 1000, TimeSpan.FromMilliseconds 10,
+        checkpoints, sink, [| category |])
+    use src = source.Start()
 
-        let stats = stats log
+    // Fetch 3 page
+    while logSink.CallCount < 3 do ()
+    src.Stop()
 
-        let handle _ _ _ =
-            task { return struct (Propulsion.Streams.SpanResult.AllProcessed, ()) }
+    test <@ logSink.Events = 20 @>
+    test <@ logSink.Pages = 2 @> }
 
-        use sink =
-            Propulsion.Streams.Default.Config.Start(log, 10, 1, handle, stats, TimeSpan.FromMinutes 1)
-
-        let source =
-            MessageDbSource(
-                log,
-                TimeSpan.FromMilliseconds 10,
-                connString,
-                10,
-                TimeSpan.FromMilliseconds 10,
-                checkpoints,
-                sink,
-                [| category |]
-            )
-
-        use src = source.Start()
-
-        // Fetch 3 page
-        while logSink.CallCount < 3 do
-            ()
-
-        src.Stop()
-
-        test <@ logSink.Events = 20 @>
-        test <@ logSink.Pages = 2 @>
-    }


### PR DESCRIPTION
This meant that the read logic was re-reading the final event of the preceding batch
(In the case of the tail batch, that resulted in a single item batch being loaded and parsed each time, with incorrect statistics and tail sleeps as `isTail` will perpetually be `false`)