### PR TITLE
cleanup some task usage

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,7 @@
     <!-- suppress false positive warning FS2003 about invalid version of AssemblyInformationalVersionAttribute -->
     <!-- supress NU5105 triggered by trailing dotted elements such as .43 and .2 in e.g.: pr.43-rc1.2: The package version '<X>' uses SemVer 2.0.0 or components of SemVer 1.0.0 that are not supported on legacy clients. Change the package version to a SemVer 1.0.0 string. If the version contains a release label it must start with a letter. This message can be ignored if the package is not intended for older clients. -->
     <NoWarn>$(NoWarn);FS2003;NU5105</NoWarn>
+    <WarningsAsErrors>true</WarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <!-- SourceLink etc -->

--- a/src/Propulsion.DynamoStore/DynamoStoreSource.fs
+++ b/src/Propulsion.DynamoStore/DynamoStoreSource.fs
@@ -209,5 +209,5 @@ type DynamoStoreSource
 
             if sw.ElapsedSeconds > 2 then statsInterval.Trigger()
             // force a final attempt to flush anything not already checkpointed (normally checkpointing is at 5s intervals)
-            return! x.Checkpoint()
+            return! x.Checkpoint(CancellationToken.None)
         finally statsInterval.SleepUntilTriggerCleared() }

--- a/src/Propulsion.Feed/FeedSource.fs
+++ b/src/Propulsion.Feed/FeedSource.fs
@@ -61,7 +61,7 @@ type FeedSourceBase internal
             let reader = FeedReader(log, partitionId, sourceId, trancheId, crawl trancheId, ingest, checkpoints.Commit, renderPos,
                                     ?logCommitFailure = logCommitFailure, ?awaitIngesterShutdown = awaitIngester)
             ingester, reader)
-        pumpStats ct |> ignore
+        pumpStats ct |> ignore // loops in background until overall pumping is cancelled
         let trancheWorkflows = (tranches, partitions) ||> Seq.mapi2 pumpPartition
         do! Task.parallelUnlimited ct trancheWorkflows |> Task.ignore<unit[]>
         do! x.Checkpoint(ct) |> Task.ignore }

--- a/src/Propulsion.Feed/FeedSource.fs
+++ b/src/Propulsion.Feed/FeedSource.fs
@@ -31,7 +31,7 @@ type FeedSourceBase internal
     let mutable partitions = Array.empty<struct(Ingestion.Ingester<_> * FeedReader)>
     let dumpStats () = for _i, r in partitions do r.DumpStats()
     let rec pumpStats ct : Task = task {
-        try do! Task.Delay(statsInterval, ct)
+        try do! Task.delay statsInterval ct
         finally dumpStats () // finally is so we do a final write after we are cancelled, which would otherwise stop us after the Async.Sleep
         return! pumpStats ct }
 

--- a/src/Propulsion.Feed/FeedSource.fs
+++ b/src/Propulsion.Feed/FeedSource.fs
@@ -32,7 +32,7 @@ type FeedSourceBase internal
     let dumpStats () = for _i, r in partitions do r.DumpStats()
     let rec pumpStats ct : Task = task {
         try do! Task.delay statsInterval ct
-        finally dumpStats () // finally is so we do a final write after we are cancelled, which would otherwise stop us after the Async.Sleep
+        finally dumpStats () // finally is so we do a final write after we are cancelled, which would otherwise stop us after the sleep
         return! pumpStats ct }
 
     member val internal Positions = positions

--- a/src/Propulsion.Feed/FeedSource.fs
+++ b/src/Propulsion.Feed/FeedSource.fs
@@ -30,17 +30,17 @@ type FeedSourceBase internal
         finally ingester.Stop() }
     let mutable partitions = Array.empty<struct(Ingestion.Ingester<_> * FeedReader)>
     let dumpStats () = for _i, r in partitions do r.DumpStats()
-    let rec pumpStats () = async {
-        try do! Async.Sleep statsInterval
+    let rec pumpStats ct : Task = task {
+        try do! Task.Delay(statsInterval, ct)
         finally dumpStats () // finally is so we do a final write after we are cancelled, which would otherwise stop us after the Async.Sleep
-        return! pumpStats () }
+        return! pumpStats ct }
 
     member val internal Positions = positions
 
     /// Runs checkpointing functions for any batches with unwritten checkpoints
     /// Yields current Tranche Positions
-    member _.Checkpoint([<O; D null>]?ct) : Task<IReadOnlyDictionary<TrancheId, Position>> = task {
-        do! Task.parallelLimit 4 (defaultArg ct CancellationToken.None) (seq { for i, _r in partitions -> i.FlushProgress }) |> Task.ignore<unit[]>
+    member _.Checkpoint(ct) : Task<IReadOnlyDictionary<TrancheId, Position>> = task {
+        do! Task.parallelLimit 4 ct (seq { for i, _r in partitions -> i.FlushProgress }) |> Task.ignore<unit[]>
         return positions.Completed() }
 
     /// Propagates exceptions raised by <c>readTranches</c> or <c>crawl</c>,
@@ -61,11 +61,9 @@ type FeedSourceBase internal
             let reader = FeedReader(log, partitionId, sourceId, trancheId, crawl trancheId, ingest, checkpoints.Commit, renderPos,
                                     ?logCommitFailure = logCommitFailure, ?awaitIngesterShutdown = awaitIngester)
             ingester, reader)
-        // This will get cancelled as we exit in the case where everything is drained (or, in the exception case)
-        let! _stats = pumpStats () |> Async.StartChild
-        let trancheWorkflows = (tranches, partitions) ||> Seq.mapi2 pumpPartition
-        do! Task.parallelUnlimited ct trancheWorkflows |> Task.ignore<unit[]>
-        do! x.Checkpoint() |> Task.ignore }
+        pumpStats ct |> ignore
+        do! (tranches, partitions) ||> Array.mapi2 pumpPartition |> Task.parallelUnlimited ct |> Task.ignore<unit[]>
+        do! x.Checkpoint(ct) |> Task.ignore }
 
     member x.Start(pump) =
         let ct, stop =

--- a/src/Propulsion.Feed/FeedSource.fs
+++ b/src/Propulsion.Feed/FeedSource.fs
@@ -62,7 +62,8 @@ type FeedSourceBase internal
                                     ?logCommitFailure = logCommitFailure, ?awaitIngesterShutdown = awaitIngester)
             ingester, reader)
         pumpStats ct |> ignore
-        do! (tranches, partitions) ||> Array.mapi2 pumpPartition |> Task.parallelUnlimited ct |> Task.ignore<unit[]>
+        let trancheWorkflows = (tranches, partitions) ||> Seq.mapi2 pumpPartition
+        do! Task.parallelUnlimited ct trancheWorkflows |> Task.ignore<unit[]>
         do! x.Checkpoint(ct) |> Task.ignore }
 
     member x.Start(pump) =

--- a/src/Propulsion.Kafka/Consumers.fs
+++ b/src/Propulsion.Kafka/Consumers.fs
@@ -160,7 +160,7 @@ type ParallelConsumer private () =
         let mapBatch onCompletion (x : Submission.Batch<_, _>) : struct (unit * Parallel.Scheduling.Batch<_, 'Msg>) =
             let onCompletion' () = x.onCompletion(); onCompletion()
             (), { partitionId = x.partitionId; messages = x.messages; onCompletion = onCompletion'; }
-        let alwaysReady _ : ValueTask<bool> = ValueTask.FromResult(true)
+        let alwaysReady _ = Task.CompletedTask
         let submitBatch (x : Parallel.Scheduling.Batch<_, _>) : int voption =
             scheduler.Submit x
             ValueSome x.messages.Length

--- a/src/Propulsion.MessageDb/MessageDbSource.fs
+++ b/src/Propulsion.MessageDb/MessageDbSource.fs
@@ -123,5 +123,5 @@ type MessageDbSource internal
 
             if sw.ElapsedSeconds > 2 then statsInterval.Trigger()
             // force a final attempt to flush anything not already checkpointed (normally checkpointing is at 5s intervals)
-            return! x.Checkpoint()
+            return! x.Checkpoint(CancellationToken.None)
         finally statsInterval.SleepUntilTriggerCleared() }

--- a/src/Propulsion/Internal.fs
+++ b/src/Propulsion/Internal.fs
@@ -1,6 +1,7 @@
 module Propulsion.Internal
 
 open System
+open System.Threading.Tasks
 
 module TimeSpan =
 
@@ -63,10 +64,10 @@ module Channel =
     let unboundedSw<'t> = Channel.CreateUnbounded<'t>(UnboundedChannelOptions(SingleWriter = true))
     let unboundedSwSr<'t> = Channel.CreateUnbounded<'t>(UnboundedChannelOptions(SingleWriter = true, SingleReader = true))
     let boundedSw<'t> c = Channel.CreateBounded<'t>(BoundedChannelOptions(c, SingleWriter = true))
-    let waitToWrite (w : ChannelWriter<_>) ct = w.WaitToWriteAsync(ct)
+    let waitToWrite (w : ChannelWriter<_>) ct = w.WaitToWriteAsync(ct).AsTask() :> Task
     let tryWrite (w : ChannelWriter<_>) = w.TryWrite
     let write (w : ChannelWriter<_>) = w.TryWrite >> ignore
-    let inline awaitRead (r : ChannelReader<_>) ct = let vt = r.WaitToReadAsync(ct) in vt.AsTask()
+    let inline awaitRead (r : ChannelReader<_>) ct = r.WaitToReadAsync(ct).AsTask()
     let inline tryRead (r : ChannelReader<_>) () =
         let mutable msg = Unchecked.defaultof<_>
         if r.TryRead(&msg) then ValueSome msg else ValueNone

--- a/src/Propulsion/Parallel.fs
+++ b/src/Propulsion/Parallel.fs
@@ -206,8 +206,7 @@ type Factory private () =
         let mapBatch onCompletion (x : Submission.Batch<_, 'Item>) : struct (unit * Scheduling.Batch<_, 'Item>) =
             let onCompletion () = x.onCompletion(); onCompletion()
             (), { partitionId = x.partitionId; onCompletion = onCompletion; messages = x.messages}
-        let trueTask = ValueTask.FromResult(true)
-        let alwaysReady _ : ValueTask<bool> = trueTask
+        let alwaysReady _  = Task.CompletedTask
         let submitBatch (x : Scheduling.Batch<_, 'Item>) : int voption =
             scheduler.Submit x
             ValueSome 0

--- a/src/Propulsion/Submission.fs
+++ b/src/Propulsion/Submission.fs
@@ -59,7 +59,7 @@ type SubmissionEngine<'P, 'M, 'S, 'B when 'P : equality>
     (   log : ILogger, statsInterval,
         mapBatch : (unit -> unit) -> Batch<'P, 'M> -> struct ('S * 'B),
         submitStreams : 'S -> unit, // We continually submit the spans of events as we receive them, in order to minimise handler invocations required
-        waitToSubmitBatch : CancellationToken -> ValueTask<bool>, // We continually fill the target to the degree possible. When full, we sleep until capacity is released on completion
+        waitToSubmitBatch : CancellationToken -> Task, // We continually fill the target to the degree possible. When full, we sleep until capacity is released on completion
         trySubmitBatch : 'B -> int voption) = // batches are submitted just in time in order to balance progress across partitions
     let stats = Stats<'P>(log, statsInterval)
     let buffer = Dictionary<'P, PartitionQueue<'B>>()
@@ -116,7 +116,7 @@ type SubmissionEngine<'P, 'M, 'S, 'B when 'P : equality>
             stats.RecordCycle()
             if stats.Interval.IfDueRestart() then stats.Dump(queueStats)
             let cts = CancellationTokenSource.CreateLinkedTokenSource(ct)
-            do! Task.WhenAny[| if awaitCapacity then let vt = waitToSubmitBatch cts.Token in vt.AsTask() :> Task
+            do! Task.WhenAny[| if awaitCapacity then waitToSubmitBatch cts.Token
                                awaitIncoming cts.Token :> Task
                                Task.Delay(stats.Interval.RemainingMs, cts.Token) |] :> Task
             cts.Cancel() }

--- a/tests/Propulsion.Tests/SourceTests.fs
+++ b/tests/Propulsion.Tests/SourceTests.fs
@@ -6,6 +6,7 @@ open Propulsion.Internal
 open Serilog
 open Swensen.Unquote
 open System
+open System.Threading
 open Xunit
 
 type Scenario(testOutput) =
@@ -34,7 +35,7 @@ type Scenario(testOutput) =
         // source runs until someone explicitly stops it, or it throws
         src.Stop()
         // TailingFeedSource does not implicitly wait for completion or flush
-        do! source.Checkpoint() |> Task.ignore
+        do! source.Checkpoint(CancellationToken.None) |> Task.ignore
         // Yields source exception, if any
         do! src.Await()
         test <@ src.RanToCompletion @> }


### PR DESCRIPTION
- We had a stray `Async.StartAsChild` inside a `task` computation expression
- We were passing a `ValueTask<bool>` where what we wanted was a `Task`