### PR TITLE
fix: Add a 'use' around linked cancellation tokens

### DIFF
--- a/src/Propulsion/Ingestion.fs
+++ b/src/Propulsion/Ingestion.fs
@@ -127,7 +127,7 @@ type Ingester<'Items> private
             while applyIncoming handleIncoming || applyMessages stats.Handle do ()
             stats.RecordCycle()
             if stats.Interval.IfDueRestart() then let struct (active, max) = maxRead.State in stats.DumpStats(active, max)
-            let cts = CancellationTokenSource.CreateLinkedTokenSource(ct)
+            use cts = CancellationTokenSource.CreateLinkedTokenSource(ct)
             do! Task.WhenAny(awaitIncoming cts.Token, awaitMessage cts.Token, Task.Delay(stats.Interval.RemainingMs, cts.Token)) :> Task
             cts.Cancel() }
 

--- a/src/Propulsion/Streams.fs
+++ b/src/Propulsion/Streams.fs
@@ -770,12 +770,12 @@ module Scheduling =
                     let waitForIncomingBatches = hasCapacity
                     let waitForDispatcherCapacity = not hasCapacity && not wakeForResults
                     let sleepTs = Stopwatch.timestamp ()
-                    let cts = CancellationTokenSource.CreateLinkedTokenSource(ct)
+                    use cts = CancellationTokenSource.CreateLinkedTokenSource(ct)
                     let wakeConditions : Task[] = [|
                         if wakeForResults then awaitResults cts.Token
                         elif waitForDispatcherCapacity then dispatcher.AwaitCapacity(cts.Token)
                         if waitForIncomingBatches then awaitPending cts.Token
-                        Task.Delay(int sleepIntervalMs, cts.Token) |]
+                        Task.Delay(sleepIntervalMs, cts.Token) |]
                     do! Task.WhenAny(wakeConditions) :> Task
                     cts.Cancel()
                     t.RecordSleep sleepTs

--- a/src/Propulsion/Submission.fs
+++ b/src/Propulsion/Submission.fs
@@ -115,7 +115,7 @@ type SubmissionEngine<'P, 'M, 'S, 'B when 'P : equality>
             while tryPropagate () |> shouldLoop do ()
             stats.RecordCycle()
             if stats.Interval.IfDueRestart() then stats.Dump(queueStats)
-            let cts = CancellationTokenSource.CreateLinkedTokenSource(ct)
+            use cts = CancellationTokenSource.CreateLinkedTokenSource(ct)
             do! Task.WhenAny[| if awaitCapacity then waitToSubmitBatch cts.Token
                                awaitIncoming cts.Token :> Task
                                Task.Delay(stats.Interval.RemainingMs, cts.Token) |] :> Task


### PR DESCRIPTION
I noticed that a lot of the objects that were surviving in my memory leak repro were CancellationTokenSources

![image](https://github.com/jet/propulsion/assets/3721521/2059ecca-61be-44ee-a2a6-cc320f773fc0)

Adding a use seems to solve for our memory leak

## Before
![Before](https://github.com/jet/propulsion/assets/3721521/54c7ca77-65d2-41c0-92ed-930261b615e7)

## After
![After](https://github.com/jet/propulsion/assets/3721521/301a6bf1-6010-4c4c-9b12-e2e998dea9c0)


See this related stack overflow https://stackoverflow.com/questions/6960520/when-to-dispose-cancellationtokensource