### PR TITLE
DynamoStore: Handle removal of "a" fields from calves

### DIFF
--- a/src/Propulsion.CosmosStore/Propulsion.CosmosStore.fsproj
+++ b/src/Propulsion.CosmosStore/Propulsion.CosmosStore.fsproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="MinVer" Version="4.2.0" PrivateAssets="All" />
 
-    <PackageReference Include="Equinox.CosmosStore" Version="4.0.0-rc.11.2" />
+    <PackageReference Include="Equinox.CosmosStore" Version="4.0.0-rc.12" />
     <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.0-rc.10" />
   </ItemGroup>
 

--- a/src/Propulsion.DynamoStore/Propulsion.DynamoStore.fsproj
+++ b/src/Propulsion.DynamoStore/Propulsion.DynamoStore.fsproj
@@ -22,7 +22,7 @@
     <ItemGroup>
       <PackageReference Include="MinVer" Version="4.2.0" PrivateAssets="All" />
 
-      <PackageReference Include="Equinox.DynamoStore" Version="4.0.0-pr.401.rc.11.3" />
+      <PackageReference Include="Equinox.DynamoStore" Version="4.0.0-rc.11.6" />
       <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.0-rc.10" />
     </ItemGroup>
     

--- a/src/Propulsion.DynamoStore/Propulsion.DynamoStore.fsproj
+++ b/src/Propulsion.DynamoStore/Propulsion.DynamoStore.fsproj
@@ -22,7 +22,7 @@
     <ItemGroup>
       <PackageReference Include="MinVer" Version="4.2.0" PrivateAssets="All" />
 
-      <PackageReference Include="Equinox.DynamoStore" Version="4.0.0-rc.11.2" />
+      <PackageReference Include="Equinox.DynamoStore" Version="4.0.0-pr.401.rc.11.3" />
       <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.0-rc.10" />
     </ItemGroup>
     

--- a/src/Propulsion.DynamoStore/Propulsion.DynamoStore.fsproj
+++ b/src/Propulsion.DynamoStore/Propulsion.DynamoStore.fsproj
@@ -22,7 +22,7 @@
     <ItemGroup>
       <PackageReference Include="MinVer" Version="4.2.0" PrivateAssets="All" />
 
-      <PackageReference Include="Equinox.DynamoStore" Version="4.0.0-rc.11.6" />
+      <PackageReference Include="Equinox.DynamoStore" Version="4.0.0-rc.12" />
       <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.0-rc.10" />
     </ItemGroup>
     

--- a/src/Propulsion.EventStore/Propulsion.EventStore.fsproj
+++ b/src/Propulsion.EventStore/Propulsion.EventStore.fsproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="MinVer" Version="4.2.0" PrivateAssets="All" />
 
-    <PackageReference Include="Equinox.EventStore" Version="4.0.0-rc.11.2" />
+    <PackageReference Include="Equinox.EventStore" Version="4.0.0-rc.12" />
     <PackageReference Include="FsCodec.Box" Version="3.0.0-rc.10" />
   </ItemGroup>
 

--- a/src/Propulsion.EventStoreDb/Propulsion.EventStoreDb.fsproj
+++ b/src/Propulsion.EventStoreDb/Propulsion.EventStoreDb.fsproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="MinVer" Version="4.2.0" PrivateAssets="All" />
 
-    <PackageReference Include="Equinox.EventStoreDb" Version="4.0.0-rc.11.2" />
+    <PackageReference Include="Equinox.EventStoreDb" Version="4.0.0-rc.12" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Propulsion.MemoryStore/Propulsion.MemoryStore.fsproj
+++ b/src/Propulsion.MemoryStore/Propulsion.MemoryStore.fsproj
@@ -19,7 +19,7 @@
     <PackageReference Include="MinVer" Version="4.2.0" PrivateAssets="All" />
 
     <PackageReference Include="FsCodec.Box" Version="3.0.0-rc.10" />
-    <PackageReference Include="Equinox.MemoryStore" Version="4.0.0-rc.11.2" />
+    <PackageReference Include="Equinox.MemoryStore" Version="4.0.0-rc.12" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
As of https://github.com/jet/equinox/pull/401
- non-Tip batches no longer bear an `"a"` field (as all writes must feed through Tip to guarantee correct arrival order for Indexer etc)
- Indexer needs to be using same in order for it in turn to be able to guarantee same for the Notifier

Technically, the existing code would continue to work, but an out of date version would mean the Notifier cannot be trusted where the Index writes are not guaranteed to have been fed through tip.

Hence this intentional breaking change is to force people to upgrade Indexers to latest to match the Equinox behavior.