### PR TITLE
remove frequency from checkpointer.Start interface

### DIFF
--- a/src/Propulsion.CosmosStore/ReaderCheckpoint.fs
+++ b/src/Propulsion.CosmosStore/ReaderCheckpoint.fs
@@ -96,9 +96,9 @@ let decideStart establishOrigin at freq state = async {
     | Fold.NotStarted ->
         let! origin = establishOrigin
         let config, checkpoint = mk at freq origin
-        return struct (configFreq config, checkpoint.pos), [Events.Started { config = config; origin = checkpoint}]
+        return checkpoint.pos, [Events.Started { config = config; origin = checkpoint}]
     | Fold.Running s ->
-        return (configFreq s.config, s.state.pos), [] }
+        return s.state.pos, [] }
 
 let decideOverride at (freq : TimeSpan) pos = function
     | Fold.Running s when s.state.pos = pos && s.config.checkpointFreqS = int freq.TotalSeconds -> []
@@ -126,7 +126,7 @@ type Service internal (resolve : SourceId * TrancheId * string -> Decider<Events
 
         /// Start a checkpointing series with the supplied parameters
         /// Yields the checkpoint interval and the starting position
-        member _.Start(source, tranche, establishOrigin, ct) : Task<struct (TimeSpan * Position)> =
+        member _.Start(source, tranche, establishOrigin, ct) : Task<Position> =
             let decider = resolve (source, tranche, consumerGroupName)
             let establishOrigin = match establishOrigin with None -> async { return Position.initial } | Some f -> Async.call f.Invoke
 #if COSMOSV3

--- a/src/Propulsion.Feed/FeedSource.fs
+++ b/src/Propulsion.Feed/FeedSource.fs
@@ -22,9 +22,9 @@ type FeedSourceBase internal
     let pumpPartition (partitionId : int) trancheId struct (ingester : Ingestion.Ingester<_>, reader : FeedReader) ct = task {
         try let log (e : exn) = reader.Log.Warning(e, "Finishing {partition}", partitionId)
             let establishTrancheOrigin (f : Func<_, CancellationToken, _>) = Func<_, _>(fun ct -> f.Invoke(trancheId, ct))
-            try let! freq, pos = checkpoints.Start(sourceId, trancheId, establishOrigin = (establishOrigin |> Option.map establishTrancheOrigin), ct = ct)
-                reader.Log.Information("Reading {partition} {source:l}/{tranche:l} From {pos} Checkpoint Event interval {checkpointFreq:n1}m",
-                                       partitionId, sourceId, trancheId, renderPos pos, freq.TotalMinutes)
+            try let! pos = checkpoints.Start(sourceId, trancheId, establishOrigin = (establishOrigin |> Option.map establishTrancheOrigin), ct = ct)
+                reader.Log.Information("Reading {partition} {source:l}/{tranche:l} From {pos}",
+                                       partitionId, sourceId, trancheId, renderPos pos)
                 return! reader.Pump(pos, ct)
             with Exception.Log log () -> ()
         finally ingester.Stop() }

--- a/src/Propulsion.MessageDb/ReaderCheckpoint.fs
+++ b/src/Propulsion.MessageDb/ReaderCheckpoint.fs
@@ -46,7 +46,7 @@ module internal Impl =
         use! conn = Internal.createConnectionAndOpen connString ct
         return! f conn ct }
 
-type CheckpointStore(connString : string, schema : string, consumerGroupName, defaultCheckpointFrequency : System.TimeSpan) =
+type CheckpointStore(connString : string, schema : string, consumerGroupName) =
 
     let exec f = Impl.exec connString f
     let setPos source tranche pos ct =
@@ -70,7 +70,7 @@ type CheckpointStore(connString : string, schema : string, consumerGroupName, de
                     | ValueSome pos, _ -> task { return Position.parse pos }
                     | ValueNone, Some f -> f.Invoke ct
                     | ValueNone, None -> task { return Position.initial }
-                return struct (defaultCheckpointFrequency, pos) }
+                return pos }
             exec start ct
 
         member _.Commit(source, tranche, pos, ct) =

--- a/src/Propulsion.SqlStreamStore/ReaderCheckpoint.fs
+++ b/src/Propulsion.SqlStreamStore/ReaderCheckpoint.fs
@@ -48,7 +48,7 @@ let tryGetPosition (conn : IDbConnection) (stream : string) (consumerGroup : str
          { Stream = stream; ConsumerGroup = consumerGroup; Position = Nullable() })
     return Seq.tryHead res |> Option.bind (fun r -> Option.ofNullable r.Position) }
 
-type Service(connString : string, consumerGroupName, defaultCheckpointFrequency) =
+type Service(connString : string, consumerGroupName) =
 
     let streamName source tranche =
         match SourceId.toString source, TrancheId.toString tranche with
@@ -69,7 +69,7 @@ type Service(connString : string, consumerGroupName, defaultCheckpointFrequency)
                 | Some pos, _ -> task { return Position.parse pos }
                 | None, Some f -> f.Invoke ct
                 | None, None -> task { return Position.initial }
-            return struct (defaultCheckpointFrequency, pos) }
+            return pos }
 
         member _.Commit(source, tranche, pos, _ct) = task {
             use conn = createConnection connString

--- a/src/Propulsion/Feed.fs
+++ b/src/Propulsion/Feed.fs
@@ -29,5 +29,5 @@ module Position =
 type IFeedCheckpointStore =
 
     /// Determines the starting position, and checkpointing frequency for a given tranche
-    abstract member Start: source: SourceId * tranche : TrancheId * establishOrigin : Func<CancellationToken, Task<Position>> option * ct : CancellationToken -> Task<struct (TimeSpan * Position)>
+    abstract member Start: source: SourceId * tranche : TrancheId * establishOrigin : Func<CancellationToken, Task<Position>> option * ct : CancellationToken -> Task<Position>
     abstract member Commit: source: SourceId * tranche : TrancheId * pos: Position * CancellationToken -> Task

--- a/tests/Propulsion.MessageDb.Integration/Tests.fs
+++ b/tests/Propulsion.MessageDb.Integration/Tests.fs
@@ -61,7 +61,7 @@ let stats log = { new Propulsion.Streams.Stats<_>(log, TimeSpan.FromMinutes 1, T
                        member _.HandleExn(log, x) = () }
 
 let makeCheckpoints consumerGroup = task {
-    let checkpoints = ReaderCheckpoint.CheckpointStore(CheckpointConnectionString, "public", $"TestGroup{consumerGroup}", TimeSpan.FromSeconds 10)
+    let checkpoints = ReaderCheckpoint.CheckpointStore(CheckpointConnectionString, "public", $"TestGroup{consumerGroup}")
     do! checkpoints.CreateSchemaIfNotExists()
     return checkpoints }
 

--- a/tools/Propulsion.Tool/Args.fs
+++ b/tools/Propulsion.Tool/Args.fs
@@ -288,7 +288,7 @@ module Mdb =
             Array.ofList (p.GetResults Category), conn ()
 
         member x.CreateCheckpointStore(group) =
-            Propulsion.MessageDb.ReaderCheckpoint.CheckpointStore(checkpointConn (), schema, group, TimeSpan.FromSeconds 5.)
+            Propulsion.MessageDb.ReaderCheckpoint.CheckpointStore(checkpointConn (), schema, group)
 
         member x.CreateCheckpointStoreTable([<O; D null>] ?ct) = task {
             let connStringWithoutPassword = NpgsqlConnectionStringBuilder(checkpointConn (), Password = null)

--- a/tools/Propulsion.Tool/Program.fs
+++ b/tools/Propulsion.Tool/Program.fs
@@ -189,8 +189,8 @@ module Checkpoints =
         Log.Information("Checkpoint Source {source} Tranche {tranche} Consumer Group {group}", source, tranche, group)
         match p.TryGetResult OverridePosition with
         | None ->
-            let! interval, pos = store.Start(source, tranche, None, ct)
-            Log.Information("Checkpoint position {pos}; Checkpoint event frequency {checkpointEventIntervalM:f0}m", pos, interval.TotalMinutes)
+            let! pos = store.Start(source, tranche, None, ct)
+            Log.Information("Checkpoint position {pos}", pos)
         | Some pos ->
             Log.Warning("Checkpoint Overriding to {pos}...", pos)
             do! overridePosition pos


### PR DESCRIPTION
It's a feature specific to Cosmos/Dynamo stores. Having Sql checkpointers implement the same interface causes some confusion

e.g. We will log that there's a "checkpoint event interval" even if our checkpoints aren't event based at all.

I misunderstood the concept myself and thought it was there to tell propulsion to "only commit a checkpoint at most once every interval"
