### PR TITLE
fix(CosmoStoreSink): Improve error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - `Streams.SpanResult`: Renamed to `Sinks.StreamResult` [#208](https://github.com/jet/propulsion/pull/208)
 - `Propulsion.CosmosStore`: Changed to target `Equinox.CosmosStore` v `4.0.0` [#139](https://github.com/jet/propulsion/pull/139)
 - `Propulsion.CosmosStore.CosmosSource`: Changed parsing to use `System.Text.Json` [#139](https://github.com/jet/propulsion/pull/139)
+- `Propulsion.CosmosStore.CosmosStoreSink`+`CosmosStorePruner`: Exposed `*Stats` [#226](https://github.com/jet/propulsion/pull/226)
 - `Propulsion.EventStore`: Pinned to target `Equinox.EventStore` v `[3.0.7`-`3.99.0]` **Deprecated; Please migrate to `Propulsion.EventStoreDb`** [#139](https://github.com/jet/propulsion/pull/139)
 - `Propulsion.EventStoreDb.EventStoreSource`: Changed API to match`Propulsion.SqlStreamStore` API rather than`Propulsion.EventStore` [#139](https://github.com/jet/propulsion/pull/139)
 - `Propulsion.Feed`,`Kafka`: Replaced `Async` with `task` for supervision [#158](https://github.com/jet/propulsion/pull/158), [#159](https://github.com/jet/propulsion/pull/159)

--- a/src/Propulsion.CosmosStore/ChangeFeedProcessor.fs
+++ b/src/Propulsion.CosmosStore/ChangeFeedProcessor.fs
@@ -31,7 +31,7 @@ type internal SourcePipeline =
     static member Start(log : ILogger, start, maybeStartChild, stop, observer : IDisposable) =
         let cts = new CancellationTokenSource()
         let triggerStop _disposing =
-            let level = if cts.IsCancellationRequested then Events.LogEventLevel.Debug else Events.LogEventLevel.Information
+            let level = if cts.IsCancellationRequested then LogEventLevel.Debug else LogEventLevel.Information
             log.Write(level, "Source stopping...")
             observer.Dispose()
             cts.Cancel()

--- a/src/Propulsion.CosmosStore/CosmosStorePruner.fs
+++ b/src/Propulsion.CosmosStore/CosmosStorePruner.fs
@@ -54,9 +54,9 @@ type CosmosStorePrunerStats(log, statsInterval, stateInterval) =
 
     override x.Classify e =
         match e with
-        | Equinox_CosmosStore_Exceptions.RateLimited -> OutcomeKind.RateLimited
-        | Equinox_CosmosStore_Exceptions.RequestTimeout -> OutcomeKind.Timeout
-        | e -> base.Classify e
+        | Equinox.CosmosStore.Exceptions.RateLimited ->     OutcomeKind.RateLimited
+        | Equinox.CosmosStore.Exceptions.RequestTimeout ->  OutcomeKind.Timeout
+        | e ->                                              base.Classify e
     override _.HandleExn(log, exn) = log.Warning(exn, "Unhandled")
 
 /// DANGER: <c>CosmosPruner</c> DELETES events - use with care

--- a/src/Propulsion.CosmosStore/CosmosStorePruner.fs
+++ b/src/Propulsion.CosmosStore/CosmosStorePruner.fs
@@ -88,7 +88,7 @@ type CosmosStorePruner =
                 struct (metrics, span)
             Dispatcher.Concurrent<_, _, _, _>.Create(maxConcurrentStreams, interpret, Pruner.handle pruneUntil, (fun _ r -> r))
         let statsInterval, stateInterval = defaultArg statsInterval (TimeSpan.FromMinutes 5.), defaultArg stateInterval (TimeSpan.FromMinutes 5.)
-        let stats = Pruner.Stats(log.ForContext<Pruner.Stats>(), statsInterval, stateInterval)
+        let stats = Pruner.Stats(log, statsInterval, stateInterval)
         let dumpStreams logStreamStates _log = logStreamStates Event.storedSize
         let scheduler = Scheduling.Engine(dispatcher, stats, dumpStreams, pendingBufferSize = 5,
                                           ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay)

--- a/src/Propulsion.CosmosStore/CosmosStoreSink.fs
+++ b/src/Propulsion.CosmosStore/CosmosStoreSink.fs
@@ -98,7 +98,7 @@ module Internal =
     type Dispatcher =
 
         static member Create(log : ILogger, eventsContext, itemDispatcher, ?maxEvents, ?maxBytes) =
-            let maxEvents, maxBytes = defaultArg maxEvents 16384, defaultArg maxBytes (1024 * 1024 - (*fudge*)4096)
+            let maxEvents, maxBytes = defaultArg maxEvents 16384, defaultArg maxBytes (256 * 1024)
             let writerResultLog = log.ForContext<Writer.Result>()
             let attemptWrite stream span ct = task {
                 let struct (met, span') = StreamSpan.slice Event.renderedSize (maxEvents, maxBytes) span
@@ -179,7 +179,7 @@ type CosmosStoreSink =
             ?purgeInterval, ?wakeForResults, ?idleDelay,
             // Default: 16384
             ?maxEvents,
-            // Default: 1MB (limited by maximum size of a CosmosDB stored procedure invocation)
+            // Default: 256KB (limited by maximum size of a CosmosDB stored procedure invocation)
             ?maxBytes,
             ?ingesterStatsInterval)
         : Sink =

--- a/src/Propulsion.CosmosStore/CosmosStoreSink.fs
+++ b/src/Propulsion.CosmosStore/CosmosStoreSink.fs
@@ -17,6 +17,7 @@ module private Impl =
 
         let private toNativeEventBody (xs : Propulsion.Sinks.EventBody) : byte[] = xs.ToArray()
         let defaultToNative_ = FsCodec.Core.TimelineEvent.Map toNativeEventBody
+    // Trimmed edition of what V4 exposes
     module internal Equinox =
         module CosmosStore =
             module Exceptions =
@@ -25,8 +26,8 @@ module private Impl =
                 let (|RateLimited|RequestTimeout|CosmosStatusCode|Other|) = function
                     | CosmosStatus System.Net.HttpStatusCode.TooManyRequests ->     RateLimited
                     | CosmosStatus System.Net.HttpStatusCode.RequestTimeout ->      RequestTimeout
-                    | CosmosStatus s -> CosmosStatusCode s
-                    | _ -> Other
+                    | CosmosStatus s ->                                             CosmosStatusCode s
+                    | _ ->                                                          Other
 
 #else
     module StreamSpan =

--- a/src/Propulsion.CosmosStore/CosmosStoreSink.fs
+++ b/src/Propulsion.CosmosStore/CosmosStoreSink.fs
@@ -6,7 +6,6 @@ open Propulsion.Internal
 open Propulsion.Sinks
 open Propulsion.Streams
 open Serilog
-open System
 open System.Collections.Generic
 
 [<AutoOpen>]
@@ -28,6 +27,16 @@ module private Impl =
             else JsonSerializer.Deserialize(x.Span)
         let defaultToNative_ = FsCodec.Core.TimelineEvent.Map toNativeEventBody
 #endif
+
+module Equinox_CosmosStore_Exceptions =
+    open Microsoft.Azure.Cosmos
+    let [<return: Struct>] (|CosmosStatus|_|) (x: exn) = match x with :? CosmosException as ce -> ValueSome ce.StatusCode | _ -> ValueNone
+    let (|RateLimited|RequestTimeout|ServiceUnavailable|CosmosStatusCode|Other|) = function
+        | CosmosStatus System.Net.HttpStatusCode.TooManyRequests ->     RateLimited
+        | CosmosStatus System.Net.HttpStatusCode.RequestTimeout ->      RequestTimeout
+        | CosmosStatus System.Net.HttpStatusCode.ServiceUnavailable ->  ServiceUnavailable
+        | CosmosStatus s -> CosmosStatusCode s
+        | _ -> Other
 
 module Internal =
 
@@ -72,78 +81,19 @@ module Internal =
                     | actual -> Result.PartialDuplicate (span |> Array.skip (actual - span[0].Index |> int))
             log.Debug("Result: {res}", res')
             return res' }
-        let (|TimedOutMessage|RateLimitedMessage|TooLargeMessage|MalformedMessage|Other|) (e : exn) =
-            let isMalformed e =
-                let m = string e
-                m.Contains "SyntaxError: JSON.parse Error: Unexpected input at position"
-                 || m.Contains "SyntaxError: JSON.parse Error: Invalid character at position"
-            match e with
-            | :? Microsoft.Azure.Cosmos.CosmosException as ce when ce.StatusCode = System.Net.HttpStatusCode.TooManyRequests -> RateLimitedMessage
-            | :? Microsoft.Azure.Cosmos.CosmosException as ce when ce.StatusCode = System.Net.HttpStatusCode.RequestEntityTooLarge -> TooLargeMessage
-            | e when e.GetType().FullName = "Microsoft.Azure.Documents.RequestTimeoutException" -> TimedOutMessage
-            | e when isMalformed e -> MalformedMessage
-            | _ -> Other
-
+        let containsMalformedMessage e =
+            let m = string e
+            m.Contains "SyntaxError: JSON.parse Error: Unexpected input at position"
+            || m.Contains "SyntaxError: JSON.parse Error: Invalid character at position"
         let classify = function
-            | RateLimitedMessage -> ResultKind.RateLimited
-            | TimedOutMessage -> ResultKind.TimedOut
-            | TooLargeMessage -> ResultKind.TooLarge
-            | MalformedMessage -> ResultKind.Malformed
-            | Other -> ResultKind.Other
+            | Equinox_CosmosStore_Exceptions.RateLimited -> ResultKind.RateLimited
+            | Equinox_CosmosStore_Exceptions.RequestTimeout -> ResultKind.TimedOut
+            | Equinox_CosmosStore_Exceptions.CosmosStatusCode System.Net.HttpStatusCode.RequestEntityTooLarge -> ResultKind.TooLarge
+            | e when containsMalformedMessage e -> ResultKind.Malformed
+            | _ -> ResultKind.Other
         let isMalformed = function
             | ResultKind.RateLimited | ResultKind.TimedOut | ResultKind.Other -> false
             | ResultKind.TooLarge | ResultKind.Malformed -> true
-
-    type Stats(log : ILogger, statsInterval, stateInterval) =
-        inherit Scheduling.Stats<struct (StreamSpan.Metrics * Writer.Result), struct (StreamSpan.Metrics * exn)>(log, statsInterval, stateInterval)
-        let mutable okStreams, resultOk, resultDup, resultPartialDup, resultPrefix, resultExnOther = HashSet(), 0, 0, 0, 0, 0
-        let mutable badCats, failStreams, rateLimited, timedOut, tooLarge, malformed = Stats.CatStats(), HashSet(), 0, 0, 0, 0
-        let rlStreams, toStreams, tlStreams, mfStreams, oStreams = HashSet(), HashSet(), HashSet(), HashSet(), HashSet()
-        let mutable okEvents, okBytes, exnEvents, exnBytes = 0, 0L, 0, 0L
-
-        override _.DumpStats() =
-            let results = resultOk + resultDup + resultPartialDup + resultPrefix
-            log.Information("Completed {mb:n0}MB {completed:n0}r {streams:n0}s {events:n0}e ({ok:n0} ok {dup:n0} redundant {partial:n0} partial {prefix:n0} waiting)",
-                Log.miB okBytes, results, okStreams.Count, okEvents, resultOk, resultDup, resultPartialDup, resultPrefix)
-            okStreams.Clear(); resultOk <- 0; resultDup <- 0; resultPartialDup <- 0; resultPrefix <- 0; okEvents <- 0; okBytes <- 0L
-            if rateLimited <> 0 || timedOut <> 0 || tooLarge <> 0 || malformed <> 0 || badCats.Any then
-                let fails = rateLimited + timedOut + tooLarge + malformed + resultExnOther
-                log.Warning("Exceptions {mb:n0}MB {fails:n0}r {streams:n0}s {events:n0}e Rate-limited {rateLimited:n0}r {rlStreams:n0}s Timed out {toCount:n0}r {toStreams:n0}s",
-                    Log.miB exnBytes, fails, failStreams.Count, exnEvents, rateLimited, rlStreams.Count, timedOut, toStreams.Count)
-                rateLimited <- 0; timedOut <- 0; resultExnOther <- 0; failStreams.Clear(); rlStreams.Clear(); toStreams.Clear(); exnBytes <- 0L; exnEvents <- 0
-            if badCats.Any then
-                log.Warning(" Affected cats {@badCats} Too large {tooLarge:n0}r {@tlStreams} Malformed {malformed:n0}r {@mfStreams} Other {other:n0}r {@oStreams}",
-                    badCats.StatsDescending |> Seq.truncate 50, tooLarge, tlStreams |> Seq.truncate 100, malformed, mfStreams |> Seq.truncate 100, resultExnOther, oStreams |> Seq.truncate 100)
-                badCats.Clear(); tooLarge <- 0; malformed <- 0;  resultExnOther <- 0; tlStreams.Clear(); mfStreams.Clear(); oStreams.Clear()
-            Equinox.CosmosStore.Core.Log.InternalMetrics.dump log
-
-        override _.Handle message =
-            let inline adds x (set:HashSet<_>) = set.Add x |> ignore
-            let inline bads x (set:HashSet<_>) = badCats.Ingest(StreamName.categorize x); adds x set
-            match message with
-            | { stream = stream; result = Ok ((es, bs), res) } ->
-                adds stream okStreams
-                okEvents <- okEvents + es
-                okBytes <- okBytes + int64 bs
-                match res with
-                | Writer.Result.Ok _ -> resultOk <- resultOk + 1
-                | Writer.Result.Duplicate _ -> resultDup <- resultDup + 1
-                | Writer.Result.PartialDuplicate _ -> resultPartialDup <- resultPartialDup + 1
-                | Writer.Result.PrefixMissing _ -> resultPrefix <- resultPrefix + 1
-                base.RecordOk(message)
-            | { stream = stream; result = Error ((es, bs), Exception.Inner exn) } ->
-                adds stream failStreams
-                exnEvents <- exnEvents + es
-                exnBytes <- exnBytes + int64 bs
-                let kind =
-                    match Writer.classify exn with
-                    | ResultKind.RateLimited -> adds stream rlStreams; rateLimited <- rateLimited + 1; OutcomeKind.RateLimited
-                    | ResultKind.TimedOut ->    adds stream toStreams; timedOut <- timedOut + 1;       OutcomeKind.Timeout
-                    | ResultKind.TooLarge ->    bads stream tlStreams; tooLarge <- tooLarge + 1;       OutcomeKind.Failed
-                    | ResultKind.Malformed ->   bads stream mfStreams; malformed <- malformed + 1;     OutcomeKind.Failed
-                    | ResultKind.Other ->       adds stream toStreams; timedOut <- timedOut + 1;       OutcomeKind.Exception
-                base.RecordExn(message, kind, log.ForContext("stream", stream).ForContext("events", es), exn)
-        default _.HandleExn(_, _) : unit = ()
 
     type Dispatcher =
 
@@ -169,15 +119,63 @@ module Internal =
                 struct (ss.WritePos, res)
             Dispatcher.Concurrent<_, _, _, _>.Create(itemDispatcher, attemptWrite, interpretWriteResultProgress)
 
+type WriterResult = Internal.Writer.Result
+
+type CosmosStoreSinkStats(log : ILogger, statsInterval, stateInterval) =
+    inherit Scheduling.Stats<struct (StreamSpan.Metrics * WriterResult), struct (StreamSpan.Metrics * exn)>(log, statsInterval, stateInterval)
+    let mutable okStreams, resultOk, resultDup, resultPartialDup, resultPrefix, resultExnOther = HashSet(), 0, 0, 0, 0, 0
+    let mutable badCats, failStreams, rateLimited, timedOut, tooLarge, malformed = Stats.CatStats(), HashSet(), 0, 0, 0, 0
+    let rlStreams, toStreams, tlStreams, mfStreams, oStreams = HashSet(), HashSet(), HashSet(), HashSet(), HashSet()
+    let mutable okEvents, okBytes, exnEvents, exnBytes = 0, 0L, 0, 0L
+    override _.Handle message =
+        let inline adds x (set:HashSet<_>) = set.Add x |> ignore
+        let inline bads x (set:HashSet<_>) = badCats.Ingest(StreamName.categorize x); adds x set
+        match message with
+        | { stream = stream; result = Ok ((es, bs), res) } ->
+            adds stream okStreams
+            okEvents <- okEvents + es
+            okBytes <- okBytes + int64 bs
+            match res with
+            | WriterResult.Ok _ -> resultOk <- resultOk + 1
+            | WriterResult.Duplicate _ -> resultDup <- resultDup + 1
+            | WriterResult.PartialDuplicate _ -> resultPartialDup <- resultPartialDup + 1
+            | WriterResult.PrefixMissing _ -> resultPrefix <- resultPrefix + 1
+            base.RecordOk(message)
+        | { stream = stream; result = Error ((es, bs), Exception.Inner exn) } ->
+            adds stream failStreams
+            exnEvents <- exnEvents + es
+            exnBytes <- exnBytes + int64 bs
+            let kind =
+                match Internal.Writer.classify exn with
+                | Internal.Writer.ResultKind.RateLimited -> adds stream rlStreams; rateLimited <- rateLimited + 1; OutcomeKind.RateLimited
+                | Internal.Writer.ResultKind.TimedOut ->    adds stream toStreams; timedOut <- timedOut + 1;       OutcomeKind.Timeout
+                | Internal.Writer.ResultKind.TooLarge ->    bads stream tlStreams; tooLarge <- tooLarge + 1;       OutcomeKind.Failed
+                | Internal.Writer.ResultKind.Malformed ->   bads stream mfStreams; malformed <- malformed + 1;     OutcomeKind.Failed
+                | Internal.Writer.ResultKind.Other ->       adds stream toStreams; timedOut <- timedOut + 1;       OutcomeKind.Exception
+            base.RecordExn(message, kind, log.ForContext("stream", stream).ForContext("events", es), exn)
+    override _.DumpStats() =
+        let results = resultOk + resultDup + resultPartialDup + resultPrefix
+        log.Information("Completed {mb:n0}MB {completed:n0}r {streams:n0}s {events:n0}e ({ok:n0} ok {dup:n0} redundant {partial:n0} partial {prefix:n0} waiting)",
+            Log.miB okBytes, results, okStreams.Count, okEvents, resultOk, resultDup, resultPartialDup, resultPrefix)
+        okStreams.Clear(); resultOk <- 0; resultDup <- 0; resultPartialDup <- 0; resultPrefix <- 0; okEvents <- 0; okBytes <- 0L
+        if rateLimited <> 0 || timedOut <> 0 || tooLarge <> 0 || malformed <> 0 || badCats.Any then
+            let fails = rateLimited + timedOut + tooLarge + malformed + resultExnOther
+            log.Warning(" Exceptions {mb:n0}MB {fails:n0}r {streams:n0}s {events:n0}e Rate-limited {rateLimited:n0}r {rlStreams:n0}s Timed out {toCount:n0}r {toStreams:n0}s",
+                Log.miB exnBytes, fails, failStreams.Count, exnEvents, rateLimited, rlStreams.Count, timedOut, toStreams.Count)
+            rateLimited <- 0; timedOut <- 0; resultExnOther <- 0; failStreams.Clear(); rlStreams.Clear(); toStreams.Clear(); exnBytes <- 0L; exnEvents <- 0
+        if badCats.Any then
+            log.Warning("  Affected cats {@badCats} Too large {tooLarge:n0}r {@tlStreams} Malformed {malformed:n0}r {@mfStreams} Other {other:n0}r {@oStreams}",
+                badCats.StatsDescending |> Seq.truncate 50, tooLarge, tlStreams |> Seq.truncate 100, malformed, mfStreams |> Seq.truncate 100, resultExnOther, oStreams |> Seq.truncate 100)
+            badCats.Clear(); tooLarge <- 0; malformed <- 0;  resultExnOther <- 0; tlStreams.Clear(); mfStreams.Clear(); oStreams.Clear()
+        Equinox.CosmosStore.Core.Log.InternalMetrics.dump log
+
+    default _.HandleExn(_, _) : unit = ()
+
 type CosmosStoreSink =
 
     /// Starts a <c>Sink</c> that ingests all submitted events into the supplied <c>context</c>
     static member Start
-        (   log : ILogger, maxReadAhead, eventsContext, maxConcurrentStreams,
-            // Default 5m
-            ?statsInterval,
-            // Default 5m
-            ?stateInterval,
+        (   log : ILogger, maxReadAhead, eventsContext, maxConcurrentStreams, stats: CosmosStoreSinkStats,
             ?purgeInterval, ?wakeForResults, ?idleDelay,
             // Default: 16384
             ?maxEvents,
@@ -185,11 +183,9 @@ type CosmosStoreSink =
             ?maxBytes,
             ?ingesterStatsInterval)
         : Sink =
-        let statsInterval, stateInterval = defaultArg statsInterval (TimeSpan.FromMinutes 5.), defaultArg stateInterval (TimeSpan.FromMinutes 5.)
         let dispatcher = Internal.Dispatcher.Create(log, eventsContext, maxConcurrentStreams, ?maxEvents = maxEvents, ?maxBytes = maxBytes)
         let scheduler =
-            let stats = Internal.Stats(log, statsInterval, stateInterval)
             let dumpStreams logStreamStates _log = logStreamStates Event.storedSize
             Scheduling.Engine(dispatcher, stats, dumpStreams, pendingBufferSize = 5, prioritizeStreamsBy = Event.storedSize,
                               ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay)
-        Projector.Pipeline.Start(log, scheduler.Pump, maxReadAhead, scheduler, ingesterStatsInterval = defaultArg ingesterStatsInterval statsInterval)
+        Projector.Pipeline.Start(log, scheduler.Pump, maxReadAhead, scheduler, ingesterStatsInterval = defaultArg ingesterStatsInterval stats.StatsInterval.Period)

--- a/src/Propulsion.CosmosStore/CosmosStoreSink.fs
+++ b/src/Propulsion.CosmosStore/CosmosStoreSink.fs
@@ -51,7 +51,7 @@ module Internal =
             | stream, Ok (_, Result.PrefixMissing (batch, pos)) ->
                 log.Information("Waiting   {stream} missing {gap} events ({count} events @ {pos})", stream, batch[0].Index - pos, batch.Length, batch[0].Index)
             | stream, Error (_, exn) ->
-                let level = if malformed then Events.LogEventLevel.Warning else Events.LogEventLevel.Information
+                let level = if malformed then LogEventLevel.Warning else Events.LogEventLevel.Information
                 log.Write(level, exn, "Writing   {stream} failed, retrying", stream)
 
         let write (log : ILogger) (ctx : EventsContext) stream (span : Event[]) ct = task {
@@ -188,7 +188,7 @@ type CosmosStoreSink =
         let statsInterval, stateInterval = defaultArg statsInterval (TimeSpan.FromMinutes 5.), defaultArg stateInterval (TimeSpan.FromMinutes 5.)
         let dispatcher = Internal.Dispatcher.Create(log, eventsContext, maxConcurrentStreams, ?maxEvents = maxEvents, ?maxBytes = maxBytes)
         let scheduler =
-            let stats = Internal.Stats(log.ForContext<Internal.Stats>(), statsInterval, stateInterval)
+            let stats = Internal.Stats(log, statsInterval, stateInterval)
             let dumpStreams logStreamStates _log = logStreamStates Event.storedSize
             Scheduling.Engine(dispatcher, stats, dumpStreams, pendingBufferSize = 5, prioritizeStreamsBy = Event.storedSize,
                               ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay)

--- a/src/Propulsion.CosmosStore/CosmosStoreSource.fs
+++ b/src/Propulsion.CosmosStore/CosmosStoreSource.fs
@@ -20,9 +20,8 @@ module Log =
         | Read of ReadMetric
         | Lag of LagMetric
 
-    /// Attach a property to the captured event record to hold the metric information
-    // Sidestep Log.ForContext converting to a string; see https://github.com/serilog/serilog/issues/1124
     let [<Literal>] PropertyTag = "propulsionCosmosEvent"
+    /// Attach a property to the captured event record to hold the metric information
     let internal withMetric (value : Metric) = Log.withScalarProperty PropertyTag value
     let [<return: Struct>] (|MetricEvent|_|) (logEvent : Serilog.Events.LogEvent) : Metric voption =
         let mutable p = Unchecked.defaultof<_>

--- a/src/Propulsion.CosmosStore/Propulsion.CosmosStore.fsproj
+++ b/src/Propulsion.CosmosStore/Propulsion.CosmosStore.fsproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="MinVer" Version="4.2.0" PrivateAssets="All" />
 
-    <PackageReference Include="Equinox.CosmosStore" Version="4.0.0-rc.12.8" />
+    <PackageReference Include="Equinox.CosmosStore" Version="4.0.0-rc.12.12" />
     <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.0-rc.10" />
   </ItemGroup>
 

--- a/src/Propulsion.CosmosStore/ReaderCheckpoint.fs
+++ b/src/Propulsion.CosmosStore/ReaderCheckpoint.fs
@@ -202,8 +202,7 @@ module CosmosStore =
 
     let accessStrategy = AccessStrategy.Custom (Fold.isOrigin, Fold.transmute)
     let create log defaultCheckpointFrequency (context, cache) =
-        let cacheStrategy = CachingStrategy.SlidingWindow (cache, defaultCacheDuration)
-        let cat = CosmosStoreCategory(context, Events.codec, Fold.fold, Fold.initial, cacheStrategy, accessStrategy)
+        let cat = CosmosStoreCategory(context, Events.codec, Fold.fold, Fold.initial, cacheStrategy cache, accessStrategy)
         let resolveStream opt sn = cat.Resolve(sn, opt)
         create log defaultCheckpointFrequency resolveStream
 #endif

--- a/src/Propulsion.DynamoStore.Notifier/Handler.fs
+++ b/src/Propulsion.DynamoStore.Notifier/Handler.fs
@@ -72,7 +72,7 @@ let private publishBatch (client : IAmazonSimpleNotificationService) (log : Seri
     if res.HttpStatusCode <> HttpStatusCode.OK || res.Failed.Count <> 0 then
         let fails = [| for x in res.Failed -> struct (x.Code, x.SenderFault, x.Message) |]
         log.Warning("PublishBatchAsync {res}. Fails: {fails}", res.HttpStatusCode, fails)
-        failwithf "PublishBatchAsync result %A %A" res.HttpStatusCode fails }
+        failwithf $"PublishBatchAsync result {res.HttpStatusCode} %A{fails}" }
 
 type SnsClient(topicArn) =
 

--- a/src/Propulsion.DynamoStore/AppendsIndex.fs
+++ b/src/Propulsion.DynamoStore/AppendsIndex.fs
@@ -63,9 +63,9 @@ type Service internal (resolve: unit -> Equinox.Decider<Events.Event, Fold.State
         let decider = resolve ()
         decider.Transact(interpret (partitionId, epochId), Equinox.AnyCachedValue)
 
-module Config =
+module Factory =
 
-    let private createCategory store = Config.createSnapshotted Category Events.codec Fold.initial Fold.fold Fold.Snapshot.config store
+    let private createCategory store = Dynamo.createSnapshotted Category Events.codec Fold.initial Fold.fold Fold.Snapshot.config store
     let resolve log store = createCategory store |> Equinox.Decider.forStream log
     let create log (context, cache) = Service(streamId >> resolve log (context, Some cache))
 
@@ -92,5 +92,5 @@ module Reader =
             let decider = resolve ()
             decider.Query(readIngestionEpochId partitionId)
 
-    let create log context = Service(streamId >> Config.resolve log (context, None))
+    let create log context = Service(streamId >> Factory.resolve log (context, None))
 #endif

--- a/src/Propulsion.DynamoStore/DynamoStoreIndex.fs
+++ b/src/Propulsion.DynamoStore/DynamoStoreIndex.fs
@@ -107,7 +107,7 @@ module Reader =
         return spans, state.closed, sizeB }
 
     let loadIndex (log, storeLog, context) partitionId gapsLimit: Async<struct (Buffer * int64)> = async {
-        let indexEpochs = AppendsEpoch.Reader.Config.create storeLog context
+        let indexEpochs = AppendsEpoch.Reader.Factory.create storeLog context
         let mutable epochId, more, totalB, totalSpans = AppendsEpochId.initial, true, 0L, 0L
         let state = Buffer()
         let mutable invalidSpans = 0

--- a/src/Propulsion.DynamoStore/DynamoStoreIndexer.fs
+++ b/src/Propulsion.DynamoStore/DynamoStoreIndexer.fs
@@ -9,8 +9,8 @@ type DynamoStoreIndexer(log : Serilog.ILogger, context, cache, epochBytesCutoff,
     let onlyWarnOnGap = defaultArg onlyWarnOnGap false
 
     let ingester =
-        let epochs = AppendsEpoch.Config.create storeLog (epochBytesCutoff, maxVersion, maxStreams, onlyWarnOnGap) (context, cache)
-        let index = AppendsIndex.Config.create storeLog (context, cache)
+        let epochs = AppendsEpoch.Factory.create storeLog (epochBytesCutoff, maxVersion, maxStreams, onlyWarnOnGap) (context, cache)
+        let index = AppendsIndex.Factory.create storeLog (context, cache)
         let createIngester partitionId =
             let log = log.ForContext("partition", partitionId)
             let readIngestionEpoch () = index.ReadIngestionEpochId partitionId

--- a/src/Propulsion.DynamoStore/DynamoStoreSource.fs
+++ b/src/Propulsion.DynamoStore/DynamoStoreSource.fs
@@ -23,13 +23,13 @@ module private Impl =
         return Checkpoint.positionOfEpochAndOffset epochId version }
 
     let logReadFailure (storeLog : Serilog.ILogger) =
-        let force = storeLog.IsEnabled Serilog.Events.LogEventLevel.Verbose
+        let force = storeLog.IsEnabled LogEventLevel.Verbose
         function
         | Exceptions.ProvisionedThroughputExceeded when not force -> ()
         | e -> storeLog.Warning(e, "DynamoStoreSource read failure")
 
     let logCommitFailure (storeLog : Serilog.ILogger) =
-        let force = storeLog.IsEnabled Serilog.Events.LogEventLevel.Verbose
+        let force = storeLog.IsEnabled LogEventLevel.Verbose
         function
         | Exceptions.ProvisionedThroughputExceeded when not force -> ()
         | e -> storeLog.Warning(e, "DynamoStoreSource commit failure")

--- a/src/Propulsion.DynamoStore/DynamoStoreSource.fs
+++ b/src/Propulsion.DynamoStore/DynamoStoreSource.fs
@@ -18,7 +18,7 @@ module private Impl =
     let readTailPositionForPartition log context (AppendsPartitionId.Parse partitionId) ct = task {
         let index = AppendsIndex.Reader.create log context
         let! epochId = index.ReadIngestionEpochId(partitionId) |> Async.executeAsTask ct
-        let epochs = AppendsEpoch.Reader.Config.create log context
+        let epochs = AppendsEpoch.Reader.Factory.create log context
         let! version = epochs.ReadVersion(partitionId, epochId) |> Async.executeAsTask ct
         return Checkpoint.positionOfEpochAndOffset epochId version }
 
@@ -45,7 +45,7 @@ module private Impl =
     let materializeIndexEpochAsBatchesOfStreamEvents
             (log : Serilog.ILogger, sourceId, storeLog) (hydrating, maybeLoad : _  -> _ -> (CancellationToken -> Task<_>) voption, loadDop) batchCutoff (context : DynamoStoreContext)
             (AppendsPartitionId.Parse pid) (Checkpoint.Parse (epochId, offset)) ct = taskSeq {
-        let epochs = AppendsEpoch.Reader.Config.create storeLog context
+        let epochs = AppendsEpoch.Reader.Factory.create storeLog context
         let sw = Stopwatch.start ()
         let! _maybeSize, version, state = epochs.Read(pid, epochId, offset) |> Async.executeAsTask ct
         let totalChanges = state.changes.Length

--- a/src/Propulsion.DynamoStore/Propulsion.DynamoStore.fsproj
+++ b/src/Propulsion.DynamoStore/Propulsion.DynamoStore.fsproj
@@ -7,6 +7,7 @@
 
     <ItemGroup>
         <Compile Include="Types.fs" />
+        <Compile Include="Store.fs" />
         <Compile Include="ExactlyOnceIngester.fs" />
         <Compile Include="AppendsIndex.fs" />
         <Compile Include="AppendsEpoch.fs" />

--- a/src/Propulsion.DynamoStore/Propulsion.DynamoStore.fsproj
+++ b/src/Propulsion.DynamoStore/Propulsion.DynamoStore.fsproj
@@ -22,7 +22,7 @@
     <ItemGroup>
       <PackageReference Include="MinVer" Version="4.2.0" PrivateAssets="All" />
 
-      <PackageReference Include="Equinox.DynamoStore" Version="4.0.0-rc.12.8" />
+      <PackageReference Include="Equinox.DynamoStore" Version="4.0.0-rc.12.12" />
       <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.0-rc.10" />
     </ItemGroup>
     

--- a/src/Propulsion.DynamoStore/Store.fs
+++ b/src/Propulsion.DynamoStore/Store.fs
@@ -1,0 +1,33 @@
+module internal Propulsion.DynamoStore.Store
+
+module Dynamo =
+
+    open Equinox.DynamoStore
+
+    let private defaultCacheDuration = System.TimeSpan.FromMinutes 20.
+    let private create name codec initial fold accessStrategy (context, cache) =
+        let cachingStrategy = match cache with None -> Equinox.CachingStrategy.NoCaching | Some cache -> Equinox.CachingStrategy.SlidingWindow (cache, defaultCacheDuration)
+        DynamoStoreCategory(context, name, codec, fold, initial, accessStrategy, cachingStrategy)
+
+    let createSnapshotted name codec initial fold (isOrigin, toSnapshot) (context, cache) =
+        let accessStrategy = AccessStrategy.Snapshot (isOrigin, toSnapshot)
+        create name codec initial fold accessStrategy (context, cache)
+
+    let createUnoptimized name codec initial fold (context, cache) =
+        let accessStrategy = AccessStrategy.Unoptimized
+        create name codec initial fold accessStrategy (context, cache)
+
+    let createWithOriginIndex name codec initial fold context minIndex =
+        // TOCONSIDER include way to limit item count being read
+        // TOCONSIDER implement a loader hint to pass minIndex to the query as an additional filter
+        let isOrigin struct (i, _) = i <= minIndex
+        // There _should_ always be an event at minIndex - if there isn't for any reason, the load might go back one event too far
+        // Here we trim it for correctness (although Propulsion would technically ignore it)
+        let trimPotentialOverstep = Seq.filter (fun struct (i, _e) -> i >= minIndex)
+        let accessStrategy = AccessStrategy.MultiSnapshot (isOrigin, fun _ -> failwith "writing not applicable")
+        create name codec initial (fun s -> trimPotentialOverstep >> fold s) accessStrategy (context, None)
+
+module internal Codec =
+
+    let gen<'t when 't :> TypeShape.UnionContract.IUnionContract> =
+        FsCodec.SystemTextJson.Codec.Create<'t>() |> FsCodec.Deflate.EncodeTryDeflate

--- a/src/Propulsion.DynamoStore/Types.fs
+++ b/src/Propulsion.DynamoStore/Types.fs
@@ -70,14 +70,13 @@ module internal FeedSourceId =
 
     let wellKnownId : Propulsion.Feed.SourceId = UMX.tag "dynamoStore"
 
-module internal Config =
+module internal Dynamo =
 
     open Equinox.DynamoStore
 
     let private defaultCacheDuration = System.TimeSpan.FromMinutes 20.
-
     let private create name codec initial fold accessStrategy (context, cache) =
-        let cs = match cache with None -> CachingStrategy.NoCaching | Some cache -> CachingStrategy.SlidingWindow (cache, defaultCacheDuration)
+        let cs = match cache with None -> Equinox.CachingStrategy.NoCaching | Some cache -> Equinox.CachingStrategy.SlidingWindow (cache, defaultCacheDuration)
         DynamoStoreCategory(context, name, codec, fold, initial, accessStrategy, cs)
 
     let createSnapshotted name codec initial fold (isOrigin, toSnapshot) (context, cache) =

--- a/src/Propulsion.DynamoStore/Types.fs
+++ b/src/Propulsion.DynamoStore/Types.fs
@@ -70,41 +70,13 @@ module internal FeedSourceId =
 
     let wellKnownId : Propulsion.Feed.SourceId = UMX.tag "dynamoStore"
 
-module internal Dynamo =
+module Streams =
 
-    open Equinox.DynamoStore
-
-    let private defaultCacheDuration = System.TimeSpan.FromMinutes 20.
-    let private create name codec initial fold accessStrategy (context, cache) =
-        let cs = match cache with None -> Equinox.CachingStrategy.NoCaching | Some cache -> Equinox.CachingStrategy.SlidingWindow (cache, defaultCacheDuration)
-        DynamoStoreCategory(context, name, codec, fold, initial, accessStrategy, cs)
-
-    let createSnapshotted name codec initial fold (isOrigin, toSnapshot) (context, cache) =
-        let accessStrategy = AccessStrategy.Snapshot (isOrigin, toSnapshot)
-        create name codec initial fold accessStrategy (context, cache)
-
-    let createUnoptimized name codec initial fold (context, cache) =
-        let accessStrategy = AccessStrategy.Unoptimized
-        create name codec initial fold accessStrategy (context, cache)
-
-    let createWithOriginIndex name codec initial fold context minIndex =
-        // TOCONSIDER include way to limit item count being read
-        // TOCONSIDER implement a loader hint to pass minIndex to the query as an additional filter
-        let isOrigin struct (i, _) = i <= minIndex
-        // There _should_ always be an event at minIndex - if there isn't for any reason, the load might go back one event too far
-        // Here we trim it for correctness (although Propulsion would technically ignore it)
-        let trimPotentialOverstep = Seq.filter (fun struct (i, _e) -> i >= minIndex)
-        let accessStrategy = AccessStrategy.MultiSnapshot (isOrigin, fun _ -> failwith "writing not applicable")
-        create name codec initial (fun s -> trimPotentialOverstep >> fold s) accessStrategy (context, None)
-
-module internal EventCodec =
-
-    let gen<'t when 't :> TypeShape.UnionContract.IUnionContract> =
-        FsCodec.SystemTextJson.Codec.Create<'t>() |> FsCodec.Deflate.EncodeTryDeflate
     let private withUpconverter<'c, 'e when 'c :> TypeShape.UnionContract.IUnionContract> up : FsCodec.IEventCodec<'e, _, _> =
         let down (_ : 'e) = failwith "Unexpected"
         FsCodec.SystemTextJson.Codec.Create<'e, 'c, _>(up, down) |> FsCodec.Deflate.EncodeTryDeflate
-    let withIndex<'c when 'c :> TypeShape.UnionContract.IUnionContract> : FsCodec.IEventCodec<struct (int64 * 'c), _, _> =
+    let decWithIndex<'c when 'c :> TypeShape.UnionContract.IUnionContract> : FsCodec.IEventCodec<struct (int64 * 'c), _, _> =
         let up (raw : FsCodec.ITimelineEvent<_>) e = struct (raw.Index, e)
         withUpconverter<'c, struct (int64 * 'c)> up
+
 #endif

--- a/src/Propulsion.EventStore/Checkpoint.fs
+++ b/src/Propulsion.EventStore/Checkpoint.fs
@@ -1,8 +1,7 @@
 ﻿module Propulsion.EventStore.Checkpoint
 
 open FSharp.UMX
-open Propulsion.Internal
-open System // must shadow UMX to use DateTimeOffSet
+open System // must shadow UMX to use DateTimeOffset
 open System.Threading.Tasks
 
 type CheckpointSeriesId = string<checkpointSeriesId>
@@ -116,14 +115,11 @@ type Service internal (resolve: CheckpointSeriesId -> Equinox.DeciderCore<Events
         let decider = resolve series
         decider.Transact(interpret (Command.Update(DateTimeOffset.UtcNow, pos)), load = Equinox.AnyCachedValue, ct = ct)
 
-let create resolve = Service(streamId >> resolve)
-
 // General pattern is that an Equinox Service is a singleton and calls pass an identifier for a stream per call
 // This light wrapper means we can adhere to that general pattern yet still end up with legible code while we in practice only maintain a single checkpoint series per running app
-type CheckpointSeries(groupName, resolve, ?log) =
+type CheckpointSeries(groupName, resolve) =
     let seriesId = CheckpointSeriesId.ofGroupName groupName
-    let log = match log with Some x -> x | None -> Serilog.Log.ForContext<Service>()
-    let inner = create (resolve log)
+    let inner = Service(streamId >> resolve)
 
     member _.Read(ct): Task<Fold.State> = inner.Read(seriesId, ct)
     member _.Start(freq, pos, ct): Task<unit> = inner.Start(seriesId, freq, pos, ct)

--- a/src/Propulsion.EventStore/EventStoreSink.fs
+++ b/src/Propulsion.EventStore/EventStoreSink.fs
@@ -153,7 +153,7 @@ type EventStoreSink =
         let dispatcher = Internal.Dispatcher.Create(log, storeLog, connections, maxConcurrentStreams)
         let statsInterval, stateInterval = defaultArg statsInterval (TimeSpan.FromMinutes 5.), defaultArg stateInterval (TimeSpan.FromMinutes 5.)
         let scheduler =
-            let stats = Internal.Stats(log.ForContext<Internal.Stats>(), statsInterval, stateInterval)
+            let stats = Internal.Stats(log, statsInterval, stateInterval)
             let dumpStreams logStreamStates _log = logStreamStates Event.storedSize
             Scheduling.Engine(dispatcher, stats, dumpStreams, pendingBufferSize = 5, ?purgeInterval = purgeInterval, ?idleDelay = idleDelay)
         Projector.Pipeline.Start( log, scheduler.Pump, maxReadAhead, scheduler, ingesterStatsInterval = defaultArg ingesterStatsInterval statsInterval)

--- a/src/Propulsion.EventStore/EventStoreSink.fs
+++ b/src/Propulsion.EventStore/EventStoreSink.fs
@@ -132,7 +132,7 @@ type EventStoreSinkStats(log : ILogger, statsInterval, stateInterval) =
             badCats.Clear(); resultExnOther <- 0; oStreams.Clear()
         Log.InternalMetrics.dump log
 
-    default _.HandleExn(_, _) : unit = ()
+    override _.HandleExn(log, exn) = log.Warning(exn, "Unhandled")
 
 type EventStoreSink =
 

--- a/src/Propulsion.EventStore/Propulsion.EventStore.fsproj
+++ b/src/Propulsion.EventStore/Propulsion.EventStore.fsproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="MinVer" Version="4.2.0" PrivateAssets="All" />
 
-    <PackageReference Include="Equinox.EventStore" Version="4.0.0-rc.12.8" />
+    <PackageReference Include="Equinox.EventStore" Version="4.0.0-rc.12.12" />
     <PackageReference Include="FsCodec.Box" Version="3.0.0-rc.10" />
   </ItemGroup>
 

--- a/src/Propulsion.EventStoreDb/Propulsion.EventStoreDb.fsproj
+++ b/src/Propulsion.EventStoreDb/Propulsion.EventStoreDb.fsproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="MinVer" Version="4.2.0" PrivateAssets="All" />
 
-    <PackageReference Include="Equinox.EventStoreDb" Version="4.0.0-rc.12.8" />
+    <PackageReference Include="Equinox.EventStoreDb" Version="4.0.0-rc.12.12" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Propulsion.Feed/FeedReader.fs
+++ b/src/Propulsion.Feed/FeedReader.fs
@@ -32,9 +32,8 @@ module Log =
             token : Nullable<Position>; latency : TimeSpan; pages : int; items : int
             ingestLatency : TimeSpan; ingestQueued : int }
 
-    /// Attach a property to the captured event record to hold the metric information
-    // Sidestep Log.ForContext converting to a string; see https://github.com/serilog/serilog/issues/1124
     let [<Literal>] PropertyTag = "propulsionFeedEvent"
+    /// Attach a property to the captured event record to hold the metric information
     let internal withMetric (value : Metric) = Log.withScalarProperty PropertyTag value
     let [<return: Struct>] (|MetricEvent|_|) (logEvent : Serilog.Events.LogEvent) : Metric voption =
         let mutable p = Unchecked.defaultof<_>
@@ -144,7 +143,7 @@ type FeedReader
         stats.RecordBatch(readLatency, batch)
         match Array.length batch.items with
         | 0 -> log.Verbose("Page {latency:f0}ms Checkpoint {checkpoint} Empty", readLatency.TotalMilliseconds, batch.checkpoint)
-        | c -> if log.IsEnabled(Serilog.Events.LogEventLevel.Debug) then
+        | c -> if log.IsEnabled(LogEventLevel.Debug) then
                    let streamsCount = batch.items |> Seq.distinctBy ValueTuple.fst |> Seq.length
                    log.Debug("Page {latency:f0}ms Checkpoint {checkpoint} {eventCount}e {streamCount}s",
                              readLatency.TotalMilliseconds, batch.checkpoint, c, streamsCount)

--- a/src/Propulsion.Feed/FeedReader.fs
+++ b/src/Propulsion.Feed/FeedReader.fs
@@ -143,7 +143,7 @@ type FeedReader
         stats.RecordBatch(readLatency, batch)
         match Array.length batch.items with
         | 0 -> log.Verbose("Page {latency:f0}ms Checkpoint {checkpoint} Empty", readLatency.TotalMilliseconds, batch.checkpoint)
-        | c -> if log.IsEnabled(LogEventLevel.Debug) then
+        | c -> if log.IsEnabled LogEventLevel.Debug then
                    let streamsCount = batch.items |> Seq.distinctBy ValueTuple.fst |> Seq.length
                    log.Debug("Page {latency:f0}ms Checkpoint {checkpoint} {eventCount}e {streamCount}s",
                              readLatency.TotalMilliseconds, batch.checkpoint, c, streamsCount)

--- a/src/Propulsion.Feed/FeedSource.fs
+++ b/src/Propulsion.Feed/FeedSource.fs
@@ -236,7 +236,7 @@ and FeedMonitor internal (log : Serilog.ILogger, positions : TranchePositions, s
             let isDrainedNow () = positions.Current() |> isDrained
             let linger = match lingerTime with None -> TimeSpan.Zero | Some lingerF -> lingerF (isDrainedNow ()) propagationDelay propUsed procUsed
             let skipLinger = linger = TimeSpan.Zero
-            let ll = if skipLinger then Serilog.Events.LogEventLevel.Information else Serilog.Events.LogEventLevel.Debug
+            let ll = if skipLinger then LogEventLevel.Information else LogEventLevel.Debug
             let originalCompleted = currentCompleted |> Seq.cache
             if log.IsEnabled ll then
                 let completed = positions.Current() |> choose (fun v -> v.completed)

--- a/src/Propulsion.MemoryStore/Propulsion.MemoryStore.fsproj
+++ b/src/Propulsion.MemoryStore/Propulsion.MemoryStore.fsproj
@@ -19,7 +19,7 @@
     <PackageReference Include="MinVer" Version="4.2.0" PrivateAssets="All" />
 
     <PackageReference Include="FsCodec.Box" Version="3.0.0-rc.10" />
-    <PackageReference Include="Equinox.MemoryStore" Version="4.0.0-rc.12.8" />
+    <PackageReference Include="Equinox.MemoryStore" Version="4.0.0-rc.12.12" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Propulsion/Pipeline.fs
+++ b/src/Propulsion/Pipeline.fs
@@ -40,7 +40,7 @@ type Pipeline(task : Task<unit>, triggerStop) =
     static member Prepare(log : ILogger, pumpScheduler, pumpSubmitter, ?pumpIngester, ?pumpDispatcher) =
         let cts = new CancellationTokenSource()
         let triggerStop disposing =
-            let level = if disposing || cts.IsCancellationRequested then Events.LogEventLevel.Debug else Events.LogEventLevel.Information
+            let level = if disposing || cts.IsCancellationRequested then LogEventLevel.Debug else LogEventLevel.Information
             log.Write(level, "Sink stopping...")
             cts.Cancel()
         let ct = cts.Token
@@ -79,7 +79,7 @@ type Pipeline(task : Task<unit>, triggerStop) =
                 let ts = Stopwatch.timestamp ()
                 let finishedAsRequested = scheduler.Wait(TimeSpan.FromSeconds 2)
                 let ms = let t = Stopwatch.elapsed ts in int t.TotalMilliseconds
-                let level = if finishedAsRequested && ms < 200 then Events.LogEventLevel.Information else Events.LogEventLevel.Warning
+                let level = if finishedAsRequested && ms < 200 then LogEventLevel.Information else LogEventLevel.Warning
                 log.Write(level, "... sink completed {schedulerCleanupMs}ms", ms) }
 
         let task = Task.Run<unit>(supervise)

--- a/src/Propulsion/Streams.fs
+++ b/src/Propulsion/Streams.fs
@@ -50,14 +50,13 @@ module Log =
             newest : float
 
     let [<Literal>] PropertyTag = "propulsionEvent"
-    let [<Literal>] GroupTag = "group"
     /// Attach a property to the captured event record to hold the metric information
-    // Sidestep Log.ForContext converting to a string; see https://github.com/serilog/serilog/issues/1124
     let internal withMetric (value : Metric) = Internal.Log.withScalarProperty PropertyTag value
     let tryGetScalar<'t> key (logEvent : Serilog.Events.LogEvent) : 't voption =
         let mutable p = Unchecked.defaultof<_>
         logEvent.Properties.TryGetValue(key, &p) |> ignore
         match p with Log.ScalarValue (:? 't as e) -> ValueSome e | _ -> ValueNone
+    let [<Literal>] GroupTag = "group"
     let [<return: Struct>] (|MetricEvent|_|) logEvent =
         match tryGetScalar<Metric> PropertyTag logEvent with
         | ValueSome m -> ValueSome (m, tryGetScalar<string> GroupTag logEvent)

--- a/src/Propulsion/Streams.fs
+++ b/src/Propulsion/Streams.fs
@@ -924,10 +924,10 @@ type Stats<'Outcome>(log : ILogger, statsInterval, statesInterval) =
                         Log.miB okBytes, resultOk, okStreams.Count, okEvents, resultOk)
         okStreams.Clear(); resultOk <- 0; okEvents <- 0; okBytes <- 0L
         if resultExnOther <> 0 then
-            log.Warning("Exceptions {mb:n0}MB {fails:n0}r {streams:n0}s {events:n0}e",
+            log.Warning(" Exceptions {mb:n0}MB {fails:n0}r {streams:n0}s {events:n0}e",
                         Log.miB exnBytes, resultExnOther, failStreams.Count, exnEvents)
             resultExnOther <- 0; failStreams.Clear(); exnBytes <- 0L; exnEvents <- 0
-            log.Warning(" Affected cats {@badCats}", badCats.StatsDescending)
+            log.Warning("  Affected cats {@badCats}", badCats.StatsDescending)
             badCats.Clear()
 
     abstract member Classify : exn -> OutcomeKind

--- a/tools/Propulsion.Tool/Infrastructure.fs
+++ b/tools/Propulsion.Tool/Infrastructure.fs
@@ -3,11 +3,12 @@ module Propulsion.Tool.Infrastructure
 
 open Serilog
 
-module Log =
+module Metrics =
 
-    let forMetrics = Log.ForContext("isMetric", true)
-
-    let isStoreMetrics x = Serilog.Filters.Matching.WithProperty("isMetric").Invoke x
+    let [<Literal>] PropertyTag = "isMetric"
+    let log = Log.ForContext(PropertyTag, true)
+    /// Allow logging to filter out emission of log messages whose information is also surfaced as metrics
+    let logEventIsMetric e = Serilog.Filters.Matching.WithProperty(PropertyTag).Invoke e
 
 module Sinks =
 
@@ -49,4 +50,4 @@ type Logging() =
 
     [<System.Runtime.CompilerServices.Extension>]
     static member Sinks(configuration : LoggerConfiguration, configureMetricsSinks, verboseStore, verboseConsole) =
-        configuration.Sinks(configureMetricsSinks, Sinks.console verboseConsole, ?isMetric = if verboseStore then None else Some Log.isStoreMetrics)
+        configuration.Sinks(configureMetricsSinks, Sinks.console verboseConsole, ?isMetric = if verboseStore then None else Some Metrics.logEventIsMetric)


### PR DESCRIPTION
Polished Cosmos/EventStoreSink and Pruners 
- better error management under rate limiting (some message parsing was Cosmos V2 SDK specific)
- Exposed Stats types to match other sinks

- [Pushed cosmos exn parsing into `Equinox.CosmosStore.Exceptions`](https://github.com/jet/equinox/pull/416)
- Targeted interim `Equinox` v `4.0.0-rc.12.12` release

- Made CosmosStoreSink maxBytes more conservative (was 1MB, now 256KB) as erroring with `RequestEntityTooLarge` (wgy and/or the exact real limit not fully root caused)