### PR TITLE
feat(Streams)!: Stats/error logging polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - `Feed`: `Checkpoint` enables committing progress (and obtaining the achieved positions) without stopping the Sink [#162](https://github.com/jet/propulsion/pull/162)
 - `Feed.SinglePassFeedSource`: Coordinates reads of a set of tranches until each reaches its Tail [#179](https://github.com/jet/propulsion/pull/179)
 - `Scheduler`: Split out stats re `rateLimited` and `timedOut` vs `exceptions` [#194](https://github.com/jet/propulsion/pull/194)
+- `Scheduler`: Added `index`, `eventType` to error logging [#233](https://github.com/jet/propulsion/pull/233)
 - `Scheduler`: `purgeInterval` to control memory usage [#97](https://github.com/jet/propulsion/pull/97)
 - `Scheduler`: `wakeForResults` option to maximize throughput (without having to drop sleep interval to zero) [#161](https://github.com/jet/propulsion/pull/161)
 - `Sinks`, `Sinks.Config`: top level APIs for wiring common sink structures [#208](https://github.com/jet/propulsion/pull/208)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - `Feed`: `Checkpoint` enables committing progress (and obtaining the achieved positions) without stopping the Sink [#162](https://github.com/jet/propulsion/pull/162)
 - `Feed.SinglePassFeedSource`: Coordinates reads of a set of tranches until each reaches its Tail [#179](https://github.com/jet/propulsion/pull/179)
 - `Scheduler`: Split out stats re `rateLimited` and `timedOut` vs `exceptions` [#194](https://github.com/jet/propulsion/pull/194)
-- `Scheduler`: Added `index`, `eventType` to error logging [#233](https://github.com/jet/propulsion/pull/233)
+- `Scheduler`: Added `index`, `eventType` to error logging [#234](https://github.com/jet/propulsion/pull/234)
 - `Scheduler`: `purgeInterval` to control memory usage [#97](https://github.com/jet/propulsion/pull/97)
 - `Scheduler`: `wakeForResults` option to maximize throughput (without having to drop sleep interval to zero) [#161](https://github.com/jet/propulsion/pull/161)
 - `Sinks`, `Sinks.Config`: top level APIs for wiring common sink structures [#208](https://github.com/jet/propulsion/pull/208)

--- a/src/Propulsion.CosmosStore/CosmosStorePruner.fs
+++ b/src/Propulsion.CosmosStore/CosmosStorePruner.fs
@@ -32,8 +32,8 @@ module Pruner =
         let writePos = max trimmedPos (untilIndex + 1L)
         return struct (writePos, res) }
 
-type CosmosStorePrunerStats(log, statsInterval, stateInterval) =
-    inherit Propulsion.Streams.Stats<Pruner.Outcome>(log, statsInterval, stateInterval)
+type CosmosStorePrunerStats(log, statsInterval, stateInterval, [<O; D null>] ?failThreshold) =
+    inherit Propulsion.Streams.Stats<Pruner.Outcome>(log, statsInterval, stateInterval, ?failThreshold = failThreshold)
 
     let mutable nops, totalRedundant, ops, totalDeletes, totalDeferred = 0, 0, 0, 0, 0
     override _.HandleOk outcome =

--- a/src/Propulsion.CosmosStore/EquinoxSystemTextJsonParser.fs
+++ b/src/Propulsion.CosmosStore/EquinoxSystemTextJsonParser.fs
@@ -38,7 +38,10 @@ module EquinoxSystemTextJsonParser =
 
     /// Enumerates the events represented within a batch
     let enumEquinoxCosmosEvents (batch: Batch): Event seq =
-        batch.e |> Seq.mapi (fun offset x -> FsCodec.Core.TimelineEvent.Create(batch.i + int64 offset, x.c, batch.MapData x.d, batch.MapData x.m, timestamp = x.t))
+        batch.e |> Seq.mapi (fun offset x ->
+            let d = batch.MapData x.d
+            let m = batch.MapData x.m
+            FsCodec.Core.TimelineEvent.Create(batch.i + int64 offset, x.c, d, m, timestamp = x.t, size = x.c.Length + d.Length + m.Length + 80))
 
     /// Attempts to parse a Document/Item from the Store
     /// returns ValueNone if it does not bear the hallmarks of a valid Batch, or the streamFilter predicate rejects

--- a/src/Propulsion.Feed/FeedReader.fs
+++ b/src/Propulsion.Feed/FeedReader.fs
@@ -66,7 +66,7 @@ type internal Stats(partition : int, source : SourceId, tranche : TrancheId, ren
                     elif lastCommittedPosition = batchLastPosition then "COMPLETE"
                     else if finishedReading then "End" else "Tail"
         (Log.withMetric m log).ForContext("tail", lastWasTail).Information(
-            "Reader {partition} {state} @ {lastCommittedPosition}/{readPosition} Pages {pagesRead} empty {pagesEmpty} events {events} | Recent {l:f1}s Pages {recentPagesRead} empty {recentPagesEmpty} events {recentEvents} | Wait {pausedS:f1}s Ahead {cur}/{max}",
+            "Reader {partition} {state} @ {lastCommittedPosition}/{readPosition} Pages {pagesRead} empty {pagesEmpty} events {events} | Recent {l:f1}s Pages {recentPagesRead} empty {recentPagesEmpty} events {recentEvents} Wait {pausedS:f1}s Ahead {cur}/{max}",
             partition, state, r lastCommittedPosition, r batchLastPosition, pagesRead, pagesEmpty, events, readS, recentPagesRead, recentPagesEmpty, recentEvents, postS, currentBatches, maxReadAhead)
         readLatency <- TimeSpan.Zero; ingestLatency <- TimeSpan.Zero
         recentPagesRead <- 0; recentEvents <- 0; recentPagesEmpty <- 0

--- a/src/Propulsion.Kafka/Consumers.fs
+++ b/src/Propulsion.Kafka/Consumers.fs
@@ -348,7 +348,7 @@ type Factory private () =
             select, handle : Func<Scheduling.Item<_>[], CancellationToken, Task<seq<Result<int64, exn>>>>, stats,
             ?logExternalState, ?purgeInterval, ?wakeForResults, ?idleDelay) =
         let handle (items : Scheduling.Item<EventBody>[]) ct
-            : Task<struct (TimeSpan * FsCodec.StreamName * bool * Result<struct (int64 * struct (StreamSpan.Metrics * unit)), struct (StreamSpan.Metrics * exn)>)[]> = task {
+            : Task<struct (TimeSpan * FsCodec.StreamName * int64 * bool * Result<struct (int64 * struct (StreamSpan.Metrics * unit)), struct (StreamSpan.Metrics * exn)>)[]> = task {
             let sw = Stopwatch.start ()
             let avgElapsed () =
                 let tot = float sw.ElapsedMilliseconds
@@ -361,16 +361,16 @@ type Factory private () =
                         | item, Ok index' ->
                             let used = item.span |> Seq.takeWhile (fun e -> e.Index <> index' ) |> Array.ofSeq
                             let metrics = StreamSpan.metrics Event.storedSize used
-                            struct (ae, item.stream, true, Ok struct (index', struct (metrics, ())))
+                            struct (ae, item.stream, Events.index item.span, true, Ok struct (index', struct (metrics, ())))
                         | item, Error exn ->
                             let metrics = StreamSpan.metrics Event.renderedSize item.span
-                            ae, item.stream, false, Result.Error struct (metrics, exn) |]
+                            ae, item.stream, Events.index item.span, false, Result.Error struct (metrics, exn) |]
             with e ->
                 let ae = avgElapsed ()
                 return
                     [| for x in items ->
                         let metrics = StreamSpan.metrics Event.renderedSize x.span
-                        ae, x.stream, false, Result.Error struct (metrics, e) |] }
+                        ae, x.stream, Events.index x.span, false, Result.Error struct (metrics, e) |] }
         let dispatcher = Dispatcher.Batched(select, handle)
         let dumpStreams logStreamStates log =
             logExternalState |> Option.iter (fun f -> f log)

--- a/src/Propulsion.Kafka/Consumers.fs
+++ b/src/Propulsion.Kafka/Consumers.fs
@@ -344,33 +344,25 @@ type Factory private () =
             ?purgeInterval = purgeInterval, ?wakeForResults = wakeForResults, ?idleDelay = idleDelay)
 
     static member StartBatchedAsync<'Info>
-        (   log : ILogger, config : KafkaConsumerConfig, consumeResultToInfo, infoToStreamEvents,
-            select, handle : Func<Scheduling.Item<_>[], CancellationToken, Task<seq<Result<int64, exn>>>>, stats,
+        (   log: ILogger, config: KafkaConsumerConfig, consumeResultToInfo, infoToStreamEvents,
+            select, handle: Func<Scheduling.Item<_>[], CancellationToken, Task<seq<struct (TimeSpan * Result<int64, exn>)>>>, stats,
             ?logExternalState, ?purgeInterval, ?wakeForResults, ?idleDelay) =
-        let handle (items : Scheduling.Item<EventBody>[]) ct
-            : Task<Scheduling.Res<Result<struct (int64 * struct (StreamSpan.Metrics * unit)), struct (StreamSpan.Metrics * exn)>>[]> = task {
-            let sw = Stopwatch.start ()
-            let avgElapsed () =
-                let tot = float sw.ElapsedMilliseconds
-                TimeSpan.FromMilliseconds(tot / float items.Length)
+        let handle (items: Scheduling.Item<EventBody>[]) ct
+            : Task<Scheduling.InternalRes<Result<struct (StreamSpan.Metrics * int64), struct (StreamSpan.Metrics * exn)>>[]> = task {
+            let start = Stopwatch.timestamp ()
+            let inline err ts e (x: Scheduling.Item<_>) =
+                let met = StreamSpan.metrics Event.renderedSize x.span
+                Scheduling.InternalRes.create (x, ts, Result.Error struct (met, e))
             try let! results = handle.Invoke(items, ct)
-                let ae = avgElapsed ()
-                return
-                    [| for x in Seq.zip items results ->
-                        match x with
-                        | item, Ok index' ->
-                            let used = item.span |> Seq.takeWhile (fun e -> e.Index <> index' ) |> Array.ofSeq
-                            let metrics = StreamSpan.metrics Event.storedSize used
-                            Scheduling.Res.create (ae, item.stream, Events.index item.span, not (Array.isEmpty used), Ok struct (index', struct (metrics, ())))
-                        | item, Error e ->
-                            let metrics = StreamSpan.metrics Event.renderedSize item.span
-                            Scheduling.Item.createResE (ae, item, metrics, e) |]
+                return Array.ofSeq (Seq.zip items results |> Seq.map(function
+                    | item, (ts, Ok index') ->
+                        let used = item.span |> Seq.takeWhile (fun e -> e.Index <> index' ) |> Array.ofSeq
+                        let metrics = StreamSpan.metrics Event.storedSize used
+                        Scheduling.InternalRes.create (item, ts, Result.Ok struct (metrics, index'))
+                    | item, (ts, Error e) -> err ts e item))
             with e ->
-                let ae = avgElapsed ()
-                return
-                    [| for x in items ->
-                        let metrics = StreamSpan.metrics Event.renderedSize x.span
-                        Scheduling.Item.createResE (ae, x, metrics, e) |] }
+                let ts = Stopwatch.elapsed start
+                return items |> Array.map (err ts e) }
         let dispatcher = Dispatcher.Batched(select, handle)
         let dumpStreams logStreamStates log =
             logExternalState |> Option.iter (fun f -> f log)
@@ -394,14 +386,14 @@ type Factory private () =
     /// Processor <c>'Outcome<c/>s are passed to be accumulated into the <c>stats</c> for periodic emission.<br/>
     /// Processor will run perpetually in a background until `Stop()` is requested.
     static member StartBatched<'Info>
-        (   log : ILogger, config : KafkaConsumerConfig, consumeResultToInfo, infoToStreamEvents,
-            select : StreamState seq -> StreamState[],
+        (   log: ILogger, config: KafkaConsumerConfig, consumeResultToInfo, infoToStreamEvents,
+            select: StreamState seq -> StreamState[],
             // Handler responses:
             // - the result seq is expected to match the ordering of the input <c>Scheduling.Item</c>s
             // - Ok: Index at which next processing will proceed (which can trigger discarding of earlier items on that stream)
             // - Error: Records the processing of the stream in question as having faulted (the stream's pending events and/or
             //   new ones that arrived while the handler was processing are then eligible for retry purposes in the next dispatch cycle)
-            handle : StreamState[] -> Async<seq<Result<int64, exn>>>,
+            handle: StreamState[] -> Async<seq<struct (TimeSpan * Result<int64, exn>)>>,
             // The responses from each <c>handle</c> invocation are passed to <c>stats</c> for periodic emission
             stats,
             ?logExternalState, ?purgeInterval, ?wakeForResults, ?idleDelay) =

--- a/src/Propulsion/Ingestion.fs
+++ b/src/Propulsion/Ingestion.fs
@@ -123,15 +123,16 @@ type Ingester<'Items> private
     member private x.Pump(ct) = task {
         use _ = progressWriter.Result.Subscribe(ProgressResult >> enqueueMessage)
         Task.start (fun () -> x.CheckpointPeriodically ct)
-        while not ct.IsCancellationRequested do
+        let mutable exiting = false
+        while not exiting do
+            exiting <- ct.IsCancellationRequested
             while applyIncoming handleIncoming || applyMessages stats.Handle do ()
             stats.RecordCycle()
-            if stats.Interval.IfDueRestart() then let struct (active, max) = maxRead.State in stats.DumpStats(active, max)
+            if exiting || stats.Interval.IfDueRestart() then let struct (active, max) = maxRead.State in stats.DumpStats(active, max)
             let startWaits ct = [| awaitIncoming ct :> Task
                                    awaitMessage ct
                                    Task.Delay(stats.Interval.RemainingMs, ct) |]
-            do! Task.runWithCancellation ct (fun ct -> Task.WhenAny(startWaits ct)) }
-
+            if not exiting then do! Task.runWithCancellation ct (fun ct -> Task.WhenAny(startWaits ct)) }
     /// Starts an independent Task that handles
     /// a) `unpack`ing of `incoming` items
     /// b) `submit`ting them onward (assuming there is capacity within the `maxReadAhead`)

--- a/src/Propulsion/Internal.fs
+++ b/src/Propulsion/Internal.fs
@@ -225,7 +225,7 @@ module Stats =
             stddev : TimeSpan option }
 
     open MathNet.Numerics.Statistics
-    let private dumpStats (kind : string) (xs : TimeSpan seq) (log : Serilog.ILogger) =
+    let private dumpStats (log : Serilog.ILogger) (kind : string) (xs : TimeSpan seq) =
         let sortedLatencies = xs |> Seq.map (fun ts -> ts.TotalSeconds) |> Seq.sort |> Seq.toArray
 
         let pc p = SortedArrayStatistics.Percentile(sortedLatencies, p) |> TimeSpan.FromSeconds
@@ -246,47 +246,44 @@ module Stats =
             kind, sortedLatencies.Length, l.max.TotalSeconds, l.p99.TotalSeconds, l.p95.TotalSeconds, l.p50.TotalSeconds, l.min.TotalSeconds, l.avg.TotalSeconds, stdDev)
 
     /// Operations on an instance are safe cross-thread
-    type ConcurrentLatencyStats(kind) =
+    type ConcurrentLatencyStats(label) =
         let buffer = System.Collections.Concurrent.ConcurrentStack<TimeSpan>()
         member _.Record value = buffer.Push value
-        member _.Dump(log : Serilog.ILogger) =
+        member _.Dump(log: Serilog.ILogger) =
             if not buffer.IsEmpty then
-                dumpStats kind buffer log
+                dumpStats log label buffer
                 buffer.Clear() // yes, there is a race
 
     /// Not thread-safe, i.e. suitable for use in a Stats handler only
-    type LatencyStats(kind) =
+    type LatencyStats(label) =
         let buffer = ResizeArray<TimeSpan>()
         member _.Record value = buffer.Add value
-        member _.Dump(log : Serilog.ILogger) =
+        member _.Dump(log: Serilog.ILogger) =
             if buffer.Count <> 0 then
-                dumpStats kind buffer log
+                dumpStats log label buffer
                 buffer.Clear()
-    /// Not thread-safe, i.e. suitable for use in a Stats handler only
-    type LatencyStatsSet(?totalLabel) =
-        let totalLabel = defaultArg totalLabel "      TOTAL"
-        let groups = Dictionary<string, ResizeArray<TimeSpan>>()
-        member _.Record(kind, value: TimeSpan) =
-            match groups.TryGetValue kind with
-            | false, _ -> let n = ResizeArray() in n.Add value; groups.Add(kind, n)
-            | true, buf -> buf.Add value
-        member _.Dump(log : Serilog.ILogger) =
-            let max = groups.Keys |> Seq.map String.length |> Seq.max
-            for name in Seq.sort groups.Keys do
-                dumpStats (name.PadRight(max)) groups[name] log
-        member _.DumpGrouped(f, log : Serilog.ILogger) =
-            dumpStats totalLabel (groups |> Seq.collect (fun kv -> kv.Value)) log
-            let clusters =
-                groups
-                |> Seq.groupBy (fun kv -> f kv.Key)
-                |> Seq.sortBy fst
-                |> Seq.toArray
 
-            let max = clusters |> Seq.map (fst >> String.length) |> Seq.max
+    /// Not thread-safe, i.e. suitable for use in a Stats handler only
+    type LatencyStatsSet() =
+        let buckets = Dictionary<string, ResizeArray<TimeSpan>>()
+        let emit log names =
+            let maxGroupLen = names |> Seq.map String.length |> Seq.max
+            fun (label: string) -> dumpStats log (label.PadRight maxGroupLen)
+        member _.Record(bucket, value: TimeSpan) =
+            match buckets.TryGetValue bucket with
+            | false, _ -> let n = ResizeArray() in n.Add value; buckets.Add(bucket, n)
+            | true, buf -> buf.Add value
+        member _.Dump(log: Serilog.ILogger, ?labelSortOrder) =
+            let emit = emit log buckets.Keys
+            for name in Seq.sortBy (defaultArg labelSortOrder id) buckets.Keys do
+                emit name buckets[name]
+        member _.DumpGrouped(bucketGroup, log: Serilog.ILogger, ?totalLabel) =
+            let clusters = buckets |> Seq.groupBy (fun kv -> bucketGroup kv.Key) |> Seq.sortBy fst |> Seq.toArray
+            let emit = emit log (clusters |> Seq.map fst)
+            totalLabel |> Option.iter (fun l -> emit l (buckets |> Seq.collect (fun kv -> kv.Value)))
             for name, items in clusters do
-                let lats = seq { for kv in items -> kv.Value }
-                dumpStats (name.PadRight(max)) (Seq.concat lats) log
-        member _.Clear() = groups.Clear()
+                emit name (items |> Seq.collect (fun kv -> kv.Value))
+        member _.Clear() = buckets.Clear()
 
 type LogEventLevel = Serilog.Events.LogEventLevel
 

--- a/src/Propulsion/Streams.fs
+++ b/src/Propulsion/Streams.fs
@@ -341,17 +341,17 @@ module Scheduling =
             let bufferingStats : Log.BufferMetric = { cats = gapCats.Count; streams = gapStreams.Count; events = gapsE; bytes = gapsB }
             let malformedStats : Log.BufferMetric = { cats = malformedCats.Count; streams = malformedStreams.Count; events = malformedE; bytes = malformedB }
             let m = Log.Metric.SchedulerStateReport (synced, busyStats, readyStats, bufferingStats, malformedStats)
-            (log |> Log.withMetric m).Information("Streams Synced {synced:n0} Purged {purged:n0} Active {busy:n0}/{busyMb:n1}MB Ready {ready:n0}/{readyMb:n1}MB Waiting {waiting}/{waitingMb:n1}MB Malformed {malformed}/{malformedMb:n1}MB",
+            (log |> Log.withMetric m).Information("STATE Synced {synced:n0} Purged {purged:n0} Active {busy:n0}/{busyMb:n1}MB Ready {ready:n0}/{readyMb:n1}MB Waiting {waiting}/{waitingMb:n1}MB Malformed {malformed}/{malformedMb:n1}MB",
                                                   synced, totalPurged, busyCount, Log.miB busyB, ready, Log.miB readyB, gaps, Log.miB gapsB, malformed, Log.miB malformedB)
             if busyCats.Any then log.Information(" Active Categories, events {@busyCats}", Seq.truncate 5 busyCats.StatsDescending)
             if readyCats.Any then log.Information(" Ready Categories, events {@readyCats}", Seq.truncate 5 readyCats.StatsDescending)
-            if readyCats.Any then log.Information(" Ready Streams, KB {@readyStreams}", Seq.truncate 5 readyStreams.StatsDescending)
+                                  log.Information(" Ready Streams, KB {@readyStreams}", Seq.truncate 5 readyStreams.StatsDescending)
             if gapStreams.Any then log.Information(" Waiting Streams, KB {@waitingStreams}", Seq.truncate 5 gapStreams.StatsDescending)
             if malformedStreams.Any then log.Information(" Malformed Streams, MB {@malformedStreams}", malformedStreams.StatsDescending)
             gapStreams.Any
 
     [<Struct; NoComparison; NoEquality>]
-    type InternalResult<'R> = { duration : TimeSpan; stream : FsCodec.StreamName; progressed : bool; result : 'R }
+    type InternalResult<'R> = { duration: TimeSpan; stream: FsCodec.StreamName; index: int64; progressed: bool; result: 'R }
 
     type [<Struct; NoEquality; NoComparison>] BufferState = Idle | Active | Full
 
@@ -384,6 +384,7 @@ module Scheduling =
                     state.Remove sn |> ignore
                     res.ts
                 member _.State = walkAges state |> renderState
+                member _.Contains sn = state.ContainsKey sn
             /// Represents state of streams where the handler did not make progress on the last execution either intentionally or due to an exception
             type private Repeating() =
                 let state = Dictionary<FsCodec.StreamName, StreamState>()
@@ -393,6 +394,13 @@ module Scheduling =
                          if state.TryGetValue(sn, &v) then v.count <- v.count + 1
                          else state.Add(sn, { ts = startTs; count = 1 })
                 member _.State = walkAges state |> renderState
+                member _.Contains sn = state.ContainsKey sn
+                member _.TryGet sn = match state.TryGetValue sn with true, v -> ValueSome v.count | _ -> ValueNone
+                member x.OldestIsOlderThan threshold =
+                    let _, struct (oldest, _) = x.State
+                    oldest > threshold
+
+            type [<Struct>] State = Running | Failing of c: int | Stuck of c2: int | Waiting
             /// Collates all state and reactions to manage the list of busy streams based on callbacks/notifications from the Dispatcher
             type Monitor() =
                 let active, failing, stuck = Active(), Repeating(), Repeating()
@@ -405,6 +413,17 @@ module Scheduling =
                     let startTs = active.TakeFinished(sn)
                     failing.HandleResult(sn, not succeeded, startTs)
                     stuck.HandleResult(sn, succeeded && not progressed, startTs)
+                member _.Classify(sn) =
+                    match failing.TryGet sn with
+                    | ValueSome count -> Failing count
+                    | ValueNone ->
+                        match stuck.TryGet sn with
+                        | ValueSome count -> Stuck count
+                        | ValueNone ->
+                            if active.Contains sn then Running
+                            else Waiting
+                member _.IsFailing(failingThreshold: TimeSpan) =
+                    failing.OldestIsOlderThan failingThreshold || stuck.OldestIsOlderThan TimeSpan.Zero
                 member _.DumpState(log : ILogger) =
                     let dump state struct (streams, attempts) ages =
                         if streams <> 0 then
@@ -459,11 +478,12 @@ module Scheduling =
 
     /// Gathers stats pertaining to the core projection/ingestion activity
     [<AbstractClass>]
-    type Stats<'R, 'E>(log : ILogger, statsInterval : TimeSpan, stateInterval : TimeSpan) =
+    type Stats<'R, 'E>(log: ILogger, statsInterval: TimeSpan, stateInterval: TimeSpan, [<O; D null>] ?failThreshold) =
+        let failThreshold = defaultArg failThreshold stateInterval
         let metricsLog = log.ForContext("isMetric", true)
         let monitor, monitorInterval = Stats.Busy.Monitor(), IntervalTimer(TimeSpan.FromSeconds 1.)
         let stateStats = Stats.StateStats()
-        let oks, exns, rateLimited, timeouts = Stats.LatencyStats("ok"), Stats.LatencyStats("exceptions"), Stats.LatencyStats("rateLimited"), Stats.LatencyStats("timedOut")
+        let oks, exns, rateLimited, timeouts = Stats.LatencyStats("         ok"), Stats.LatencyStats(" exceptions"), Stats.LatencyStats("rateLimited"), Stats.LatencyStats("   timedOut")
         let mutable cycles, batchesCompleted, batchesStarted, streamsStarted, eventsStarted, streamsWrittenAhead, eventsWrittenAhead = 0, 0, 0, 0, 0, 0, 0
 
         member val Log = log
@@ -484,6 +504,9 @@ module Scheduling =
             monitor.DumpState x.Log
             x.DumpStats()
 
+        member _.IsFailing = monitor.IsFailing failThreshold
+        member _.Classify sn = monitor.Classify sn
+
         member _.RecordIngested(streams, events, skippedStreams, skippedEvents) =
             batchesStarted <- batchesStarted + 1
             streamsStarted <- streamsStarted + streams
@@ -502,9 +525,13 @@ module Scheduling =
             stateStats.Ingest(state)
             x.StateInterval.IfDueRestart()
 
-        /// Allows an ingester or projector to wire in custom stats (typically based on data gathered in a `Handle` override)
+        /// Allows an ingester or projector to wire in custom stats since the last interval (typically based on data gathered in a `Handle` override)
         abstract DumpStats : unit -> unit
         default _.DumpStats () = ()
+
+        /// Allows an ingester or projector to trigger dumping of accumulated statistics (less frequent than DumpStats)
+        abstract DumpState : unit -> unit
+        default _.DumpState () = ()
 
         /// Allows serialization of the emission of statistics where multiple Schedulers are active (via an externally managed lock object)
         abstract Serialize : (unit -> unit) -> unit
@@ -567,10 +594,18 @@ module Scheduling =
                     if x.streamToRequiredIndex.TryGetValue(stream, &requiredIndex) && requiredIndex <= index then
                         x.streamToRequiredIndex.Remove stream |> ignore
 
-            member _.Dump(log : ILogger, force) =
+            member _.Dump(log : ILogger, force, classify: FsCodec.StreamName -> Stats.Busy.State) =
                 if (force || log.IsEnabled LogEventLevel.Debug) && pending.Count <> 0 then
+                    let stuck, failing, running, waiting = ResizeArray(), ResizeArray(), ResizeArray(), ResizeArray()
                     let h = pending.Peek()
-                    log.Write((if force then LogEventLevel.Information else LogEventLevel.Debug), "Active Batch {streams}", h.streamToRequiredIndex)
+                    for x in h.streamToRequiredIndex do
+                        match classify x.Key with
+                        | Stats.Busy.Stuck count -> stuck.Add struct(x.Key, x.Value, count)
+                        | Stats.Busy.Failing count -> failing.Add struct(x.Key, x.Value, count)
+                        | Stats.Busy.Running -> running.Add(ValueTuple.ofKvp x)
+                        | Stats.Busy.Waiting -> waiting.Add(ValueTuple.ofKvp x)
+                    log.Write((if force then LogEventLevel.Warning else LogEventLevel.Debug),
+                              " Active Batch (sn, version[, attempts]) Stuck {stuck} Failing {failing} Running {running} Waiting {waiting}", stuck, failing, running, waiting)
 
         // We potentially traverse the pending streams thousands of times per second so we reuse buffers for better L2 caching properties
         // NOTE internal reuse of `sortBuffer` and `streamsBuffer` means it's critical to never have >1 of these in flight
@@ -612,7 +647,7 @@ module Scheduling =
 
     /// Defines interface between Scheduler (which owns the pending work) and the Dispatcher which periodically selects work to commence based on a policy
     type IDispatcher<'P, 'R, 'E, 'F> =
-        [<CLIEvent>] abstract member Result : IEvent<struct (TimeSpan * FsCodec.StreamName * bool * Result<'P, 'E>)>
+        [<CLIEvent>] abstract member Result : IEvent<struct (TimeSpan * FsCodec.StreamName * int64 * bool * Result<'P, 'E>)>
         abstract member Pump : CancellationToken -> Task<unit>
         abstract member State : struct (int * int)
         abstract member HasCapacity : bool with get
@@ -682,18 +717,18 @@ module Scheduling =
             dispatcher.TryReplenish(candidateItems, handleStarted)
 
         // Ingest information to be gleaned from processing the results into `streams` (i.e. remove stream requirements as they are completed)
-        let handleResult { duration = duration; stream = stream; progressed = p; result = r } =
+        let handleResult { duration = duration; stream = stream; index = i; progressed = p; result = r } =
             match dispatcher.InterpretProgress(streams, stream, r) with
             | ValueSome index, Ok (r : 'R) ->
                 batches.MarkStreamProgress(stream, index)
                 streams.RecordProgress(stream, index)
-                stats.Handle { duration = duration; stream = stream; progressed = p; result = Ok r }
+                stats.Handle { duration = duration; stream = stream; index = i; progressed = p; result = Ok r }
             | ValueNone, Ok (r : 'R) ->
                 streams.RecordNoProgress(stream)
-                stats.Handle { duration = duration; stream = stream; progressed = p; result = Ok r }
+                stats.Handle { duration = duration; stream = stream; index = i; progressed = p; result = Ok r }
             | _, Error exn ->
                 streams.RecordNoProgress(stream)
-                stats.Handle { duration = duration; stream = stream; progressed = p; result = Error exn }
+                stats.Handle { duration = duration; stream = stream; index = i; progressed = p; result = Error exn }
         let tryHandleResults () = tryApplyResults handleResult
 
         // Take an incoming batch of events, correlating it against our known stream state to yield a set of remaining work
@@ -713,26 +748,35 @@ module Scheduling =
             batches.AppendBatch(onCompletion, reqs)
         let ingestBatch () = [| match tryPending () |> ValueOption.bind ingest with ValueSome b -> b | ValueNone -> () |]
 
+        let recordAndPeriodicallyLogStats exiting =
+            if stats.RecordStats() || exiting then
+                stats.Serialize(fun () -> stats.DumpStats(dispatcher.State, batchesWaitingAndRunning ()))
+                stats.StatsInterval.Restart() // manual restart only after we've serviced the call so observers can await completion
+
+        let purgeDue : unit -> bool =
+            match purgeInterval with
+            | Some ts -> IntervalTimer(ts).IfDueRestart
+            | None -> fun () -> false
         let mutable totalPurged = 0
         let purge () =
             let remaining, purged = streams.Purge()
             totalPurged <- totalPurged + purged
             let l = if purged = 0 then LogEventLevel.Debug else LogEventLevel.Information
             Log.Write(l, "PURGED Remaining {buffered:n0} Purged now {count:n0} Purged total {total:n0}", remaining, purged, totalPurged)
-        let purgeDue : unit -> bool =
-            match purgeInterval with
-            | Some ts -> IntervalTimer(ts).IfDueRestart
-            | None -> fun () -> false
-
-        let recordStats force =
-            if stats.RecordStats() || force then
-                stats.Serialize(fun () -> stats.DumpStats(dispatcher.State, batchesWaitingAndRunning ()))
-                stats.StatsInterval.Restart() // manual restart only after we've serviced the call so observers can await completion
+        let recordAndPeriodicallyLogState exiting dispatcherState =
+            if stats.RecordState(dispatcherState) || exiting then
+                let log = stats.Log
+                let dumpStreamStates (eventSize : FsCodec.ITimelineEvent<'F> -> int) =
+                    let hasGaps = streams.Dump(log, totalPurged, eventSize)
+                    batches.Dump(log, exiting || hasGaps || stats.IsFailing, stats.Classify)
+                dumpState dumpStreamStates log
+                stats.DumpState()
+                if not exiting && purgeDue () then purge ()
         let sleepIntervalMs = match idleDelay with Some ts -> TimeSpan.toMs ts | None -> 1000
         let wakeForResults = defaultArg wakeForResults false
 
         member _.Pump(abend, ct : CancellationToken) = task {
-            use _ = dispatcher.Result.Subscribe(fun struct (t, s, pr, r) -> writeResult { duration = t; stream = s; progressed = pr; result = r })
+            use _ = dispatcher.Result.Subscribe(fun struct (t, s, i, pr, r) -> writeResult { duration = t; stream = s; index = i; progressed = pr; result = r })
             Task.start (fun () -> task { try do! dispatcher.Pump ct
                                          with e -> abend (AggregateException e) })
             let inline ts () = Stopwatch.timestamp ()
@@ -742,18 +786,9 @@ module Scheduling =
             let ingestBatches () = let ts, b = ts (), ingestBatch () in t.RecordIngest ts; b
             let ingestStreamsOnly () = let ts = ts () in let r = ingestStreams () in t.RecordDispatchNone ts; r
 
-            let recordState force dispatcherState =
-                if stats.RecordState(dispatcherState) || force then
-                    let log = stats.Log
-                    let dumpStreamStates (eventSize : FsCodec.ITimelineEvent<'F> -> int) =
-                        let hasGaps = streams.Dump(log, totalPurged, eventSize)
-                        batches.Dump(log, hasGaps)
-                    dumpState dumpStreamStates log
-                    true
-                else false
-
-            let reportStats force = let ts = ts () in recordStats force; t.RecordStats ts
-            while not ct.IsCancellationRequested do
+            let mutable exiting = false
+            while not exiting do
+                exiting <- ct.IsCancellationRequested
                 // 1. propagate write write outcomes to buffer (can mark batches completed etc)
                 let processedResults = processResults ()
                 // 2. top up provisioning of writers queue
@@ -762,10 +797,15 @@ module Scheduling =
                 let struct (dispatched, hasCapacity) =
                     if not dispatcher.HasCapacity then struct ((*dispatched*)false, (*hasCapacity*)false)
                     else let ts = ts () in let r = tryDispatch (ingestStreams >> ignore) ingestBatches in t.RecordDispatch ts; r
+                // 3. Report the stats per stats interval
+                let statsTs = ts ()
+                if exiting then
+                    processResults () |> ignore
+                    batches.EnumPending() |> ignore
+                recordAndPeriodicallyLogStats exiting; t.RecordStats statsTs
+                // 4. Do a minimal sleep so we don't run completely hot when empty (unless we did something non-trivial)
                 let idle = not processedResults && not dispatched && not (ingestStreamsOnly ())
-                reportStats false
-                // 3. Do a minimal sleep so we don't run completely hot when empty (unless we did something non-trivial)
-                if idle then
+                if idle && not exiting then
                     let sleepTs = ts ()
                     do! Task.runWithCancellation ct (fun ct ->
                             Task.WhenAny[| if hasCapacity then awaitPending ct :> Task
@@ -773,14 +813,9 @@ module Scheduling =
                                            elif not hasCapacity then dispatcher.AwaitCapacity(ct)
                                            Task.Delay(sleepIntervalMs, ct) |])
                     t.RecordSleep sleepTs
-                // 4. Record completion state once per iteration; dumping streams is expensive so needs to be done infrequently
+                // 5. Record completion state once per iteration; dumping streams is expensive so needs to be done infrequently
                 let dispatcherState = if not hasCapacity then Full elif idle then Idle else Active
-                if recordState ct.IsCancellationRequested dispatcherState && purgeDue () then
-                    purge ()
-            // Flush
-            batches.EnumPending() |> ignore
-            processResults () |> ignore
-            reportStats true }
+                recordAndPeriodicallyLogState exiting dispatcherState }
 
         member internal _.SubmitStreams(x : Streams<_>) =
             enqueueStreams x
@@ -820,7 +855,7 @@ module Dispatcher =
 
     /// Kicks off enough work to fill the inner Dispatcher up to capacity
     type internal ItemDispatcher<'R, 'F>(maxDop) =
-        let inner = DopDispatcher<struct (TimeSpan * FsCodec.StreamName * bool * 'R)>(maxDop)
+        let inner = DopDispatcher<struct (TimeSpan * FsCodec.StreamName * int64 * bool * 'R)>(maxDop)
 
         // On each iteration, we try to fill the in-flight queue, taking the oldest and/or heaviest streams first
         let tryFillDispatcher (potential : seq<Scheduling.Item<'F>>) markStarted project =
@@ -845,23 +880,23 @@ module Dispatcher =
     /// Implementation of IDispatcher that feeds items to an item dispatcher that maximizes concurrent requests (within a limit)
     type Concurrent<'P, 'R, 'E, 'F> internal
         (   inner : ItemDispatcher<Result<'P, 'E>, 'F>,
-            project : struct (int64 * Scheduling.Item<'F>) -> CancellationToken -> Task<struct (TimeSpan * FsCodec.StreamName * bool * Result<'P, 'E>)>,
+            project : struct (int64 * Scheduling.Item<'F>) -> CancellationToken -> Task<struct (TimeSpan * FsCodec.StreamName * int64 * bool * Result<'P, 'E>)>,
             interpretProgress : Scheduling.StreamStates<'F> -> FsCodec.StreamName -> Result<'P, 'E> -> struct (int64 voption * Result<'R, 'E>)) =
         static member Create
             (   maxDop,
-                project : FsCodec.StreamName -> FsCodec.ITimelineEvent<'F>[] -> CancellationToken -> Task<struct (bool * Result<'P, 'E>)>,
+                project : FsCodec.StreamName -> FsCodec.ITimelineEvent<'F>[] -> CancellationToken -> Task<struct (int64 * bool * Result<'P, 'E>)>,
                 interpretProgress) =
             let project struct (startTs, item : Scheduling.Item<'F>) (ct : CancellationToken) = task {
-                let! struct (progressed, res) = project item.stream item.span ct
-                return struct (Stopwatch.elapsed startTs, item.stream, progressed, res) }
+                let! struct (index, progressed, res) = project item.stream item.span ct
+                return struct (Stopwatch.elapsed startTs, item.stream, index, progressed, res) }
             Concurrent<_, _, _, _>(ItemDispatcher(maxDop), project, interpretProgress)
         static member Create(maxDop, prepare : Func<_, _, _>, handle : Func<_, _, CancellationToken, Task<_>>, toIndex : Func<_, 'R, int64>) =
             let project sn span ct = task {
                 let struct (met, span : FsCodec.ITimelineEvent<'F>[]) = prepare.Invoke(sn, span)
                 try let! struct (spanResult, outcome) = handle.Invoke(sn, span, ct)
                     let index' = toIndex.Invoke(span, spanResult)
-                    return struct (index' > span[0].Index, Ok struct (index', met, outcome))
-                with e -> return struct (false, Error struct (met, e)) }
+                    return struct (StreamSpan.idx span, index' > StreamSpan.idx span, Ok struct (index', met, outcome))
+                with e -> return struct (StreamSpan.idx span, false, Error struct (met, e)) }
             let interpretProgress (_streams : Scheduling.StreamStates<'F>) _stream = function
                 | Ok struct (index, met, outcome) -> struct (ValueSome index, Ok struct (met, outcome))
                 | Error struct (stats, exn) -> ValueNone, Error struct (stats, exn)
@@ -879,9 +914,9 @@ module Dispatcher =
     type Batched<'F>
         (   select : Func<Scheduling.Item<'F> seq, Scheduling.Item<'F>[]>,
             handle : Scheduling.Item<'F>[] -> CancellationToken ->
-                     Task<struct (TimeSpan * FsCodec.StreamName * bool * Result<struct (int64 * struct (StreamSpan.Metrics * unit)), struct (StreamSpan.Metrics * exn)>)[]>) =
+                     Task<struct (TimeSpan * FsCodec.StreamName * int64 * bool * Result<struct (int64 * struct (StreamSpan.Metrics * unit)), struct (StreamSpan.Metrics * exn)>)[]>) =
         let inner = DopDispatcher 1
-        let result = Event<struct (TimeSpan * FsCodec.StreamName * bool * Result<struct (int64 * struct (StreamSpan.Metrics * unit)), struct (StreamSpan.Metrics * exn)>)>()
+        let result = Event<struct (TimeSpan * FsCodec.StreamName * int64 * bool * Result<struct (int64 * struct (StreamSpan.Metrics * unit)), struct (StreamSpan.Metrics * exn)>)>()
 
         // On each iteration, we offer the ordered work queue to the selector
         // we propagate the selected streams to the handler
@@ -912,8 +947,8 @@ module Dispatcher =
                 | Error (stats, exn) -> ValueNone, Error (stats, exn)
 
 [<AbstractClass>]
-type Stats<'Outcome>(log : ILogger, statsInterval, statesInterval) =
-    inherit Scheduling.Stats<struct (StreamSpan.Metrics * 'Outcome), struct (StreamSpan.Metrics * exn)>(log, statsInterval, statesInterval)
+type Stats<'Outcome>(log: ILogger, statsInterval, statesInterval, [<O; D null>] ?failThreshold) =
+    inherit Scheduling.Stats<struct (StreamSpan.Metrics * 'Outcome), struct (StreamSpan.Metrics * exn)>(log, statsInterval, statesInterval, ?failThreshold = failThreshold)
     let okStreams, failStreams, badCats = HashSet(), HashSet(), Stats.CatStats()
     let mutable resultOk, resultExnOther, okEvents, okBytes, exnEvents, exnBytes = 0, 0, 0, 0L, 0, 0L
 
@@ -942,12 +977,12 @@ type Stats<'Outcome>(log : ILogger, statsInterval, statesInterval) =
             resultOk <- resultOk + 1
             base.RecordOk res
             this.HandleOk outcome
-        | { duration = duration; stream = stream; result = Error ((es, bs), Exception.Inner exn) } ->
+        | { duration = duration; stream = stream; index = index; result = Error ((es, bs), Exception.Inner exn) } ->
             addBadStream stream failStreams
             exnEvents <- exnEvents + es
             exnBytes <- exnBytes + int64 bs
             resultExnOther <- resultExnOther + 1
-            base.RecordExn(res, this.Classify exn, log.ForContext("stream", stream).ForContext("events", es).ForContext("duration", duration), exn)
+            base.RecordExn(res, this.Classify exn, log.ForContext("stream", stream).ForContext("index", index).ForContext("events", es).ForContext("duration", duration), exn)
 
     abstract member HandleOk : outcome : 'Outcome -> unit
 
@@ -1050,7 +1085,7 @@ type Batched private () =
             ?ingesterStatsInterval, ?requireCompleteStreams)
         : Sink<Ingestion.Ingester<StreamEvent<'F> seq>> =
         let handle (items : Scheduling.Item<'F>[]) ct
-            : Task<struct (TimeSpan * FsCodec.StreamName * bool * Result<struct (int64 * struct (StreamSpan.Metrics * unit)), struct (StreamSpan.Metrics * exn)>)[]> = task {
+            : Task<struct (TimeSpan * FsCodec.StreamName * int64 * bool * Result<struct (int64 * struct (StreamSpan.Metrics * unit)), struct (StreamSpan.Metrics * exn)>)[]> = task {
             let sw = Stopwatch.start ()
             let avgElapsed () =
                 let tot = float sw.ElapsedMilliseconds
@@ -1063,16 +1098,16 @@ type Batched private () =
                         | item, Ok index' ->
                             let used = item.span |> Seq.takeWhile (fun e -> e.Index <> index' ) |> Array.ofSeq
                             let metrics = StreamSpan.metrics eventSize used
-                            struct (ae, item.stream, true, Ok struct (index', struct (metrics, ())))
+                            struct (ae, item.stream, StreamSpan.idx item.span, index' > item.span[0].Index, Ok struct (index', struct (metrics, ())))
                         | item, Error exn ->
                             let metrics = StreamSpan.metrics eventSize item.span
-                            ae, item.stream, false, Error struct (metrics, exn) |]
+                            ae, item.stream, StreamSpan.idx item.span, false, Error struct (metrics, exn) |]
             with e ->
                 let ae = avgElapsed ()
                 return
                     [| for x in items ->
                         let metrics = StreamSpan.metrics eventSize x.span
-                        ae, x.stream, false, Error struct (metrics, e) |] }
+                        ae, x.stream, StreamSpan.idx x.span, false, Error struct (metrics, e) |] }
         let dispatcher = Dispatcher.Batched(select, handle)
         let dumpStreams logStreamStates _log = logStreamStates eventSize
         let scheduler = Scheduling.Engine(dispatcher, stats, dumpStreams,

--- a/src/Propulsion/Streams.fs
+++ b/src/Propulsion/Streams.fs
@@ -406,7 +406,7 @@ module Scheduling =
             type Monitor() =
                 let active, failing, stuck = Active(), Repeating(), Repeating()
                 let emit (log: ILogger) level state struct (streams, attempts) struct (oldest: TimeSpan, newest: TimeSpan) =
-                    log.Write(level, " {state,7} {streams,3} for {newest:n1}-{oldest:n1}s, {attempts} attempts",
+                    log.Write(level, " {state,-7} {streams,3} for {newest:n1}-{oldest:n1}s, {attempts} attempts",
                                     state, streams, newest.TotalSeconds, oldest.TotalSeconds, attempts)
                 member _.HandleStarted(sn, ts) =
                     active.HandleStarted(sn, ts)

--- a/src/Propulsion/Sync.fs
+++ b/src/Propulsion/Sync.fs
@@ -76,7 +76,7 @@ type Factory private () =
             logStreamStates eventSize
             match dumpExternalStats with Some f -> f log | None -> ()
         let scheduler =
-            Scheduling.Engine<_, struct (StreamSpan.Metrics * TimeSpan * 'Outcome), struct (StreamSpan.Metrics * exn), 'F>
+            Scheduling.Engine<struct (int64 * StreamSpan.Metrics * TimeSpan * 'Outcome), struct (StreamSpan.Metrics * TimeSpan * 'Outcome), struct (StreamSpan.Metrics * exn), 'F>
                 (dispatcher, stats, dumpStreams, pendingBufferSize = maxReadAhead, ?idleDelay = idleDelay, ?purgeInterval = purgeInterval)
 
         Projector.Pipeline.Start(log, scheduler.Pump, maxReadAhead, scheduler, stats.StatsInterval.Period)

--- a/tests/Propulsion.Kafka.Integration/ConsumersIntegration.fs
+++ b/tests/Propulsion.Kafka.Integration/ConsumersIntegration.fs
@@ -126,7 +126,7 @@ module Helpers =
                   for event in stream.span do
                       c <- c + 1
                       do! handler (getConsumer()) (deserialize consumerId event)
-                (log : ILogger).Information("BATCHED CONSUMER Handled {c} events in {l} streams", c, streams.Length )
+                (log : ILogger).Information("BATCHED CONSUMER Handled {c} events in {l} streams", c, streams.Length)
                 let ts = Stopwatch.elapsed ts
                 return seq { for x in streams -> struct (ts, Ok (Propulsion.Sinks.Events.nextIndex x.span)) } }
             let stats = Stats(log, TimeSpan.FromSeconds 5.,TimeSpan.FromSeconds 5.)

--- a/tests/Propulsion.Kafka.Integration/ConsumersIntegration.fs
+++ b/tests/Propulsion.Kafka.Integration/ConsumersIntegration.fs
@@ -119,14 +119,16 @@ module Helpers =
             // When offered, take whatever is pending
             let select = Array.ofSeq
             // when processing, declare all items processed each time we're invoked
-            let handle (streams : Propulsion.Sinks.StreamState[]) = async {
+            let handle (streams: Propulsion.Sinks.StreamState[]) = async {
+                let ts = Stopwatch.timestamp ()
                 let mutable c = 0
                 for stream in streams do
                   for event in stream.span do
                       c <- c + 1
                       do! handler (getConsumer()) (deserialize consumerId event)
                 (log : ILogger).Information("BATCHED CONSUMER Handled {c} events in {l} streams", c, streams.Length )
-                return seq { for x in streams -> Ok (Propulsion.Streams.StreamSpan.ver x.span) } }
+                let ts = Stopwatch.elapsed ts
+                return seq { for x in streams -> struct (ts, Ok (Propulsion.Sinks.Events.nextIndex x.span)) } }
             let stats = Stats(log, TimeSpan.FromSeconds 5.,TimeSpan.FromSeconds 5.)
             let messageIndexes = StreamNameSequenceGenerator()
             let consumer =


### PR DESCRIPTION
Add
- `Stats`: `DumpState` to include custom output alongside internal ones
- Generalize stats gathering to `LatencyStatsSet`
- Add `index` and `eventType` properties to Unhandled exception logging
- Emits stuck/failing stream names in head batch State output after `failTheshold` (defaults to StateInterval)
- Reordered output so it gets emitted after the normal Stats on shutdown
- Ingester emits state on shutdown

Change
- Sinks.StartBatched results now require a latency per result (as a `TimeSpan`)
- Major cleanup of internal timing/progress management