### PR TITLE
chore: Update to FsCodec.NewtonsoftJson 3.0.0-rc.14.1

### DIFF
--- a/src/Propulsion.CosmosStore/Propulsion.CosmosStore.fsproj
+++ b/src/Propulsion.CosmosStore/Propulsion.CosmosStore.fsproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="MinVer" Version="4.2.0" PrivateAssets="All" />
 
-    <PackageReference Include="Equinox.CosmosStore" Version="4.0.0-rc.14.2" />
+    <PackageReference Include="Equinox.CosmosStore" Version="4.0.0-rc.14.5" />
     <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.0-rc.14.1" />
   </ItemGroup>
 

--- a/src/Propulsion.CosmosStore/Propulsion.CosmosStore.fsproj
+++ b/src/Propulsion.CosmosStore/Propulsion.CosmosStore.fsproj
@@ -19,7 +19,7 @@
     <PackageReference Include="MinVer" Version="4.2.0" PrivateAssets="All" />
 
     <PackageReference Include="Equinox.CosmosStore" Version="4.0.0-rc.14.2" />
-    <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.0-rc.14" />
+    <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.0-rc.14.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Propulsion.CosmosStore3/Propulsion.CosmosStore3.fsproj
+++ b/src/Propulsion.CosmosStore3/Propulsion.CosmosStore3.fsproj
@@ -36,7 +36,7 @@
     <PackageReference Include="MinVer" Version="4.2.0" PrivateAssets="All" />
 
     <PackageReference Include="Equinox.CosmosStore" Version="[3.0.7, 3.99.0]" />
-    <PackageReference Include="FsCodec" Version="3.0.0-rc.14" />
+    <PackageReference Include="FsCodec" Version="3.0.0-rc.14.1" />
     <PackageReference Include="FSharp.Control.TaskSeq" Version="0.4.0-alpha.1" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.27.0" ExcludeAssets="contentfiles" />
   </ItemGroup>

--- a/src/Propulsion.DynamoStore/Propulsion.DynamoStore.fsproj
+++ b/src/Propulsion.DynamoStore/Propulsion.DynamoStore.fsproj
@@ -24,7 +24,7 @@
       <PackageReference Include="MinVer" Version="4.2.0" PrivateAssets="All" />
 
       <PackageReference Include="Equinox.DynamoStore" Version="4.0.0-rc.14.2" />
-      <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.0-rc.14" />
+      <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.0-rc.14.1" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/Propulsion.DynamoStore/Propulsion.DynamoStore.fsproj
+++ b/src/Propulsion.DynamoStore/Propulsion.DynamoStore.fsproj
@@ -23,7 +23,7 @@
     <ItemGroup>
       <PackageReference Include="MinVer" Version="4.2.0" PrivateAssets="All" />
 
-      <PackageReference Include="Equinox.DynamoStore" Version="4.0.0-rc.14.2" />
+      <PackageReference Include="Equinox.DynamoStore" Version="4.0.0-rc.14.5" />
       <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.0-rc.14.1" />
     </ItemGroup>
     

--- a/src/Propulsion.EventStore/Propulsion.EventStore.fsproj
+++ b/src/Propulsion.EventStore/Propulsion.EventStore.fsproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="MinVer" Version="4.2.0" PrivateAssets="All" />
 
-    <PackageReference Include="Equinox.EventStore" Version="4.0.0-rc.14.2" />
+    <PackageReference Include="Equinox.EventStore" Version="4.0.0-rc.14.5" />
     <PackageReference Include="FsCodec.Box" Version="3.0.0-rc.14.1" />
   </ItemGroup>
 

--- a/src/Propulsion.EventStore/Propulsion.EventStore.fsproj
+++ b/src/Propulsion.EventStore/Propulsion.EventStore.fsproj
@@ -17,7 +17,7 @@
     <PackageReference Include="MinVer" Version="4.2.0" PrivateAssets="All" />
 
     <PackageReference Include="Equinox.EventStore" Version="4.0.0-rc.14.2" />
-    <PackageReference Include="FsCodec.Box" Version="3.0.0-rc.14" />
+    <PackageReference Include="FsCodec.Box" Version="3.0.0-rc.14.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Propulsion.EventStoreDb/Propulsion.EventStoreDb.fsproj
+++ b/src/Propulsion.EventStoreDb/Propulsion.EventStoreDb.fsproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="MinVer" Version="4.2.0" PrivateAssets="All" />
 
-    <PackageReference Include="Equinox.EventStoreDb" Version="4.0.0-rc.14.2" />
+    <PackageReference Include="Equinox.EventStoreDb" Version="4.0.0-rc.14.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Propulsion.Kafka/Propulsion.Kafka.fsproj
+++ b/src/Propulsion.Kafka/Propulsion.Kafka.fsproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="MinVer" Version="4.2.0" PrivateAssets="All" />
 
-    <PackageReference Include="FsCodec.NewtonsoftJson" Version="3.0.0-rc.14" />
+    <PackageReference Include="FsCodec.NewtonsoftJson" Version="3.0.0-rc.14.1" />
     <PackageReference Include="FsKafka" Version="[1.7.0, 1.9.99)" />
   </ItemGroup>
 

--- a/src/Propulsion.MemoryStore/Propulsion.MemoryStore.fsproj
+++ b/src/Propulsion.MemoryStore/Propulsion.MemoryStore.fsproj
@@ -19,7 +19,7 @@
     <PackageReference Include="MinVer" Version="4.2.0" PrivateAssets="All" />
 
     <PackageReference Include="FsCodec.Box" Version="3.0.0-rc.14.1" />
-    <PackageReference Include="Equinox.MemoryStore" Version="4.0.0-rc.14.2" />
+    <PackageReference Include="Equinox.MemoryStore" Version="4.0.0-rc.14.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Propulsion.MemoryStore/Propulsion.MemoryStore.fsproj
+++ b/src/Propulsion.MemoryStore/Propulsion.MemoryStore.fsproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="MinVer" Version="4.2.0" PrivateAssets="All" />
 
-    <PackageReference Include="FsCodec.Box" Version="3.0.0-rc.14" />
+    <PackageReference Include="FsCodec.Box" Version="3.0.0-rc.14.1" />
     <PackageReference Include="Equinox.MemoryStore" Version="4.0.0-rc.14.2" />
   </ItemGroup>
 

--- a/src/Propulsion/Propulsion.fsproj
+++ b/src/Propulsion/Propulsion.fsproj
@@ -25,7 +25,7 @@
     <!-- Exclude FSharp.Core.xml due to temporarly malformed state -->
     <PackageReference Include="FSharp.Core" Version="6.0.0" ExcludeAssets="contentfiles" />
 
-    <PackageReference Include="FsCodec" Version="3.0.0-rc.14" />
+    <PackageReference Include="FsCodec" Version="3.0.0-rc.14.1" />
     <PackageReference Include="MathNet.Numerics" Version="4.15.0" />
     <!--    NB TEMP; needs to be shipped out-->
     <PackageReference Include="prometheus-net" Version="3.6.0" />

--- a/tests/Propulsion.Kafka.Integration/Propulsion.Kafka.Integration.fsproj
+++ b/tests/Propulsion.Kafka.Integration/Propulsion.Kafka.Integration.fsproj
@@ -19,7 +19,6 @@
 
   <ItemGroup>
 	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="unquote" Version="6.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">

--- a/tests/Propulsion.MessageDb.Integration/Propulsion.MessageDb.Integration.fsproj
+++ b/tests/Propulsion.MessageDb.Integration/Propulsion.MessageDb.Integration.fsproj
@@ -9,12 +9,11 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.0-rc.14" />
+        <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.0-rc.14.1" />
         <PackageReference Include="TypeShape" Version="10.0.0" />
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="unquote" Version="6.1.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">


### PR DESCRIPTION
The FsCodec update in question ups the minimum Newtonsoft.Json version to 13.0.3

This trims overrides that were in place to ensure the correct version of the transitive dependency was being used

The Equinox update is solely for completeness