### PR TITLE
fix(DynamoStore)!: Restore TranchePositions to Flush

### DIFF
--- a/src/Propulsion.CosmosStore/FeedObserver.fs
+++ b/src/Propulsion.CosmosStore/FeedObserver.fs
@@ -175,8 +175,4 @@ type internal Observers<'Items>(log: Serilog.ILogger, processorName, buildObserv
         for Observer o, gap in remainingWork do
             o.RecordEstimatedGap(gap)
 
-    // TODO make base class just work
-    member _.Current() =
-        let xs = (this : Propulsion.Feed.Core.ISourcePositions<_>).Current()
-        [| for kv in xs -> System.Collections.Generic.KeyValuePair(kv.Key, kv.Value :> Propulsion.Feed.Core.ITranchePosition) |]
     interface IDisposable with member _.Dispose() = base.Iter (fun x -> (x : IDisposable).Dispose())

--- a/src/Propulsion.DynamoStore.Lambda/SqsNotificationBatch.fs
+++ b/src/Propulsion.DynamoStore.Lambda/SqsNotificationBatch.fs
@@ -17,9 +17,10 @@ type SqsNotificationBatch(event: SQSEvent) =
     /// Yields the set of Index Partitions on which we are anticipating there to be work available
     member val Tranches = seq { for trancheId, _, _ in inputs -> trancheId } |> Seq.distinct |> Seq.toArray
     /// Correlates the achieved Tranche Positions with those that triggered the work; requeue any not yet acknowledged as processed
-    member _.FailuresForPositionsNotReached(updated: IReadOnlyDictionary<_, _>) =
+    member _.FailuresForPositionsNotReached(updated: Propulsion.Feed.TranchePositions) =
         let res = SQSBatchResponse()
         let incomplete = ResizeArray()
+        let updated = Dictionary updated
         for trancheId, pos, messageId in inputs do
             match updated.TryGetValue trancheId with
             | true, pos' when pos' >= pos -> ()

--- a/src/Propulsion.DynamoStore/DynamoStoreSource.fs
+++ b/src/Propulsion.DynamoStore/DynamoStoreSource.fs
@@ -188,7 +188,7 @@ type DynamoStoreSource
     abstract member Pump: ct: CancellationToken -> Task<unit>
     default x.Pump(ct) = base.Pump(x.ListTranches, ct)
 
-    abstract member Start: unit -> Propulsion.SourcePipeline<Propulsion.Feed.Core.FeedMonitor>
+    abstract member Start: unit -> Propulsion.Feed.Core.SourcePipeline
     default x.Start() = base.Start(x.Pump)
 
     /// Pumps to the Sink until either the specified timeout has been reached, or all items in the Source have been fully consumed

--- a/src/Propulsion.Feed/PeriodicSource.fs
+++ b/src/Propulsion.Feed/PeriodicSource.fs
@@ -104,7 +104,7 @@ type PeriodicSource
     /// Any exception from <c>readTranches</c> or <c>crawl</c> will be propagated in order to enable termination of the overall projector loop
     abstract member StartAsync: crawl: Func<TrancheId, IAsyncEnumerable<struct (TimeSpan * SourceItem<Propulsion.Sinks.EventBody>[])>>
                                 * ?readTranches: Func<CancellationToken, Task<TrancheId[]>>
-                                -> Propulsion.SourcePipeline<Propulsion.Feed.Core.FeedMonitor>
+                                -> Propulsion.Feed.Core.SourcePipeline
     default x.StartAsync(crawl, ?readTranches) =
         let readTranches = match readTranches with Some f -> f.Invoke | None -> fun _ct -> task { return [| TrancheId.parse "0" |] }
         base.Start(fun ct -> x.Pump(readTranches, crawl, ct))

--- a/src/Propulsion.MessageDb/MessageDbSource.fs
+++ b/src/Propulsion.MessageDb/MessageDbSource.fs
@@ -102,7 +102,7 @@ type MessageDbSource =
     abstract member Pump: CancellationToken -> Task<unit>
     default x.Pump(ct) = base.Pump(x.ListTranches, ct)
 
-    abstract member Start: unit -> Propulsion.SourcePipeline<Propulsion.Feed.Core.FeedMonitor>
+    abstract member Start: unit -> Propulsion.Feed.Core.SourcePipeline
     default x.Start() = base.Start(x.Pump)
 
     /// Pumps to the Sink until either the specified timeout has been reached, or all items in the Source have been fully consumed

--- a/src/Propulsion/Feed.fs
+++ b/src/Propulsion/Feed.fs
@@ -26,6 +26,8 @@ module Position =
     let toInt64 (value: Position): int64 = %value
     let toString (value: Position): string = string value
 
+type TranchePositions = System.Collections.Generic.KeyValuePair<TrancheId, Position>[]
+
 type IFeedCheckpointStore =
 
     /// Determines the starting position, and checkpointing frequency for a given tranche

--- a/src/Propulsion/Pipeline.fs
+++ b/src/Propulsion/Pipeline.fs
@@ -34,12 +34,12 @@ type Pipeline(task: Task<unit>, triggerStop) =
         use _ = ct.Register(Action x.Stop)
         return! x.Await() }
 
- type SourcePipeline<'M>(task, flush: unit -> Task<unit>, triggerStop, monitor: Lazy<'M>) =
+ type SourcePipeline<'M, 'P>(task, flush: unit -> Task<'P>, triggerStop, monitor: Lazy<'M>) =
     inherit Pipeline(task, triggerStop)
 
     member _.Monitor = monitor.Value
-    member _.FlushAsync() = flush ()
-    member x.Flush() = x.FlushAsync() |> Async.AwaitTaskCorrect
+    member _.FlushAsync(): Task<'P> = flush ()
+    member x.Flush(): Async<'P> = x.FlushAsync() |> Async.AwaitTaskCorrect
 
 type SinkPipeline<'Ingester> internal (task: Task<unit>, triggerStop, startIngester) =
     inherit Pipeline(task, triggerStop)

--- a/tests/Propulsion.MessageDb.Integration/Tests.fs
+++ b/tests/Propulsion.MessageDb.Integration/Tests.fs
@@ -142,7 +142,7 @@ let ``It doesn't read the tail event again`` () = task {
 
     use capture = new ActivityCapture()
 
-    do! source.RunUntilCaughtUp(TimeSpan.FromSeconds(10), stats.StatsInterval)
+    do! source.RunUntilCaughtUp(TimeSpan.FromSeconds(10), stats.StatsInterval) |> Task.ignore<Propulsion.Feed.TranchePositions>
 
     // 3 batches fetched, 1 checkpoint read, and 1 checkpoint write
     test <@ capture.Operations.Count = 5 @> }

--- a/tests/Propulsion.Tests/SourceTests.fs
+++ b/tests/Propulsion.Tests/SourceTests.fs
@@ -2,11 +2,8 @@ module Propulsion.Tests.SourceTests
 
 open FSharp.Control
 open Propulsion.Feed
-open Propulsion.Internal
-open Serilog
 open Swensen.Unquote
 open System
-open System.Threading
 open Xunit
 
 type Scenario(testOutput) =
@@ -35,7 +32,7 @@ type Scenario(testOutput) =
         // source runs until someone explicitly stops it, or it throws
         src.Stop()
         // Ensure checkpoints are written
-        do! src.Flush()
+        do! src.FlushAsync() |> Task.ignore<TranchePositions>
         // Yields source exception, if any
         do! src.Await()
         test <@ src.RanToCompletion @> }

--- a/tools/Propulsion.Tool/Program.fs
+++ b/tools/Propulsion.Tool/Program.fs
@@ -379,7 +379,7 @@ module Project =
                 do! source.Monitor.AwaitCompletion(initialWait, awaitFullyCaughtUp = true, logInterval = stats.StatsInterval / 2.) |> Async.AwaitTask
                 source.Stop()
                 do! source.Await() // Let it emit the stats
-                do! source.Flush() // flush checkpoints (currently a no-op)
+                do! source.Flush() |> Async.Ignore<Propulsion.Feed.TranchePositions> // flush checkpoints (currently a no-op)
                 raise <| System.Threading.Tasks.TaskCanceledException "Stopping; FeedMonitor wait completed" } // trigger tear down of sibling waits
             sink.AwaitWithStopOnCancellation() ]
         return! work |> Async.Parallel |> Async.Ignore<unit[]> }


### PR DESCRIPTION
Fixes an oversight: `Flush` needed to yield the positions for the Lambda template in `dotnet-templates` to work cleanly (and that return value had erroneously been dropped in adding CosmosStore's FeedMonitor support recently)