### PR TITLE
fix: Correct/polish shutdown behaviors

### DIFF
--- a/src/Propulsion.CosmosStore/FeedObserver.fs
+++ b/src/Propulsion.CosmosStore/FeedObserver.fs
@@ -160,8 +160,8 @@ type internal Observers<'Items>(log: Serilog.ILogger, processorName, buildObserv
     member _.LogStart(leaseAcquireInterval: TimeSpan, leaseTtl: TimeSpan, leaseRenewInterval: TimeSpan, feedPollInterval: TimeSpan, startFromTail: bool, ?maxItems) =
         log.Information("ChangeFeed {processorName} Lease acquire {leaseAcquireIntervalS:n0}s ttl {ttlS:n0}s renew {renewS:n0}s feedPollInterval {feedPollIntervalS:n0}s Items limit {maxItems} fromTail {fromTail}",
                         processorName, leaseAcquireInterval.TotalSeconds, leaseTtl.TotalSeconds, leaseRenewInterval.TotalSeconds, feedPollInterval.TotalSeconds, Option.toNullable maxItems, startFromTail)
-    member _.LogReaderExn(rangeId: int, ex: exn) =
-        log.Error(ex, "ChangeFeed {processorName}/{partition} error", processorName, rangeId)
+    member _.LogReaderExn(rangeId: int, ex: exn, isNoise: bool) =
+        log.Write((if isNoise then LogEventLevel.Debug else LogEventLevel.Error), ex, "ChangeFeed {processorName}/{partition} error", processorName, rangeId)
     member _.LogHandlerExn(rangeId: int, ex: exn) =
         log.Error(ex, "ChangeFeed {processorName}/{partition} Handler Threw", processorName, rangeId)
     member _.Ingest(context, docs, checkpoint, ct) =

--- a/src/Propulsion.EventStore/EventStoreReader.fs
+++ b/src/Propulsion.EventStore/EventStoreReader.fs
@@ -270,7 +270,7 @@ type EventStoreReader(connections: _[], defaultBatchSize, minBatchSize, tryMapEv
                 let! res = pullAll (slicesStats, stats) (conn, batchSize) (range, true) tryMapEvent postBatch
                 do! awaitInterval
                 match res with
-                | PullResult.EndOfTranche | PullResult.Eof _ -> ()
+                | PullResult.EndOfTranche | PullResult.Eof -> ()
                 | PullResult.Exn e ->
                     batchSize <- adjust batchSize
                     Log.Warning(e, "Tail $all failed, adjusting batch size to {bs}", batchSize) }

--- a/src/Propulsion.Feed/FeedReader.fs
+++ b/src/Propulsion.Feed/FeedReader.fs
@@ -166,7 +166,7 @@ type FeedReader
                 do! submitPage (readLatency, batch)
                 currentPos <- batch.checkpoint
                 lastWasTail <- batch.isTail
-        if stopAtTail then
+        if not ct.IsCancellationRequested && stopAtTail then
             stats.EnteringShutdown()
             let! struct (cur, max) = ingester.AwaitCompleted()
             stats.ShutdownCompleted(cur, max) }

--- a/src/Propulsion/Pipeline.fs
+++ b/src/Propulsion/Pipeline.fs
@@ -64,7 +64,7 @@ type [<AbstractClass; Sealed>] PipelineFactory private () =
             let recordExn (e: exn) = tcs.TrySetException e |> ignore
             let inner () = task {
                 try do! pump ct
-                    // If the source completes all reading cleanly, convey that fact ()
+                    // If the source completes all reading cleanly, convey that fact
                     if not ct.IsCancellationRequested then log.Information "Source drained..."
                     markCompleted ()
                 with e ->

--- a/tools/Propulsion.Tool/Program.fs
+++ b/tools/Propulsion.Tool/Program.fs
@@ -100,8 +100,8 @@ and [<NoComparison; NoEquality; RequireSubcommand>] ProjectParameters =
     interface IArgParserTemplate with
         member a.Usage = a |> function
             | ConsumerGroupName _ ->        "Projector instance context name."
-            | FromTail _ ->                 "(iff fresh projection) - force starting from present Position. Default: Ensure each and every event is projected from the start."
-            | Follow _ ->                   "Stop when the Tail is reached."
+            | FromTail ->                   "(iff fresh projection) - force starting from present Position. Default: Ensure each and every event is projected from the start."
+            | Follow ->                     "Stop when the Tail is reached."
             | MaxItems _ ->                 "Controls checkpointing granularity by adjusting the batch size being loaded from the feed. Default: Unlimited"
 
             | Stats _ ->                    "Do not emit events, only stats."


### PR DESCRIPTION
Polishing the `AwaitWithStopOnCancellation` behavior for Feed and Cosmos sources
- Remove erroneous Cosmos logging
- Resolve Ingester wait deadlock
- Handle cancellation via Ctrl-C correctly