### PR TITLE
fix(Scheduler)!: requireComplete -> requireAll

### DIFF
--- a/src/Propulsion/Streams.fs
+++ b/src/Propulsion/Streams.fs
@@ -157,7 +157,7 @@ module Buffer =
         member x.HeadSpan = x.queue[0]
         member x.QueuePos = x.HeadSpan[0].Index
         member x.IsMalformed = not x.IsEmpty && WritePosMalformed = x.write
-        member x.HasGap = match x.write with WritePosUnknown -> false | w -> w <> x.QueuePos
+        member x.HasGap = match x.write with WritePosUnknown -> not x.IsEmpty && x.QueuePos <> 0L | w -> w <> x.QueuePos
         member x.IsReady = not x.IsEmpty && not x.IsMalformed
 
         member x.WritePos = match x.write with WritePosUnknown | WritePosMalformed -> ValueNone | w -> ValueSome w

--- a/src/Propulsion/Streams.fs
+++ b/src/Propulsion/Streams.fs
@@ -141,9 +141,10 @@ type StreamEvent<'Format> = (struct (FsCodec.StreamName * FsCodec.ITimelineEvent
 
 module Buffer =
 
-    /// NOTE: Optimized Representation as this is the dominant data structure in terms of memory usage - takes it from 24b to a cache-friendlier 16b
     let [<Literal>] WritePosUnknown = -2L // sentinel value for write position signifying `None` (no write position yet established)
     let [<Literal>] WritePosMalformed = -3L // sentinel value for malformed data
+    /// <summary>Buffers events for a stream, tolerating gaps and out of order arrival (see <c>requireAll</c> for scenarios dictating this need)</summary>
+    /// <remarks>Optimized Representation as this is the dominant one in terms of memory usage - takes it from 24b to a cache-friendlier 16b</remarks>
     [<NoComparison; NoEquality; Struct>]
     type StreamState<'Format> = private { write: int64; queue: FsCodec.ITimelineEvent<'Format>[][] } with
         static member Create(write, queue, malformed) =

--- a/tools/Propulsion.Tool/Sync.fs
+++ b/tools/Propulsion.Tool/Sync.fs
@@ -186,15 +186,15 @@ type Stats(log, statsInterval, stateInterval, verboseStore, logExternalStats) =
         if handled > 0 || ignored > 0 then
             if ignored > 0 then log.Information(" Handled {count}, skipped {skipped}", handled, ignored)
             handled <- 0; ignored <- 0
-            intervalLats.Dump(log, "EVENTS")
-            intervalLats.Clear()
         base.DumpStats()
+        intervalLats.Dump(log, "EVENTS")
+        intervalLats.Clear()
     override _.DumpState purge =
-        accEventTypeLats.Dump(log, "ΣEVENTS")
         for cat in Seq.append accHam.Categories accSpam.Categories |> Seq.distinct |> Seq.sort do
             let ham, spam = accHam.StatsDescending(cat) |> Array.ofSeq, accSpam.StatsDescending cat |> Array.ofSeq
             if ham.Length > 00 then log.Information(" Category {cat} handled {@ham}", cat, ham)
             if spam.Length <> 0 then log.Information(" Category {cat} ignored {@spam}", cat, spam)
+        accEventTypeLats.Dump(log, "ΣEVENTS")
         if purge then
             accHam.Clear(); accSpam.Clear()
             accEventTypeLats.Clear()


### PR DESCRIPTION
the `requireComplete` flag (normally used with SinglePassFeedSource; not a mainline scenario) currently has the following semantics:
- alert/don't dispatch if there's a gap
- BUT trust the first batch received to
  a. be safe to dispatch
  b. dictate the write position going forward

When doing a full projection against a changefeed with mutated items (manually updated outside Equinox), this can lead to out of order events

The change here is to make the relatively loose `requireComplete` semantic into a more useful one, `requireAll`, which requires all events processed to start from `0` for each and every stream.

Its conceivable that another more tolerant mode is possible, but this change to the semantics covers both scenarios:
1. projecting from a broken Event Store with events arriving out of order
2. SinglePassFeedSource with items internally being delivered out of order