### PR TITLE
feat(JsonSource): Support HTTP Uris instead of path

### DIFF
--- a/src/Propulsion.Feed/JsonSource.fs
+++ b/src/Propulsion.Feed/JsonSource.fs
@@ -1,6 +1,8 @@
 namespace Propulsion.Feed
 
 open FSharp.Control
+open Propulsion.Internal
+open System.IO
 
 /// <summary>Parses CR separated file with items dumped from a Cosmos Container containing Equinox Items<br/>
 /// Such items can be extracted via Equinox.Tool via <c>eqx query -o JSONFILE cosmos</c>.</summary>
@@ -11,10 +13,21 @@ open FSharp.Control
 /// </remarks>
 type [<Sealed; AbstractClass>] JsonSource private () =
 
+    static member DownloadIfHttpUri filePathOrHttpUri =
+        match Uri.tryParseHttp filePathOrHttpUri with
+        | None -> Task.FromResult filePathOrHttpUri
+        | Some uri -> task {
+            use c = new System.Net.Http.HttpClient()
+            let tmpPath = Path.GetTempFileName()
+            do! c.GetToFile(uri, tmpPath)
+            Serilog.Log.Information("Processing downloaded content in {tmpPath}", tmpPath)
+            return tmpPath }
+
     static member Start(log, statsInterval, filePath, skip, parseFeedDoc, checkpoints, sink, ?truncateTo) =
         let isNonCommentLine (line: string) = System.Text.RegularExpressions.Regex.IsMatch(line, "^\s*#") |> not
         let truncate = match truncateTo with Some count -> Seq.truncate count | None -> id
-        let lines = Seq.append (System.IO.File.ReadLines filePath |> truncate) (Seq.singleton null) // Add a trailing EOF sentinel so checkpoint positions can be line numbers even when finished reading
+        let lines = Seq.append (File.ReadLines filePath |> truncate) (Seq.singleton null) // Add a trailing EOF sentinel so checkpoint positions can be line numbers even when finished reading
+        let sourceId = Path.GetFileName filePath |> SourceId.parse
         let crawl _ _ _ = taskSeq {
             let mutable i = 0
             for line in lines do
@@ -26,5 +39,5 @@ type [<Sealed; AbstractClass>] JsonSource private () =
                                     else System.Text.Json.JsonDocument.Parse line |> parseFeedDoc |> Seq.toArray
                         struct (System.TimeSpan.Zero, ({ items = items; isTail = isEof; checkpoint = Position.parse lineNo }: Core.Batch<_>))
                     with e -> raise <| exn($"File Parse error on L{lineNo}: '{line.Substring(0, 200)}'", e) }
-        let source = Propulsion.Feed.Core.SinglePassFeedSource(log, statsInterval, SourceId.parse filePath, crawl, checkpoints, sink, string)
+        let source = Propulsion.Feed.Core.SinglePassFeedSource(log, statsInterval, sourceId, crawl, checkpoints, sink, string)
         source.Start(fun _ct -> task { return [| TrancheId.parse "0" |] })

--- a/src/Propulsion/Internal.fs
+++ b/src/Propulsion/Internal.fs
@@ -64,6 +64,19 @@ type IntervalTimer(period: TimeSpan) =
         while x.IsTriggered && not timeout.IsDue do
             System.Threading.Thread.Sleep(defaultArg sleepMs 1)
 
+type System.Net.Http.HttpClient with
+
+    member x.GetToFile(uri: Uri, filePath) = task {
+        use! s = x.GetStreamAsync(uri)
+        use fs = System.IO.File.Create(filePath) // Will silently truncate if it exists
+        do! s.CopyToAsync(fs) }
+
+module Uri =
+
+    let tryParseHttp uriOrFilepath =
+        match Uri.TryCreate(uriOrFilepath, UriKind.Absolute) with
+        | true, uri -> Some uri | false, _ -> None
+
 module Exception =
 
     let rec inner (e: exn) =

--- a/tools/Propulsion.Tool/Args.fs
+++ b/tools/Propulsion.Tool/Args.fs
@@ -392,11 +392,11 @@ module Json =
         | [<AltCommandLine "-pos"; Unique>] LineNo of int
         interface IArgParserTemplate with
             member p.Usage = p |> function
-                | Path _ ->                 "specify file path"
+                | Path _ ->                 "specify file path (or a HTTP URL to GET)"
                 | Skip _ ->                 "specify number of lines to skip"
                 | Truncate _ ->             "specify line number to pretend is End of File"
                 | LineNo _ ->               "specify line number to start (1-based)"
-    and Arguments(c: Configuration, p: ParseResults<Parameters>) =
+    and Arguments(p: ParseResults<Parameters>) =
         member val Filepath =               p.GetResult Path
         member val Skip =                   p.TryGetResult(LineNo, fun l -> l - 1) |> Option.defaultWith (fun () -> p.GetResult(Skip, 0))
         member val Trunc =                  p.TryGetResult Truncate

--- a/tools/Propulsion.Tool/Sync.fs
+++ b/tools/Propulsion.Tool/Sync.fs
@@ -75,7 +75,7 @@ and SourceArguments(c, p: ParseResults<SourceParameters>) =
         | SourceParameters.Cosmos p ->      Cosmos (Args.Cosmos.Arguments (c, p))
         | SourceParameters.Dynamo p ->      Dynamo (Args.Dynamo.Arguments (c, p))
         | SourceParameters.Mdb p ->         Mdb (Args.Mdb.Arguments (c, p))
-        | SourceParameters.Json p ->        Json (Args.Json.Arguments (c, p))
+        | SourceParameters.Json p ->        Json (Args.Json.Arguments p)
 and [<NoEquality; NoComparison>] StoreArgs =
     | Cosmos of Args.Cosmos.Arguments
     | Dynamo of Args.Dynamo.Arguments
@@ -281,7 +281,8 @@ let run appName (c: Args.Configuration, p: ParseResults<Parameters>) = async {
             ).Start()
         | Json sa ->
             let checkpoints = Propulsion.Feed.ReaderCheckpoint.MemoryStore.createNull ()
-            Propulsion.Feed.JsonSource.Start(Log.Logger, statsInterval, sa.Filepath, sa.Skip, parse, checkpoints, sink, ?truncateTo = sa.Trunc)
+            let filePath = Propulsion.Feed.JsonSource.DownloadIfHttpUri sa.Filepath |> Async.ofTask |> Async.RunSynchronously
+            Propulsion.Feed.JsonSource.Start(Log.Logger, statsInterval, filePath, sa.Skip, parse, checkpoints, sink, ?truncateTo = sa.Trunc)
 
     let pipeline = [
         Async.AwaitKeyboardInterruptAsTaskCanceledException()


### PR DESCRIPTION
Allows `propulsion sync` JSON sources to be URIs