### PR TITLE
feat!: use FsCodec.Encoded bodies

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,5 +47,9 @@ jobs:
   pool:
     vmImage: 'macOS-latest'
   steps:
+  - task: UseDotNet@2
+    displayName: Temp workaround for macOS-latest installing SDK 9.0.202 with F# compiler issue
+    inputs:
+      useGlobalJson: true
   - script: dotnet pack build.proj
     displayName: dotnet pack build.proj

--- a/src/Propulsion.CosmosStore/CosmosStoreSink.fs
+++ b/src/Propulsion.CosmosStore/CosmosStoreSink.fs
@@ -32,7 +32,7 @@ module private Impl =
 #else
     module StreamSpan =
 
-        let toNativeEventBody (x: EventBody): Equinox.CosmosStore.Core.EncodedBody = FsCodec.SystemTextJson.Encoding.OfEncodedUtf8 x
+        let toNativeEventBody (x: EventBody): Equinox.CosmosStore.Core.EncodedBody = FsCodec.SystemTextJson.Encoding.OfUtf8Encoded x
 #endif
 
 module Internal =

--- a/src/Propulsion.CosmosStore/EquinoxSystemTextJsonParser.fs
+++ b/src/Propulsion.CosmosStore/EquinoxSystemTextJsonParser.fs
@@ -10,9 +10,7 @@ open Propulsion.Sinks
 #if !COSMOSV3
 module EquinoxSystemTextJsonParser =
 
-    type System.Text.Json.JsonElement with
-        member x.Cast<'T>() = System.Text.Json.JsonSerializer.Deserialize<'T>(x)
-
+    type System.Text.Json.JsonElement with member x.Cast<'T>() = System.Text.Json.JsonSerializer.Deserialize<'T>(x)
     type System.Text.Json.JsonDocument with member x.Cast<'T>() = x.RootElement.Cast<'T>()
     let timestamp (doc: System.Text.Json.JsonDocument) =
         let unixEpoch = System.DateTime.UnixEpoch

--- a/src/Propulsion.CosmosStore/EquinoxSystemTextJsonParser.fs
+++ b/src/Propulsion.CosmosStore/EquinoxSystemTextJsonParser.fs
@@ -44,7 +44,7 @@ module EquinoxSystemTextJsonParser =
                                               size = size, correlationId = x.correlationId, causationId = x.causationId, isUnfold = isUnfold)
         let events = batch.e |> Seq.mapi (fun offset -> gen false (batch.i + int64 offset))
         // an Unfold won't have a corr/cause id, but that's OK - can't use Tip type as don't want to expand compressed form etc
-        match u |> ValueOption.map (fun u -> u.Cast<Equinox.CosmosStore.Core.Event[]>()) with
+        match u |> ValueOption.map (fun x -> x.Cast<Equinox.CosmosStore.Core.Event[]>()) with
         | ValueNone | ValueSome null | ValueSome [||] -> events
         | ValueSome unfolds -> seq {
             yield! events

--- a/src/Propulsion.CosmosStore/Propulsion.CosmosStore.fsproj
+++ b/src/Propulsion.CosmosStore/Propulsion.CosmosStore.fsproj
@@ -21,8 +21,8 @@
   <ItemGroup>
     <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="All" />
 
-    <PackageReference Include="Equinox.CosmosStore" Version="4.1.0-rc.1" />
-    <PackageReference Include="FsCodec.SystemTextJson" Version="3.1.0-rc.4" />
+    <PackageReference Include="Equinox.CosmosStore" Version="4.1.0" />
+    <PackageReference Include="FsCodec.SystemTextJson" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Propulsion.CosmosStore/Propulsion.CosmosStore.fsproj
+++ b/src/Propulsion.CosmosStore/Propulsion.CosmosStore.fsproj
@@ -22,7 +22,7 @@
     <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="All" />
 
     <PackageReference Include="Equinox.CosmosStore" Version="4.1.0-rc.1" />
-    <PackageReference Include="FsCodec.SystemTextJson" Version="3.1.0-rc.3" />
+    <PackageReference Include="FsCodec.SystemTextJson" Version="3.1.0-rc.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Propulsion.CosmosStore/Propulsion.CosmosStore.fsproj
+++ b/src/Propulsion.CosmosStore/Propulsion.CosmosStore.fsproj
@@ -21,7 +21,7 @@
   <ItemGroup>
     <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="All" />
 
-    <PackageReference Include="Equinox.CosmosStore" Version="4.1.0-alpha.22" />
+    <PackageReference Include="Equinox.CosmosStore" Version="4.1.0-rc.1" />
     <PackageReference Include="FsCodec.SystemTextJson" Version="3.1.0-rc.3" />
   </ItemGroup>
 

--- a/src/Propulsion.CosmosStore/Propulsion.CosmosStore.fsproj
+++ b/src/Propulsion.CosmosStore/Propulsion.CosmosStore.fsproj
@@ -21,8 +21,8 @@
   <ItemGroup>
     <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="All" />
 
-    <PackageReference Include="Equinox.CosmosStore" Version="4.1.0-alpha.20" />
-    <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.4-alpha.0.15" />
+    <PackageReference Include="Equinox.CosmosStore" Version="4.1.0-alpha.22" />
+    <PackageReference Include="FsCodec.SystemTextJson" Version="3.1.0-rc.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Propulsion.CosmosStore/Propulsion.CosmosStore.fsproj
+++ b/src/Propulsion.CosmosStore/Propulsion.CosmosStore.fsproj
@@ -21,8 +21,8 @@
   <ItemGroup>
     <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="All" />
 
-    <PackageReference Include="Equinox.CosmosStore" Version="4.1.0-alpha.15" />
-    <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.2" />
+    <PackageReference Include="Equinox.CosmosStore" Version="4.1.0-alpha.19" />
+    <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.4-alpha.0.14" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Propulsion.CosmosStore/Propulsion.CosmosStore.fsproj
+++ b/src/Propulsion.CosmosStore/Propulsion.CosmosStore.fsproj
@@ -21,8 +21,8 @@
   <ItemGroup>
     <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="All" />
 
-    <PackageReference Include="Equinox.CosmosStore" Version="4.1.0-alpha.19" />
-    <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.4-alpha.0.14" />
+    <PackageReference Include="Equinox.CosmosStore" Version="4.1.0-alpha.20" />
+    <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.4-alpha.0.15" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Propulsion.CosmosStore/ReaderCheckpoint.fs
+++ b/src/Propulsion.CosmosStore/ReaderCheckpoint.fs
@@ -43,7 +43,7 @@ module Events =
     let codec = FsCodec.Box.Codec.Create<Event>()
 #else
 #if DYNAMOSTORE
-    let codec = FsCodec.SystemTextJson.Codec.Create<Event>() |> FsCodec.Compression.EncodeUncompressed
+    let codec = FsCodec.SystemTextJson.Codec.Create<Event>() |> FsCodec.Encoder.Uncompressed
 #else
 #if !COSMOSV3
     let codec = FsCodec.SystemTextJson.CodecJsonElement.Create<Event>()
@@ -193,7 +193,7 @@ module CosmosStore =
 
     let accessStrategy = AccessStrategy.Custom (Fold.isOrigin, Fold.transmute)
     let create log (consumerGroupName, defaultCheckpointFrequency) (context, cache) =
-        let cat = CosmosStoreCategory(context, Stream.Category, Events.codec, Fold.fold, Fold.initial, accessStrategy, cacheStrategy cache)
+        let cat = CosmosStoreCategory(context, Stream.Category, FsCodec.SystemTextJson.Encoder.Compressed Events.codec, Fold.fold, Fold.initial, accessStrategy, cacheStrategy cache)
         let resolve = Equinox.Decider.forStream log cat
         Service(Stream.id >> resolve, consumerGroupName, defaultCheckpointFrequency)
 #else

--- a/src/Propulsion.CosmosStore3/Propulsion.CosmosStore3.fsproj
+++ b/src/Propulsion.CosmosStore3/Propulsion.CosmosStore3.fsproj
@@ -39,7 +39,7 @@
     <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="All" />
 
     <PackageReference Include="Equinox.CosmosStore" Version="[3.0.7, 3.99.0]" />
-    <PackageReference Include="FsCodec" Version="3.0.4-alpha.0.14" />
+    <PackageReference Include="FsCodec" Version="3.0.4-alpha.0.15" />
     <PackageReference Include="FSharp.Control.TaskSeq" Version="0.4.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.27.0" ExcludeAssets="contentfiles" />
   </ItemGroup>

--- a/src/Propulsion.CosmosStore3/Propulsion.CosmosStore3.fsproj
+++ b/src/Propulsion.CosmosStore3/Propulsion.CosmosStore3.fsproj
@@ -39,7 +39,7 @@
     <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="All" />
 
     <PackageReference Include="Equinox.CosmosStore" Version="[3.0.7, 3.99.0]" />
-    <PackageReference Include="FsCodec" Version="3.1.0-rc.4" />
+    <PackageReference Include="FsCodec" Version="3.1.0" />
     <PackageReference Include="FSharp.Control.TaskSeq" Version="0.4.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.27.0" ExcludeAssets="contentfiles" />
   </ItemGroup>

--- a/src/Propulsion.CosmosStore3/Propulsion.CosmosStore3.fsproj
+++ b/src/Propulsion.CosmosStore3/Propulsion.CosmosStore3.fsproj
@@ -39,7 +39,7 @@
     <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="All" />
 
     <PackageReference Include="Equinox.CosmosStore" Version="[3.0.7, 3.99.0]" />
-    <PackageReference Include="FsCodec" Version="3.0.0" />
+    <PackageReference Include="FsCodec" Version="3.0.4-alpha.0.14" />
     <PackageReference Include="FSharp.Control.TaskSeq" Version="0.4.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.27.0" ExcludeAssets="contentfiles" />
   </ItemGroup>

--- a/src/Propulsion.CosmosStore3/Propulsion.CosmosStore3.fsproj
+++ b/src/Propulsion.CosmosStore3/Propulsion.CosmosStore3.fsproj
@@ -39,7 +39,7 @@
     <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="All" />
 
     <PackageReference Include="Equinox.CosmosStore" Version="[3.0.7, 3.99.0]" />
-    <PackageReference Include="FsCodec" Version="3.0.4-alpha.0.15" />
+    <PackageReference Include="FsCodec" Version="3.1.0-rc.3" />
     <PackageReference Include="FSharp.Control.TaskSeq" Version="0.4.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.27.0" ExcludeAssets="contentfiles" />
   </ItemGroup>

--- a/src/Propulsion.CosmosStore3/Propulsion.CosmosStore3.fsproj
+++ b/src/Propulsion.CosmosStore3/Propulsion.CosmosStore3.fsproj
@@ -39,7 +39,7 @@
     <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="All" />
 
     <PackageReference Include="Equinox.CosmosStore" Version="[3.0.7, 3.99.0]" />
-    <PackageReference Include="FsCodec" Version="3.1.0-rc.3" />
+    <PackageReference Include="FsCodec" Version="3.1.0-rc.4" />
     <PackageReference Include="FSharp.Control.TaskSeq" Version="0.4.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.27.0" ExcludeAssets="contentfiles" />
   </ItemGroup>

--- a/src/Propulsion.DynamoStore/DynamoStoreSource.fs
+++ b/src/Propulsion.DynamoStore/DynamoStoreSource.fs
@@ -50,7 +50,7 @@ module private Impl =
         sw.Stop()
         let totalStreams, chosenEvents, totalEvents, streamEvents =
             let all = state.changes |> Seq.collect (fun struct (_i, xs) -> xs) |> AppendsEpoch.flatten |> Array.ofSeq
-            let totalEvents = all |> Array.sumBy _.c.Length
+            let totalEvents = all |> Array.sumBy (fun x -> x.c.Length)
             let mutable chosenEvents = 0
             let chooseStream (span: AppendsEpoch.Events.StreamSpan) =
                 match maybeLoad (IndexStreamId.toStreamName span.p) (span.i, span.c) with

--- a/src/Propulsion.DynamoStore/Propulsion.DynamoStore.fsproj
+++ b/src/Propulsion.DynamoStore/Propulsion.DynamoStore.fsproj
@@ -27,7 +27,7 @@
       <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="All" />
 
       <PackageReference Include="Equinox.DynamoStore" Version="4.0.0" />
-      <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.4-alpha.0.14" />
+      <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.4-alpha.0.15" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/Propulsion.DynamoStore/Propulsion.DynamoStore.fsproj
+++ b/src/Propulsion.DynamoStore/Propulsion.DynamoStore.fsproj
@@ -27,7 +27,7 @@
       <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="All" />
 
       <PackageReference Include="Equinox.DynamoStore" Version="4.0.0" />
-      <PackageReference Include="FsCodec.SystemTextJson" Version="3.1.0-rc.3" />
+      <PackageReference Include="FsCodec.SystemTextJson" Version="3.1.0-rc.4" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/Propulsion.DynamoStore/Propulsion.DynamoStore.fsproj
+++ b/src/Propulsion.DynamoStore/Propulsion.DynamoStore.fsproj
@@ -27,7 +27,7 @@
       <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="All" />
 
       <PackageReference Include="Equinox.DynamoStore" Version="4.0.0" />
-      <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.2" />
+      <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.4-alpha.0.14" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/Propulsion.DynamoStore/Propulsion.DynamoStore.fsproj
+++ b/src/Propulsion.DynamoStore/Propulsion.DynamoStore.fsproj
@@ -27,7 +27,7 @@
       <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="All" />
 
       <PackageReference Include="Equinox.DynamoStore" Version="4.0.0" />
-      <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.4-alpha.0.15" />
+      <PackageReference Include="FsCodec.SystemTextJson" Version="3.1.0-rc.3" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/Propulsion.DynamoStore/Propulsion.DynamoStore.fsproj
+++ b/src/Propulsion.DynamoStore/Propulsion.DynamoStore.fsproj
@@ -27,7 +27,7 @@
       <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="All" />
 
       <PackageReference Include="Equinox.DynamoStore" Version="4.0.0" />
-      <PackageReference Include="FsCodec.SystemTextJson" Version="3.1.0-rc.4" />
+      <PackageReference Include="FsCodec.SystemTextJson" Version="3.1.0" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/Propulsion.DynamoStore/Store.fs
+++ b/src/Propulsion.DynamoStore/Store.fs
@@ -31,4 +31,4 @@ module Dynamo =
 module internal Codec =
 
     let gen<'t when 't :> TypeShape.UnionContract.IUnionContract> =
-        FsCodec.SystemTextJson.Codec.Create<'t>() |> FsCodec.Compression.EncodeTryCompress
+        FsCodec.SystemTextJson.Codec.Create<'t>() |> FsCodec.Encoder.Compressed

--- a/src/Propulsion.DynamoStore/Types.fs
+++ b/src/Propulsion.DynamoStore/Types.fs
@@ -75,7 +75,7 @@ module Streams =
 
     let private withUpconverter<'c, 'e when 'c :> TypeShape.UnionContract.IUnionContract> up: FsCodec.IEventCodec<'e, _, _> =
         let down (_: 'e) = failwith "Unexpected"
-        FsCodec.SystemTextJson.Codec.Create<'e, 'c, _>(up, down) |> FsCodec.Compression.EncodeTryCompress
+        FsCodec.SystemTextJson.Codec.Create<'e, 'c, _>(up, down) |> FsCodec.Encoder.Compressed
     let decWithIndex<'c when 'c :> TypeShape.UnionContract.IUnionContract> : FsCodec.IEventCodec<struct (int64 * 'c), _, _> =
         let up (raw: FsCodec.ITimelineEvent<_>) e = struct (raw.Index, e)
         withUpconverter<'c, struct (int64 * 'c)> up

--- a/src/Propulsion.EventStore/EventStoreSink.fs
+++ b/src/Propulsion.EventStore/EventStoreSink.fs
@@ -40,9 +40,9 @@ module Internal =
             let i = StreamSpan.index span
             log.Debug("Writing {s}@{i}x{n}", stream, i, span.Length)
 #if EVENTSTORE_LEGACY
-            let! res = context.Sync(log, stream, i - 1L, span |> Array.map (fun span -> span :> _))
+            let! res = context.Sync(log, stream, i - 1L, span |> Array.map (FsCodec.Core.EventData.mapBodies FsCodec.Encoding.ToBlob))
 #else
-            let! res = context.Sync(log, stream, i - 1L, span |> Array.map (fun span -> span :> _), ct)
+            let! res = context.Sync(log, stream, i - 1L, span |> Array.map (FsCodec.Core.EventData.mapBodies FsCodec.Encoding.ToBlob), ct)
 #endif
             let res' =
                 match res with

--- a/src/Propulsion.EventStore/EventStoreSource.fs
+++ b/src/Propulsion.EventStore/EventStoreSource.fs
@@ -36,8 +36,7 @@ module Mapping =
         member x.Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(x.CreatedEpoch)
 
     let (|PropulsionTimelineEvent|) (x: RecordedEvent): Propulsion.Sinks.Event =
-        let inline len0ToNull (x: _[]) = match x with null -> ReadOnlyMemory.Empty | x when x.Length = 0 -> ReadOnlyMemory.Empty | x -> ReadOnlyMemory x
-        FsCodec.Core.TimelineEvent.Create(x.EventNumber, x.EventType, len0ToNull x.Data, len0ToNull x.Metadata, timestamp = x.Timestamp)
+        FsCodec.Core.TimelineEvent.Create(x.EventNumber, x.EventType, FsCodec.Encoding.OfBlob x.Data, FsCodec.Encoding.OfBlob x.Metadata, timestamp = x.Timestamp)
 
     let (|PropulsionStreamEvent|) (x: RecordedEvent): Propulsion.Sinks.StreamEvent =
         Propulsion.Streams.StreamName.internalParseSafe x.EventStreamId, (|PropulsionTimelineEvent|) x

--- a/src/Propulsion.EventStoreDb/EventStoreSource.fs
+++ b/src/Propulsion.EventStoreDb/EventStoreSource.fs
@@ -9,7 +9,7 @@ module private Impl =
         for e in events do
             let sn = Propulsion.Streams.StreamName.internalParseSafe e.EventStreamId
             if streamFilter sn then
-                yield sn, Equinox.EventStoreDb.ClientCodec.timelineEvent e |]
+                yield sn, Equinox.EventStoreDb.ClientCodec.timelineEvent e |> FsCodec.Core.TimelineEvent.mapBodies FsCodec.Encoding.OfBlob |]
     let private checkpointPos (xs: EventRecord[]) =
         match Array.tryLast xs with Some e -> int64 e.Position.CommitPosition | None -> -1L
         |> Propulsion.Feed.Position.parse

--- a/src/Propulsion.Kafka/Propulsion.Kafka.fsproj
+++ b/src/Propulsion.Kafka/Propulsion.Kafka.fsproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="All" />
 
-    <PackageReference Include="FsCodec.NewtonsoftJson" Version="3.0.0" />
+    <PackageReference Include="FsCodec.NewtonsoftJson" Version="3.1.0-rc.4" />
     <PackageReference Include="FsKafka" Version="[1.7.0, 1.9.99)" />
   </ItemGroup>
 

--- a/src/Propulsion.Kafka/Propulsion.Kafka.fsproj
+++ b/src/Propulsion.Kafka/Propulsion.Kafka.fsproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="All" />
 
-    <PackageReference Include="FsCodec.NewtonsoftJson" Version="3.1.0-rc.4" />
+    <PackageReference Include="FsCodec.NewtonsoftJson" Version="3.1.0" />
     <PackageReference Include="FsKafka" Version="[1.7.0, 1.9.99)" />
   </ItemGroup>
 

--- a/src/Propulsion.MemoryStore/MemoryStoreSource.fs
+++ b/src/Propulsion.MemoryStore/MemoryStoreSource.fs
@@ -123,13 +123,9 @@ and MemoryStoreMonitor internal (log: Serilog.ILogger, positions: TranchePositio
             if sink.IsCompleted && not sink.RanToCompletion then
                 return! sink.Wait() }
 
-module TimelineEvent =
-
-    let mapEncoded = FsCodec.Core.TimelineEvent.Map(Func<_, _> FsCodec.Compression.EncodedToUtf8)
-
 /// Coordinates forwarding of a VolatileStore's Committed events to a supplied Sink
 /// Supports awaiting the (asynchronous) handling by the Sink of all Committed events from a given point in time
 type MemoryStoreSource(log, store: Equinox.MemoryStore.VolatileStore<FsCodec.EncodedBody>, categoryFilter, sink) =
-    inherit MemoryStoreSource<FsCodec.EncodedBody>(log, store, categoryFilter, TimelineEvent.mapEncoded, sink)
+    inherit MemoryStoreSource<FsCodec.EncodedBody>(log, store, categoryFilter, id, sink)
     new(log, store, categories, sink) =
         MemoryStoreSource(log, store, (fun x -> Array.contains x categories), sink)

--- a/src/Propulsion.MemoryStore/MemoryStoreSource.fs
+++ b/src/Propulsion.MemoryStore/MemoryStoreSource.fs
@@ -125,7 +125,7 @@ and MemoryStoreMonitor internal (log: Serilog.ILogger, positions: TranchePositio
 
 /// Coordinates forwarding of a VolatileStore's Committed events to a supplied Sink
 /// Supports awaiting the (asynchronous) handling by the Sink of all Committed events from a given point in time
-type MemoryStoreSource(log, store: Equinox.MemoryStore.VolatileStore<FsCodec.EncodedBody>, categoryFilter, sink) =
-    inherit MemoryStoreSource<FsCodec.EncodedBody>(log, store, categoryFilter, id, sink)
+type MemoryStoreSource(log, store: Equinox.MemoryStore.VolatileStore<FsCodec.Encoded>, categoryFilter, sink) =
+    inherit MemoryStoreSource<FsCodec.Encoded>(log, store, categoryFilter, id, sink)
     new(log, store, categories, sink) =
         MemoryStoreSource(log, store, (fun x -> Array.contains x categories), sink)

--- a/src/Propulsion.SqlStreamStore/SqlStreamStoreSource.fs
+++ b/src/Propulsion.SqlStreamStore/SqlStreamStoreSource.fs
@@ -1,12 +1,14 @@
 namespace Propulsion.SqlStreamStore
 
+module EncodedBody = let bytes ((_t, d): FsCodec.EncodedBody) = d.Length
+
 module private Impl =
 
     let private toStreamEvent (dataJson: string) struct (sn, msg: SqlStreamStore.Streams.StreamMessage): Propulsion.Sinks.StreamEvent =
         let c = msg.Type
-        let d = match dataJson with null -> System.ReadOnlyMemory.Empty | x -> x |> System.Text.Encoding.UTF8.GetBytes |> System.ReadOnlyMemory
-        let m = msg.JsonMetadata |> System.Text.Encoding.UTF8.GetBytes |> System.ReadOnlyMemory
-        let sz = c.Length + d.Length + m.Length
+        let d = dataJson |> NotNull.map System.Text.Encoding.UTF8.GetBytes |> FsCodec.Encoding.OfBlob
+        let m = msg.JsonMetadata |> NotNull.map System.Text.Encoding.UTF8.GetBytes |> FsCodec.Encoding.OfBlob
+        let sz = c.Length + EncodedBody.bytes d + EncodedBody.bytes m
         sn, FsCodec.Core.TimelineEvent.Create(msg.StreamVersion, c, d, m, msg.MessageId, timestamp = System.DateTimeOffset(msg.CreatedUtc), size = sz)
     let private readWithDataAsStreamEvent (struct (_sn, msg: SqlStreamStore.Streams.StreamMessage) as m) ct = task {
         let! json = msg.GetJsonData(ct)

--- a/src/Propulsion.SqlStreamStore/Types.fs
+++ b/src/Propulsion.SqlStreamStore/Types.fs
@@ -5,3 +5,7 @@ open FSharp.UMX
 module internal FeedSourceId =
 
     let wellKnownId: Propulsion.Feed.SourceId = UMX.tag "sqlStreamStore"
+
+module internal NotNull =
+
+    let inline map f = function null -> null | x -> f x

--- a/src/Propulsion/Feed/FeedSource.fs
+++ b/src/Propulsion/Feed/FeedSource.fs
@@ -133,8 +133,8 @@ module Categories =
 
     let mapFilters categories streamFilter =
         match categories, streamFilter with
-        | None, None ->                   fun _ -> true
-        | Some categories, None -> categoryFilter categories
+        | None, None ->                         fun _ -> true
+        | Some categories, None ->              categoryFilter categories
         | None, Some (filter: Func<_, bool>) -> filter.Invoke
         | Some categories, Some filter ->
             let categoryFilter = categoryFilter categories

--- a/src/Propulsion/Propulsion.fsproj
+++ b/src/Propulsion/Propulsion.fsproj
@@ -32,7 +32,7 @@
   <ItemGroup>
     <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="All" />
 
-    <PackageReference Include="FsCodec" Version="3.1.0-rc.4" />
+    <PackageReference Include="FsCodec" Version="3.1.0" />
     <!-- NOTE this transitively implies a min FSharp.Core 6.0.1 dependency (was 6.0.0 before) -->
     <PackageReference Include="FSharp.Control.TaskSeq" Version="0.4.0" />
     <PackageReference Include="MathNet.Numerics" Version="4.15.0" />

--- a/src/Propulsion/Propulsion.fsproj
+++ b/src/Propulsion/Propulsion.fsproj
@@ -32,7 +32,7 @@
   <ItemGroup>
     <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="All" />
 
-    <PackageReference Include="FsCodec" Version="3.1.0-rc.3" />
+    <PackageReference Include="FsCodec" Version="3.1.0-rc.4" />
     <!-- NOTE this transitively implies a min FSharp.Core 6.0.1 dependency (was 6.0.0 before) -->
     <PackageReference Include="FSharp.Control.TaskSeq" Version="0.4.0" />
     <PackageReference Include="MathNet.Numerics" Version="4.15.0" />

--- a/src/Propulsion/Propulsion.fsproj
+++ b/src/Propulsion/Propulsion.fsproj
@@ -32,7 +32,7 @@
   <ItemGroup>
     <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="All" />
 
-    <PackageReference Include="FsCodec" Version="3.0.4-alpha.0.15" />
+    <PackageReference Include="FsCodec" Version="3.1.0-rc.3" />
     <!-- NOTE this transitively implies a min FSharp.Core 6.0.1 dependency (was 6.0.0 before) -->
     <PackageReference Include="FSharp.Control.TaskSeq" Version="0.4.0" />
     <PackageReference Include="MathNet.Numerics" Version="4.15.0" />

--- a/src/Propulsion/Propulsion.fsproj
+++ b/src/Propulsion/Propulsion.fsproj
@@ -32,7 +32,7 @@
   <ItemGroup>
     <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="All" />
 
-    <PackageReference Include="FsCodec" Version="3.0.4-alpha.0.14" />
+    <PackageReference Include="FsCodec" Version="3.0.4-alpha.0.15" />
     <!-- NOTE this transitively implies a min FSharp.Core 6.0.1 dependency (was 6.0.0 before) -->
     <PackageReference Include="FSharp.Control.TaskSeq" Version="0.4.0" />
     <PackageReference Include="MathNet.Numerics" Version="4.15.0" />

--- a/src/Propulsion/Propulsion.fsproj
+++ b/src/Propulsion/Propulsion.fsproj
@@ -32,7 +32,7 @@
   <ItemGroup>
     <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="All" />
 
-    <PackageReference Include="FsCodec" Version="3.0.0" />
+    <PackageReference Include="FsCodec" Version="3.0.4-alpha.0.14" />
     <!-- NOTE this transitively implies a min FSharp.Core 6.0.1 dependency (was 6.0.0 before) -->
     <PackageReference Include="FSharp.Control.TaskSeq" Version="0.4.0" />
     <PackageReference Include="MathNet.Numerics" Version="4.15.0" />

--- a/src/Propulsion/Sinks.fs
+++ b/src/Propulsion/Sinks.fs
@@ -5,7 +5,7 @@ open Propulsion.Internal
 open System
 
 /// Canonical Data/Meta type supplied by the majority of Sources
-type EventBody = ReadOnlyMemory<byte>
+type EventBody = FsCodec.EncodedBody
 
 /// Timeline Event with Data/Meta in the default format
 type Event = FsCodec.ITimelineEvent<EventBody>

--- a/src/Propulsion/Sinks.fs
+++ b/src/Propulsion/Sinks.fs
@@ -5,7 +5,7 @@ open Propulsion.Internal
 open System
 
 /// Canonical Data/Meta type supplied by the majority of Sources
-type EventBody = FsCodec.EncodedBody
+type EventBody = FsCodec.Encoded
 
 /// Timeline Event with Data/Meta in the default format
 type Event = FsCodec.ITimelineEvent<EventBody>

--- a/src/Propulsion/Streams.fs
+++ b/src/Propulsion/Streams.fs
@@ -1112,7 +1112,7 @@ type Stats<'Outcome>(log: ILogger, statsInterval, statesInterval,
     override _.DumpStats() =
         if resultOk <> 0 then
             log.Information("Projected {mb:n0}MB {completed:n0}r {streams:n0}s {events:n0}e {unfolds:n0}u ({ok:n0} ok)",
-                        Log.miB okBytes, resultOk, okStreams.Count, okEvents, resultOk)
+                        Log.miB okBytes, resultOk, okStreams.Count, okEvents, okUnfolds, resultOk)
             okStreams.Clear(); resultOk <- 0; okEvents <- 0; okUnfolds <- 0; okBytes <- 0L
         if resultExn <> 0 then
             log.Warning(" Exceptions {mb:n0}MB {fails:n0}r {streams:n0}s {events:n0}e {unfolds:n0}u",

--- a/tests/Propulsion.Kafka.Integration/ConsumersIntegration.fs
+++ b/tests/Propulsion.Kafka.Integration/ConsumersIntegration.fs
@@ -96,7 +96,7 @@ module Helpers =
     }
 
     let deserialize consumerId (e: ITimelineEvent<Propulsion.Sinks.EventBody>): ConsumedTestMessage =
-        { consumerId = consumerId; meta = serdes.Deserialize(e.Data); payload = unbox e.Context }
+        { consumerId = consumerId; meta = serdes.Deserialize(Encoding.ToBlob e.Data); payload = unbox e.Context }
 
     type Stats(log, statsInterval, stateInterval) =
         inherit Propulsion.Streams.Stats<unit>(log, statsInterval, stateInterval)
@@ -147,7 +147,7 @@ module Helpers =
 
     let mapStreamConsumeResultToDataAndContext (x: ConsumeResult<_,string>): Propulsion.Sinks.EventBody * obj =
         let m = Binding.message x
-        System.Text.Encoding.UTF8.GetBytes(m.Value) |> ReadOnlyMemory,
+        System.Text.Encoding.UTF8.GetBytes m.Value |> Encoding.OfBlob,
         box { key = m.Key; value = m.Value; partition = Binding.partitionValue x.Partition; offset = let o = x.Offset in o.Value }
 
     let runConsumersStream log (config: KafkaConsumerConfig) (numConsumers: int) (timeout: TimeSpan option) (handler: ConsumerCallback) = async {

--- a/tests/Propulsion.Kafka.Integration/ConsumersIntegration.fs
+++ b/tests/Propulsion.Kafka.Integration/ConsumersIntegration.fs
@@ -96,7 +96,7 @@ module Helpers =
     }
 
     let deserialize consumerId (e: ITimelineEvent<Propulsion.Sinks.EventBody>): ConsumedTestMessage =
-        { consumerId = consumerId; meta = serdes.Deserialize(Encoding.ToBlob e.Data); payload = unbox e.Context }
+        { consumerId = consumerId; meta = serdes.Deserialize(e.Data); payload = unbox e.Context }
 
     type Stats(log, statsInterval, stateInterval) =
         inherit Propulsion.Streams.Stats<unit>(log, statsInterval, stateInterval)

--- a/tests/Propulsion.MessageDb.Integration/Propulsion.MessageDb.Integration.fsproj
+++ b/tests/Propulsion.MessageDb.Integration/Propulsion.MessageDb.Integration.fsproj
@@ -9,7 +9,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.4-alpha.0.14" />
+        <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.4-alpha.0.15" />
         <PackageReference Include="TypeShape" Version="10.0.0" />
     </ItemGroup>
     <ItemGroup>

--- a/tests/Propulsion.MessageDb.Integration/Propulsion.MessageDb.Integration.fsproj
+++ b/tests/Propulsion.MessageDb.Integration/Propulsion.MessageDb.Integration.fsproj
@@ -9,7 +9,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.4-alpha.0.15" />
+        <PackageReference Include="FsCodec.SystemTextJson" Version="3.1.0-rc.3" />
         <PackageReference Include="TypeShape" Version="10.0.0" />
     </ItemGroup>
     <ItemGroup>

--- a/tests/Propulsion.MessageDb.Integration/Propulsion.MessageDb.Integration.fsproj
+++ b/tests/Propulsion.MessageDb.Integration/Propulsion.MessageDb.Integration.fsproj
@@ -9,7 +9,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="FsCodec.SystemTextJson" Version="3.1.0-rc.3" />
+        <PackageReference Include="FsCodec.SystemTextJson" Version="3.1.0-rc.4" />
         <PackageReference Include="TypeShape" Version="10.0.0" />
     </ItemGroup>
     <ItemGroup>

--- a/tests/Propulsion.MessageDb.Integration/Propulsion.MessageDb.Integration.fsproj
+++ b/tests/Propulsion.MessageDb.Integration/Propulsion.MessageDb.Integration.fsproj
@@ -9,7 +9,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="FsCodec.SystemTextJson" Version="3.1.0-rc.4" />
+        <PackageReference Include="FsCodec.SystemTextJson" Version="3.1.0" />
         <PackageReference Include="TypeShape" Version="10.0.0" />
     </ItemGroup>
     <ItemGroup>

--- a/tests/Propulsion.MessageDb.Integration/Propulsion.MessageDb.Integration.fsproj
+++ b/tests/Propulsion.MessageDb.Integration/Propulsion.MessageDb.Integration.fsproj
@@ -9,7 +9,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.2" />
+        <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.4-alpha.0.14" />
         <PackageReference Include="TypeShape" Version="10.0.0" />
     </ItemGroup>
     <ItemGroup>

--- a/tests/Propulsion.MessageDb.Integration/Tests.fs
+++ b/tests/Propulsion.MessageDb.Integration/Tests.fs
@@ -14,7 +14,7 @@ module Simple =
     type Event =
         | Hello of Hello
         interface TypeShape.UnionContract.IUnionContract
-    let codec = FsCodec.SystemTextJson.Codec.Create<Event>()
+    let codec = FsCodec.SystemTextJson.Codec.Create<Event>() |> FsCodec.Encoder.Uncompressed
 
 let createStreamMessage streamName =
     let cmd = NpgsqlBatchCommand()

--- a/tests/Propulsion.Tests/SinkHealthTests.fs
+++ b/tests/Propulsion.Tests/SinkHealthTests.fs
@@ -35,7 +35,7 @@ type Scenario(testOutput) =
     let dispose () =
         sink.Stop()
         sink.Await() |> Async.Catch |> Async.RunSynchronously |> ignore
-    let mk p c: FsCodec.ITimelineEvent<_> = FsCodec.Core.TimelineEvent.Create(p, c, Propulsion.Sinks.EventBody.Empty)
+    let mk p c: FsCodec.ITimelineEvent<_> = FsCodec.Core.TimelineEvent.Create(p, c, FsCodec.Encoding.OfBlob ReadOnlyMemory.Empty)
     let items: Propulsion.Sinks.StreamEvent[] =
         [|  sid "a-ok", mk 0 "EventType"
             failingSid, mk 0 "EventType"

--- a/tools/Propulsion.Tool/Args.fs
+++ b/tools/Propulsion.Tool/Args.fs
@@ -57,9 +57,8 @@ module Cosmos =
         | [<AltCommandLine "-s">]           Connection of string
         | [<AltCommandLine "-d">]           Database of string
         | [<AltCommandLine "-c">]           Container of string
-        | [<AltCommandLine "-o">]           Timeout of float
         | [<AltCommandLine "-r">]           Retries of int
-        | [<AltCommandLine "-rt">]          RetriesWaitTime of float
+        | [<AltCommandLine "-o">]           RetriesWaitTime of float
         | [<AltCommandLine "-a"; Unique>]   LeaseContainer of string
         | [<AltCommandLine "-as"; Unique>]  Suffix of string
 
@@ -70,7 +69,6 @@ module Cosmos =
                 | Connection _ ->           "specify a connection string for a Cosmos account. (optional if environment variable " + CONNECTION + " specified)"
                 | Database _ ->             "specify a database name for Cosmos store. (optional if environment variable " + DATABASE + " specified)"
                 | Container _ ->            "specify a container name for Cosmos store. (optional if environment variable " + CONTAINER + " specified)"
-                | Timeout _ ->              "specify operation timeout in seconds (default: 5)."
                 | Retries _ ->              "specify operation retries (default: 1)."
                 | RetriesWaitTime _ ->      "specify max wait-time for retry when being throttled by Cosmos in seconds (default: 5)"
                 | LeaseContainer _ ->       "Specify full Lease Container Name (default: Container + Suffix)."
@@ -80,11 +78,10 @@ module Cosmos =
     type Arguments(c: Configuration, p: ParseResults<Parameters>) =
         let connection =                    p.GetResult(Connection, fun () -> c.CosmosConnection)
         let connector =
-            let timeout =                   p.GetResult(Timeout, 5.) |> TimeSpan.seconds
             let retries =                   p.GetResult(Retries, 1)
             let maxRetryWaitTime =          p.GetResult(RetriesWaitTime, 5.) |> TimeSpan.seconds
             let mode =                      p.TryGetResult ConnectionMode
-            Equinox.CosmosStore.CosmosStoreConnector((connection |> Equinox.CosmosStore.Discovery.ConnectionString), timeout, retries, maxRetryWaitTime, ?mode = mode)
+            Equinox.CosmosStore.CosmosStoreConnector(Equinox.CosmosStore.Discovery.ConnectionString connection, retries, maxRetryWaitTime, ?mode = mode)
         let databaseId =                    p.GetResult(Database, fun () -> c.CosmosDatabase)
         let containerId =                   p.GetResult(Container, fun () -> c.CosmosContainer)
         let leasesContainerName =           p.GetResult(LeaseContainer, fun () -> containerId + p.GetResult(Suffix, "-aux"))

--- a/tools/Propulsion.Tool/Args.fs
+++ b/tools/Propulsion.Tool/Args.fs
@@ -58,7 +58,7 @@ module Cosmos =
         | [<AltCommandLine "-d">]           Database of string
         | [<AltCommandLine "-c">]           Container of string
         | [<AltCommandLine "-r">]           Retries of int
-        | [<AltCommandLine "-o">]           RetriesWaitTime of float
+        | [<AltCommandLine "-rt">]          RetriesWaitTime of float
         | [<AltCommandLine "-a"; Unique>]   LeaseContainer of string
         | [<AltCommandLine "-as"; Unique>]  Suffix of string
 

--- a/tools/Propulsion.Tool/Infrastructure.fs
+++ b/tools/Propulsion.Tool/Infrastructure.fs
@@ -10,7 +10,7 @@ module Metrics =
     let [<Literal>] PropertyTag = "isMetric"
     let mutable log = Log.ForContext(PropertyTag, true)
     // In a real app, you have a separate module Store with Metrics inside, and the static initializer is not triggered too early
-    // TODO get rid of this; I have up this time around :(
+    // TODO get rid of this; I gave up this time around :(
     let init () = log <- Log.ForContext(PropertyTag, true)
 
 module EnvVar =

--- a/tools/Propulsion.Tool/Propulsion.Tool.fsproj
+++ b/tools/Propulsion.Tool/Propulsion.Tool.fsproj
@@ -31,7 +31,7 @@
     <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="All" />
 
     <!-- The tool should use a relatively fresh Cosmos lib; Equinox.CosmosStore has a conservative dependency-->
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.46.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.49.0" />
 
 	<PackageReference Include="Argu" Version="6.2.2" />
     <!-- Required or there'll be an exception at runtime re missing support DLLs when using RBAC -->

--- a/tools/Propulsion.Tool/Propulsion.Tool.fsproj
+++ b/tools/Propulsion.Tool/Propulsion.Tool.fsproj
@@ -31,7 +31,7 @@
     <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="All" />
 
     <!-- The tool should use a relatively fresh Cosmos lib; Equinox.CosmosStore has a conservative dependency-->
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.42.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.46.0" />
 
 	<PackageReference Include="Argu" Version="6.2.2" />
     <!-- Required or there'll be an exception at runtime re missing support DLLs when using RBAC -->

--- a/tools/Propulsion.Tool/Sync.fs
+++ b/tools/Propulsion.Tool/Sync.fs
@@ -137,10 +137,9 @@ and CosmosArguments(c: Args.Configuration, p: ParseResults<CosmosParameters>) =
                                             | Json _ -> p.GetResult(Connection, fun () -> c.CosmosConnection)
                                             | x -> p.Raise $"unexpected subcommand %A{x}"
     let connector =
-        let timeout =                       p.GetResult(Timeout, 5) |> TimeSpan.seconds
         let retries =                       p.GetResult(Retries, 2)
         let maxRetryWaitTime =              p.GetResult(RetriesWaitTime, 5) |> TimeSpan.seconds
-        Equinox.CosmosStore.CosmosStoreConnector(Equinox.CosmosStore.Discovery.ConnectionString connection, timeout, retries, maxRetryWaitTime)
+        Equinox.CosmosStore.CosmosStoreConnector(Equinox.CosmosStore.Discovery.ConnectionString connection, retries, maxRetryWaitTime)
     let database =                          match source.Store with
                                             | Cosmos c -> p.GetResult(Database, fun () -> c.Database)
                                             | Json _ -> p.GetResult(Database, fun () -> c.CosmosDatabase)


### PR DESCRIPTION
Removes two problems:
- Feeds that support encoding (.e.. DynamoStore) used to have to uncompress on reading, wasting memory
- CosmosStore used to pass JsonElement verbatim, but not pass the encoding. Equinox.CosmosStore v 4.1.0 requires the encoding value to be passed as a JSON String can now represent either Deflate or Brotli encoded data depending on the encoding stored in `D` or `M` alongside the body field