### PR TITLE
Allow marking a stream complete in propulsion

### DIFF
--- a/src/Propulsion/Sinks.fs
+++ b/src/Propulsion/Sinks.fs
@@ -20,6 +20,8 @@ module Events =
     let next: Event[] -> int64 = Streams.StreamSpan.next
     /// The Index of the first event as supplied to this handler
     let index: Event[] -> int64 = Streams.StreamSpan.index
+    /// Mark stream completed
+    let complete: Event[] -> int64 = Streams.StreamSpan.complete
 
 /// Internal helpers used to compute buffer sizes for stats
 module Event =


### PR DESCRIPTION
This is useful for cases where you have a lot of small streams that get
discarded, otherwise the StreamStates map grows uncontrollably for no
value whatsoever.

Adds a sentinel value of -2L to represent a completed stream, once this
is returned the stream is removed from all state tracking.

NOTE: This does mean that we lose some guarantees, the handler might be
called again for the same stream due to at-least-once shenanigans.
