### PR TITLE
fix: Enable compile with SDK >= 9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ## [Unreleased]
 
+### Changed
+
+- Targeted`FSharp.Core` v `8.0.403` (To handle SDK >= 9 being strict on `RequireQualifiedAccess` with `Struct`) [#270](https://github.com/jet/propulsion/pull/270)
+
 <a name="3.0.0"></a>
 ## [3.0.0] - 2025-09-23
 

--- a/src/Propulsion/Propulsion.fsproj
+++ b/src/Propulsion/Propulsion.fsproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <!-- NOTE FSharp.Core dep is implies by what `FSharp.Control.TaskSeq` dictates; see below -->
+    <!-- We want to depend on as old a version as possible. That would be 6.0.1, but we need v8 to be able to do RequireQualifiedAccess on a Struct with a V9+ compiler -->  
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <PackageValidationBaselineVersion>3.0.0</PackageValidationBaselineVersion>
   </PropertyGroup>
@@ -31,9 +31,9 @@
 
   <ItemGroup>
     <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="All" />
-
+    <!-- Min FSharp.Core version that allows RequireQualifiedAccess on structs -->  
+    <PackageReference Include="FSharp.Core" Version="8.0.403" />
     <PackageReference Include="FsCodec" Version="3.1.0" />
-    <!-- NOTE this transitively implies a min FSharp.Core 6.0.1 dependency (was 6.0.0 before) -->
     <PackageReference Include="FSharp.Control.TaskSeq" Version="0.4.0" />
     <PackageReference Include="MathNet.Numerics" Version="4.15.0" />
     <PackageReference Include="Serilog" Version="2.7.1" />

--- a/tests/Propulsion.Tests/Propulsion.Tests.fsproj
+++ b/tests/Propulsion.Tests/Propulsion.Tests.fsproj
@@ -27,8 +27,6 @@
   <ItemGroup>
     <PackageReference Include="FsCheck.Xunit" Version="3.0.0-rc3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <!-- Pin requirement for at least 6.0.6 in one of the tests by requesting same as Propulsion.DynamoStore will require-->
-	<PackageReference Include="FSharp.Core" Version="6.0.7" ExcludeAssets="contentfiles" />
 	<PackageReference Include="unquote" Version="6.1.0" />
     <PackageReference Include="xunit" Version="2.7.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">


### PR DESCRIPTION
In general, we try to be as tolerant as possible with regard to `TargetFramework` and `FSharp.Core` version.

Updates the minimum `FSharp.Core` version to `8.0.403` from `6.0.1` in order to avoid compile errors on F# >= 9 due to the combination of `RequireQualifiedAccess` and `Struct` on a DU.